### PR TITLE
Proof Validator Action Filter change

### DIFF
--- a/src/WopiHost.Core/Controllers/ContainersController.cs
+++ b/src/WopiHost.Core/Controllers/ContainersController.cs
@@ -7,6 +7,7 @@ using WopiHost.Core.Extensions;
 using WopiHost.Core.Infrastructure;
 using WopiHost.Core.Models;
 using WopiHost.Core.Results;
+using WopiHost.Core.Security.Authentication;
 using WopiHost.Core.Security.Authorization;
 
 namespace WopiHost.Core.Controllers;
@@ -23,6 +24,7 @@ namespace WopiHost.Core.Controllers;
 [Authorize]
 [ApiController]
 [Route("wopi/[controller]")]
+[ServiceFilter(typeof(WopiOriginValidationActionFilter))]
 public class ContainersController(
     IWopiStorageProvider storageProvider,
     IWopiLockProvider? lockProvider = null,

--- a/src/WopiHost.Core/Controllers/EcosystemController.cs
+++ b/src/WopiHost.Core/Controllers/EcosystemController.cs
@@ -1,11 +1,11 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
 using System.Net.Mime;
 using WopiHost.Abstractions;
 using WopiHost.Core.Extensions;
 using WopiHost.Core.Infrastructure;
 using WopiHost.Core.Models;
+using WopiHost.Core.Security.Authentication;
 
 namespace WopiHost.Core.Controllers;
 
@@ -19,6 +19,7 @@ namespace WopiHost.Core.Controllers;
 [Authorize]
 [ApiController]
 [Route("wopi/[controller]")]
+[ServiceFilter(typeof(WopiOriginValidationActionFilter))]
 public class EcosystemController(
     IWopiStorageProvider storageProvider) : ControllerBase
 {

--- a/src/WopiHost.Core/Controllers/FilesController.cs
+++ b/src/WopiHost.Core/Controllers/FilesController.cs
@@ -6,12 +6,12 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Options;
 using WopiHost.Abstractions;
 using WopiHost.Core.Extensions;
 using WopiHost.Core.Infrastructure;
 using WopiHost.Core.Models;
 using WopiHost.Core.Results;
+using WopiHost.Core.Security.Authentication;
 using WopiHost.Core.Security.Authorization;
 
 namespace WopiHost.Core.Controllers;
@@ -28,6 +28,7 @@ namespace WopiHost.Core.Controllers;
 [Authorize]
 [ApiController]
 [Route("wopi/[controller]")]
+[ServiceFilter(typeof(WopiOriginValidationActionFilter))]
 public class FilesController(
     IWopiStorageProvider storageProvider,
     IMemoryCache memoryCache,

--- a/src/WopiHost.Core/Controllers/WopiBootstrapperController.cs
+++ b/src/WopiHost.Core/Controllers/WopiBootstrapperController.cs
@@ -2,13 +2,13 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using WopiHost.Abstractions;
 using WopiHost.Core.Extensions;
 using WopiHost.Core.Infrastructure;
 using WopiHost.Core.Models;
 using WopiHost.Core.Results;
+using WopiHost.Core.Security.Authentication;
 
 namespace WopiHost.Core.Controllers;
 
@@ -23,6 +23,7 @@ namespace WopiHost.Core.Controllers;
 [Authorize]
 [ApiController]
 [Route("wopibootstrapper")]
+[ServiceFilter(typeof(WopiOriginValidationActionFilter))]
 public class WopiBootstrapperController(
     IWopiStorageProvider storageProvider,
     IWopiSecurityHandler securityHandler) : ControllerBase

--- a/src/WopiHost.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/WopiHost.Core/Extensions/ServiceCollectionExtensions.cs
@@ -27,11 +27,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IAuthorizationHandler, WopiAuthorizationHandler>();
         
         services.AddScoped<IWopiProofValidator, WopiProofValidator>();
-
-        services.AddControllers(options =>
-            {
-                options.Filters.Add<WopiOriginValidationActionFilter>();
-            })
+        services.AddScoped<WopiOriginValidationActionFilter>();
+        services.AddControllers()
             .AddApplicationPart(typeof(ServiceCollectionExtensions).GetTypeInfo().Assembly) // Add controllers from this assembly
             .AddJsonOptions(o => o.JsonSerializerOptions.PropertyNamingPolicy = null); // Ensure PascalCase property name-style
 

--- a/src/WopiHost.Core/Security/Authentication/WopiOriginValidationActionFilter.cs
+++ b/src/WopiHost.Core/Security/Authentication/WopiOriginValidationActionFilter.cs
@@ -10,7 +10,7 @@ namespace WopiHost.Core.Security.Authentication;
 /// <summary>
 /// Action Filter running on Core /wopi Controllers, that validates the origin of WOPI requests by checking proof keys.
 /// </summary>
-public class WopiOriginValidationActionFilter : IAsyncActionFilter
+public class WopiOriginValidationActionFilter : Attribute, IAsyncActionFilter
 {
     private readonly IWopiProofValidator _proofValidator;
     private readonly ILogger<WopiOriginValidationActionFilter> _logger;


### PR DESCRIPTION
Changed Action filter to be specific to Core controllers, otherwise it overrides any project's implementation of WopiHost

### Motivation

When a Web App project implemented WopiHost, the ActionFilter implementation to validate proof key's were running on every controller in the project, not just /wopi