### PR TITLE
Fix case sensitivity for file extensions in WopiDiscoverer

### DIFF
--- a/src/WopiHost.Discovery/WopiDiscoverer.cs
+++ b/src/WopiHost.Discovery/WopiDiscoverer.cs
@@ -94,7 +94,7 @@ public class WopiDiscoverer(
     public async Task<bool> SupportsExtensionAsync(string extension)
     {
         var query = (await GetAppsAsync()).Elements()
-            .FirstOrDefault(e => e.Attribute(AttrActionExtension)?.Value == extension);
+            .FirstOrDefault(e => string.Equals(e.Attribute(AttrActionExtension)?.Value, extension, StringComparison.OrdinalIgnoreCase));
         return query is not null;
     }
 
@@ -104,7 +104,7 @@ public class WopiDiscoverer(
         var actionString = action.ToString().ToUpperInvariant();
 
         var query = (await GetAppsAsync()).Elements()
-            .Where(e => e.Attribute(AttrActionExtension)?.Value == extension && 
+            .Where(e => string.Equals(e.Attribute(AttrActionExtension)?.Value, extension, StringComparison.OrdinalIgnoreCase) && 
                 e.Attribute(AttrActionName)?.Value.Equals(actionString, StringComparison.InvariantCultureIgnoreCase) == true);
 
         return query.Any();
@@ -116,7 +116,7 @@ public class WopiDiscoverer(
         var actionString = action.ToString().ToUpperInvariant();
 
         var query = (await GetAppsAsync()).Elements()
-            .Where(e => e.Attribute(AttrActionExtension)?.Value == extension && 
+            .Where(e => string.Equals(e.Attribute(AttrActionExtension)?.Value, extension, StringComparison.OrdinalIgnoreCase) && 
                 e.Attribute(AttrActionName)?.Value.Equals(actionString, StringComparison.InvariantCultureIgnoreCase) == true)
             .Select(e => e.Attribute(AttrActionRequires)?.Value.Split(','));
 
@@ -135,7 +135,7 @@ public class WopiDiscoverer(
     {
         var actionString = action.ToString().ToUpperInvariant();
         var query = (await GetAppsAsync()).Elements()
-            .Where(e => e.Attribute(AttrActionExtension)?.Value == extension && 
+            .Where(e => string.Equals(e.Attribute(AttrActionExtension)?.Value, extension, StringComparison.OrdinalIgnoreCase) && 
                 e.Attribute(AttrActionName)?.Value.Equals(actionString, StringComparison.InvariantCultureIgnoreCase) == true)
             .Select(e => e.Attribute(AttrActionUrl)?.Value);
         return query.FirstOrDefault();
@@ -145,7 +145,7 @@ public class WopiDiscoverer(
     public async Task<string?> GetApplicationNameAsync(string extension)
     {
         var query = (await GetAppsAsync())
-            .Where(e => e.Descendants(ElementAction).Any(d => d.Attribute(AttrActionExtension)?.Value == extension))
+            .Where(e => e.Descendants(ElementAction).Any(d => string.Equals(d.Attribute(AttrActionExtension)?.Value, extension, StringComparison.OrdinalIgnoreCase)))
             .Select(e => e.Attribute(AttrAppName)?.Value);
 
         return query.FirstOrDefault();
@@ -155,7 +155,7 @@ public class WopiDiscoverer(
     public async Task<Uri?> GetApplicationFavIconAsync(string extension)
     {
         var query = (await GetAppsAsync())
-            .Where(e => e.Descendants(ElementAction).Any(d => d.Attribute(AttrActionExtension)?.Value == extension))
+            .Where(e => e.Descendants(ElementAction).Any(d => string.Equals(d.Attribute(AttrActionExtension)?.Value, extension, StringComparison.OrdinalIgnoreCase)))
             .Select(e => e.Attribute(AttrAppFavicon)?.Value);
         var result = query.FirstOrDefault();
         return result is not null ? new Uri(result) : null;

--- a/test/WopiHost.Discovery.Tests/WopiDiscovererTests.cs
+++ b/test/WopiHost.Discovery.Tests/WopiDiscovererTests.cs
@@ -67,6 +67,22 @@ public class WopiDiscovererTests
     }
 
     [Theory]
+    [InlineData(NetZoneEnum.InternalHttp, "XLSX", XmlOos2016)]
+    [InlineData(NetZoneEnum.InternalHttp, "DOCX", XmlOos2016)]
+    [InlineData(NetZoneEnum.InternalHttp, "XlSx", XmlOos2016)]
+    public async Task CaseInsensitiveSupportedExtension(NetZoneEnum netZone, string extension, string fileName)
+    {
+        // Arrange
+        InitDiscoverer(fileName, netZone);
+
+        // Act
+        var result = await _wopiDiscoverer.SupportsExtensionAsync(extension);
+
+        // Assert
+        Assert.True(result, $"{extension} should be supported!");
+    }
+
+    [Theory]
     [InlineData(NetZoneEnum.InternalHttp, "html", XmlOos2016)]
     [InlineData(NetZoneEnum.InternalHttp, "txt", XmlOos2016)]
     public async Task NonSupportedExtension(NetZoneEnum netZone, string extension, string fileName)
@@ -100,6 +116,22 @@ public class WopiDiscovererTests
     [InlineData(NetZoneEnum.InternalHttp, "pptx", XmlOos2016)]
     [InlineData(NetZoneEnum.InternalHttp, "docx", XmlOos2016)]
     public async Task SupportedExtensionWithAction(NetZoneEnum netZone, string extension, string fileName)
+    {
+        // Arrange
+        InitDiscoverer(fileName, netZone);
+
+        // Act
+        var result = await _wopiDiscoverer.SupportsActionAsync(extension, WopiActionEnum.Edit);
+
+        // Assert
+        Assert.True(result, $"{extension} should be supported!");
+    }
+
+    [Theory]
+    [InlineData(NetZoneEnum.InternalHttp, "PPTX", XmlOos2016)]
+    [InlineData(NetZoneEnum.InternalHttp, "DOCX", XmlOos2016)]
+    [InlineData(NetZoneEnum.InternalHttp, "PpTx", XmlOos2016)]
+    public async Task CaseInsensitiveSupportedExtensionWithAction(NetZoneEnum netZone, string extension, string fileName)
     {
         // Arrange
         InitDiscoverer(fileName, netZone);
@@ -159,11 +191,43 @@ public class WopiDiscovererTests
     }
 
     [Theory]
+    [InlineData(NetZoneEnum.InternalHttp, "XLSX", WopiActionEnum.Edit, "http://owaserver/x/_layouts/xlviewerinternal.aspx?edit=1&<ui=UI_LLCC&><rs=DC_LLCC&>", XmlOwa2013)]
+    [InlineData(NetZoneEnum.InternalHttp, "DOCX", WopiActionEnum.Edit, "http://owaserver/we/wordeditorframe.aspx?<ui=UI_LLCC&><rs=DC_LLCC&><showpagestats=PERFSTATS&>", XmlOwa2013)]
+    [InlineData(NetZoneEnum.InternalHttp, "XlSx", WopiActionEnum.Edit, "http://owaserver/x/_layouts/xlviewerinternal.aspx?edit=1&<ui=UI_LLCC&><rs=DC_LLCC&>", XmlOwa2013)]
+    public async Task CaseInsensitiveExtensionTests(NetZoneEnum netZone, string extension, WopiActionEnum action, string? expectedValue, string fileName)
+    {
+        // Arrange
+        InitDiscoverer(fileName, netZone);
+
+        // Act
+        var result = await _wopiDiscoverer.GetUrlTemplateAsync(extension, action);
+
+        // Assert
+        Assert.Equal(expectedValue, result);
+    }
+
+    [Theory]
     [InlineData(NetZoneEnum.InternalHttp, "xlsx", "Excel", XmlOos2016)]
     [InlineData(NetZoneEnum.InternalHttp, "docx", "Word", XmlOos2016)]
     [InlineData(NetZoneEnum.InternalHttp, "html", null, XmlOos2016)]
     [InlineData(NetZoneEnum.InternalHttp, "txt", null, XmlOos2016)]
     public async Task AppNameTests(NetZoneEnum netZone, string extension, string? expectedValue, string fileName)
+    {
+        // Arrange
+        InitDiscoverer(fileName, netZone);
+
+        // Act
+        var result = await _wopiDiscoverer.GetApplicationNameAsync(extension);
+
+        // Assert
+        Assert.Equal(expectedValue, result);
+    }
+
+    [Theory]
+    [InlineData(NetZoneEnum.InternalHttp, "XLSX", "Excel", XmlOos2016)]
+    [InlineData(NetZoneEnum.InternalHttp, "DOCX", "Word", XmlOos2016)]
+    [InlineData(NetZoneEnum.InternalHttp, "XlSx", "Excel", XmlOos2016)]
+    public async Task CaseInsensitiveAppNameTests(NetZoneEnum netZone, string extension, string? expectedValue, string fileName)
     {
         // Arrange
         InitDiscoverer(fileName, netZone);


### PR DESCRIPTION
### Motivation

File extensions with uppercase characters (e.g., .XLSX) fail to match WOPI actions because comparisons were case-sensitive.

Discovery XML contains lowercase extensions (ext="xlsx"), so runtime extensions must be compared case-insensitively.

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [n/a] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
- [x] Adheres to [.NET Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/)

### How to test

New automated tests are available; they pass in non-lowercase extensions.  Also, loading a file with an all-caps extension should correctly find the right action in Discoverer.

### Changes
Updated all extension comparisons in WopiDiscoverer.cs to use StringComparison.OrdinalIgnoreCase
Affected methods: SupportsExtensionAsync, SupportsActionAsync, GetActionRequirementsAsync, GetUrlTemplateAsync, GetApplicationNameAsync, GetApplicationFavIconAsync
Added automated tests for each of the affected methods.

Example
Before:

.Where(e => e.Attribute(AttrActionExtension)?.Value == extension && ...)

After:

.Where(e => string.Equals(e.Attribute(AttrActionExtension)?.Value, extension, StringComparison.OrdinalIgnoreCase) && ...)


