### PR TITLE
feat: add cache-control headers to WOPI host page

### DIFF
--- a/sample/WopiHost.Web/Controllers/HomeController.cs
+++ b/sample/WopiHost.Web/Controllers/HomeController.cs
@@ -68,6 +68,13 @@ public class HomeController(
         var extension = file.Extension.TrimStart('.');
         ViewData["urlsrc"] = await urlGenerator.GetFileUrlAsync(extension, new Uri(wopiOptions.Value.HostUrl, $"/wopi/files/{id}"), actionEnum); //TODO: add a test for the URL not to contain double slashes between host and path
         ViewData["favicon"] = await discoverer.GetApplicationFavIconAsync(extension);
+
+        // Host page headers as per WOPI spec to prevent browser caching
+        // https://learn.microsoft.com/en-us/microsoft-365/cloud-storage-partner-program/online/hostpage#host-page-headers
+        Response.Headers.CacheControl = "no-cache, no-store";
+        Response.Headers.Expires = "-1";
+        Response.Headers.Pragma = "no-cache";
+
         return View();
     }
 

--- a/sample/WopiHost.Web/Controllers/HomeController.cs
+++ b/sample/WopiHost.Web/Controllers/HomeController.cs
@@ -68,7 +68,7 @@ public class HomeController(
         ViewData["favicon"] = await discoverer.GetApplicationFavIconAsync(extension);
 
         // Host page headers as per WOPI spec to prevent browser caching
-        // https://learn.microsoft.com/en-us/microsoft-365/cloud-storage-partner-program/online/hostpage#host-page-headers
+        // https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/online/hostpage#host-page-headers
         Response.Headers.CacheControl = "no-cache, no-store";
         Response.Headers.Expires = "-1";
         Response.Headers.Pragma = "no-cache";

--- a/sample/WopiHost.Web/Controllers/HomeController.cs
+++ b/sample/WopiHost.Web/Controllers/HomeController.cs
@@ -57,13 +57,11 @@ public class HomeController(
             ?? throw new FileNotFoundException($"File with ID '{id}' not found.");
         var token = await securityHandler.GenerateAccessToken("Anonymous", file.Identifier);
 
-
         ViewData["access_token"] = securityHandler.WriteToken(token);
         //TODO: fix
         //ViewData["access_token_ttl"] = //token.ValidTo
 
         //http://dotnet-stuff.com/tutorials/aspnet-mvc/how-to-render-different-layout-in-asp-net-mvc
-
 
         var extension = file.Extension.TrimStart('.');
         ViewData["urlsrc"] = await urlGenerator.GetFileUrlAsync(extension, new Uri(wopiOptions.Value.HostUrl, $"/wopi/files/{id}"), actionEnum); //TODO: add a test for the URL not to contain double slashes between host and path

--- a/sample/WopiHost.Web/Controllers/HomeController.cs
+++ b/sample/WopiHost.Web/Controllers/HomeController.cs
@@ -72,6 +72,7 @@ public class HomeController(
         Response.Headers.CacheControl = "no-cache, no-store";
         Response.Headers.Expires = "-1";
         Response.Headers.Pragma = "no-cache";
+        Response.Headers.Vary = "*";
 
         return View();
     }


### PR DESCRIPTION
## Summary
- Adds `Cache-Control: no-cache, no-store`, `Expires: -1`, `Pragma: no-cache`, and `Vary: *` headers to the `Detail` action in `HomeController`, which serves the WOPI host page
- Required by the [WOPI spec](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/online/hostpage#host-page-headers) to prevent browsers from caching the host page
- The `Date` header is already included automatically by Kestrel, so no explicit addition is needed

Closes #125

## Test plan
- [ ] Verify the host page response includes the cache-control headers
- [ ] Confirm the WOPI client iframe still loads correctly in the host page

🤖 Generated with [Claude Code](https://claude.com/claude-code)