### PR TITLE
feat: consolidate WopiUserPermissions and container permissions

### DIFF
--- a/sample/WopiHost.Validator/Infrastructure/WopiSecurityHandler.cs
+++ b/sample/WopiHost.Validator/Infrastructure/WopiSecurityHandler.cs
@@ -15,12 +15,22 @@ namespace WopiHost.Validator.Infrastructure;
 public class WopiSecurityHandler(IOptions<WopiOptions> options) : IWopiSecurityHandler
 {
     /// <inheritdoc/>
-    public Task<WopiUserPermissions> GetUserPermissions(ClaimsPrincipal principal, IWopiFile file, CancellationToken cancellationToken = default)
+    public Task<WopiFilePermissions> GetFilePermissions(ClaimsPrincipal principal, IWopiFile file, CancellationToken cancellationToken = default)
     {
-        return Task.FromResult(WopiUserPermissions.UserCanWrite |
-            WopiUserPermissions.UserCanRename |
-            WopiUserPermissions.UserCanAttend |
-            WopiUserPermissions.UserCanPresent);
+        return Task.FromResult(WopiFilePermissions.UserCanWrite |
+            WopiFilePermissions.UserCanRename |
+            WopiFilePermissions.UserCanAttend |
+            WopiFilePermissions.UserCanPresent);
+    }
+
+    /// <inheritdoc/>
+    public Task<WopiContainerPermissions> GetContainerPermissions(ClaimsPrincipal principal, IWopiFolder container, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(
+            WopiContainerPermissions.UserCanCreateChildContainer |
+            WopiContainerPermissions.UserCanCreateChildFile |
+            WopiContainerPermissions.UserCanDelete |
+            WopiContainerPermissions.UserCanRename);
     }
 
     /// <inheritdoc/>

--- a/src/WopiHost.Abstractions/IWopiSecurityHandler.cs
+++ b/src/WopiHost.Abstractions/IWopiSecurityHandler.cs
@@ -42,9 +42,18 @@ public interface IWopiSecurityHandler
     /// <summary>
     /// Retrieves permissions for the given user on the given file.
     /// </summary>
-    /// <param name="file">the file in question</param>
     /// <param name="principal">User principal object</param>
+    /// <param name="file">the file in question</param>
 	/// <param name="cancellationToken">Cancellation token</param>
     /// <returns></returns>
-    Task<WopiUserPermissions> GetUserPermissions(ClaimsPrincipal principal, IWopiFile file, CancellationToken cancellationToken = default);
+    Task<WopiFilePermissions> GetFilePermissions(ClaimsPrincipal principal, IWopiFile file, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves permissions for the given user on the given container.
+    /// </summary>
+    /// <param name="principal">User principal object</param>
+    /// <param name="container">the container in question</param>
+	/// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    Task<WopiContainerPermissions> GetContainerPermissions(ClaimsPrincipal principal, IWopiFolder container, CancellationToken cancellationToken = default);
 }

--- a/src/WopiHost.Abstractions/README.md
+++ b/src/WopiHost.Abstractions/README.md
@@ -244,26 +244,26 @@ public class CustomSecurityHandler : IWopiSecurityHandler
     private readonly IUserService _userService;
     private readonly ITokenService _tokenService;
     
-    public async Task<WopiUserPermissions> GetUserPermissionsAsync(string userId, string resourceId)
+    public async Task<WopiFilePermissions> GetFilePermissionsAsync(string userId, string resourceId)
     {
         var user = await _userService.GetUserAsync(userId);
         var resource = await GetResourceAsync(resourceId);
         
-        var permissions = WopiUserPermissions.None;
+        var permissions = WopiFilePermissions.None;
         
         if (user.CanRead(resource))
         {
-            permissions |= WopiUserPermissions.Read;
+            permissions |= WopiFilePermissions.Read;
         }
         
         if (user.CanWrite(resource))
         {
-            permissions |= WopiUserPermissions.Write;
+            permissions |= WopiFilePermissions.Write;
         }
         
         if (user.CanDelete(resource))
         {
-            permissions |= WopiUserPermissions.Delete;
+            permissions |= WopiFilePermissions.Delete;
         }
         
         return permissions;
@@ -281,8 +281,8 @@ public class CustomSecurityHandler : IWopiSecurityHandler
                 return false;
             }
             
-            var permissions = await GetUserPermissionsAsync(userId, resourceId);
-            return permissions != WopiUserPermissions.None;
+            var permissions = await GetFilePermissionsAsync(userId, resourceId);
+            return permissions != WopiFilePermissions.None;
         }
         catch
         {
@@ -432,7 +432,7 @@ Handles authentication and authorization.
 ```csharp
 public interface IWopiSecurityHandler
 {
-    Task<WopiUserPermissions> GetUserPermissionsAsync(string userId, string resourceId);
+    Task<WopiFilePermissions> GetFilePermissionsAsync(string userId, string resourceId);
     Task<bool> ValidateTokenAsync(string token, string resourceId);
     Task<string> GetUserIdAsync(string token);
 }

--- a/src/WopiHost.Abstractions/WopiContainerPermissions.cs
+++ b/src/WopiHost.Abstractions/WopiContainerPermissions.cs
@@ -1,0 +1,33 @@
+namespace WopiHost.Abstractions;
+
+/// <summary>
+/// WOPI container permission flags implemented in accordance with: https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/containers/checkcontainerinfo
+/// </summary>
+[Flags]
+	public enum WopiContainerPermissions
+	{
+		/// <summary>
+		/// Default value - user has no permissions.
+		/// </summary>
+		None = 0,
+
+		/// <summary>
+		/// A Boolean value that indicates that the user has permission to create a new child container.
+		/// </summary>
+		UserCanCreateChildContainer = 1,
+
+		/// <summary>
+		/// A Boolean value that indicates that the user has permission to create a new child file.
+		/// </summary>
+		UserCanCreateChildFile = 2,
+
+		/// <summary>
+		/// A Boolean value that indicates that the user has permission to delete the container.
+		/// </summary>
+		UserCanDelete = 4,
+
+		/// <summary>
+		/// A Boolean value that indicates that the user has permission to rename the container.
+		/// </summary>
+		UserCanRename = 8,
+	}

--- a/src/WopiHost.Abstractions/WopiFilePermissions.cs
+++ b/src/WopiHost.Abstractions/WopiFilePermissions.cs
@@ -1,10 +1,10 @@
-﻿namespace WopiHost.Abstractions;
+namespace WopiHost.Abstractions;
 
 /// <summary>
-/// WOPI claims  implemented in accordance with: https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/checkfileinfo/checkfileinfo-response#user-permissions-properties
+/// WOPI file permission flags implemented in accordance with: https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/checkfileinfo/checkfileinfo-response#user-permissions-properties
 /// </summary>
 [Flags]
-	public enum WopiUserPermissions
+	public enum WopiFilePermissions
 	{
 		/// <summary>
 		/// Default value - user has no permissions.
@@ -47,7 +47,7 @@
 		UserCanWrite = 64,
 
 		/// <summary>
-		/// A Boolean value that indicates that the WOPI client must not allow the user to edit the file. This does not mean that the user doesn’t have rights to edit the file. Hosts should use the UserCanWrite property for that purpose.
+		/// A Boolean value that indicates that the WOPI client must not allow the user to edit the file. This does not mean that the user doesn't have rights to edit the file. Hosts should use the UserCanWrite property for that purpose.
 		/// </summary>
 		WebEditingDisabled = 128
 	}

--- a/src/WopiHost.Core/Controllers/ContainersController.cs
+++ b/src/WopiHost.Core/Controllers/ContainersController.cs
@@ -41,8 +41,7 @@ public class ContainersController(
     /// <returns></returns>
     [HttpGet("{id}", Name = WopiRouteNames.CheckContainerInfo)]
     [Produces(MediaTypeNames.Application.Json)]
-    [WopiAuthorize(WopiResourceType.Container, Permission.Read,
-        CheckPermissions = [Permission.Create, Permission.Delete, Permission.Rename, Permission.CreateChildFile])]
+    [WopiAuthorize(WopiResourceType.Container, Permission.Read)]
     public async Task<IActionResult> CheckContainerInfo(string id, CancellationToken cancellationToken = default)
     {
         var container = await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken);
@@ -50,7 +49,7 @@ public class ContainersController(
         {
             return NotFound();
         }
-        var checkContainerInfo = await container.GetWopiCheckContainerInfo(HttpContext);
+        var checkContainerInfo = await container.GetWopiCheckContainerInfo(HttpContext, cancellationToken);
         return new JsonResult<WopiCheckContainerInfo>(checkContainerInfo);
     }
 
@@ -128,7 +127,7 @@ public class ContainersController(
 
         if (newFolder is not null)
         {
-            var checkContainerInfo = await newFolder.GetWopiCheckContainerInfo(HttpContext);
+            var checkContainerInfo = await newFolder.GetWopiCheckContainerInfo(HttpContext, cancellationToken);
             return new JsonResult(
                 new CreateChildContainerResponse(
                     new(newFolder.Name, Url.GetWopiSrc(WopiResourceType.Container, newFolder.Identifier)),

--- a/src/WopiHost.Core/Extensions/Extensions.cs
+++ b/src/WopiHost.Core/Extensions/Extensions.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Mvc;
 using WopiHost.Abstractions;
 using WopiHost.Core.Infrastructure;
 using WopiHost.Core.Security.Authentication;
-using WopiHost.Core.Security.Authorization;
 
 namespace WopiHost.Core.Extensions;
 
@@ -116,17 +115,6 @@ internal static class Extensions
                 WopiResourceType.Container => WopiRouteNames.CheckContainerInfo,
                 _ => throw new ArgumentOutOfRangeException(nameof(resourceType), resourceType, null)
             }, identifier, accessToken);
-    }
-
-    /// <summary>
-    /// Checks if the resource has a specific permission as setup by <see cref="WopiAuthorizationHandler"/>
-    /// </summary>
-    /// <param name="httpContext">HTTP context</param>
-    /// <param name="permission">type of permission</param>
-    /// <returns>true if permission found and allowed, false otherwise</returns>
-    public static bool IsPermitted(this HttpContext httpContext, Permission permission)
-    {
-        return httpContext.Items.TryGetValue(permission, out var value) && value is bool boolValue && boolValue;
     }
 
     /// <summary>

--- a/src/WopiHost.Core/Extensions/WopiExtensions.cs
+++ b/src/WopiHost.Core/Extensions/WopiExtensions.cs
@@ -102,15 +102,15 @@ public static class WopiExtensions
 
             // try to parse permissions claims
             var securityHandler = httpContext.RequestServices.GetRequiredService<IWopiSecurityHandler>();
-            var permissions = await securityHandler.GetUserPermissions(httpContext.User, file, cancellationToken);
-            checkFileInfo.ReadOnly = permissions.HasFlag(WopiUserPermissions.ReadOnly);
-            checkFileInfo.RestrictedWebViewOnly = permissions.HasFlag(WopiUserPermissions.RestrictedWebViewOnly);
-            checkFileInfo.UserCanAttend = permissions.HasFlag(WopiUserPermissions.UserCanAttend);
-            checkFileInfo.UserCanNotWriteRelative = capabilities?.SupportsUpdate == false || permissions.HasFlag(WopiUserPermissions.UserCanNotWriteRelative);
-            checkFileInfo.UserCanPresent = permissions.HasFlag(WopiUserPermissions.UserCanPresent);
-            checkFileInfo.UserCanRename = permissions.HasFlag(WopiUserPermissions.UserCanRename);
-            checkFileInfo.UserCanWrite = permissions.HasFlag(WopiUserPermissions.UserCanWrite);
-            checkFileInfo.WebEditingDisabled = permissions.HasFlag(WopiUserPermissions.WebEditingDisabled);
+            var permissions = await securityHandler.GetFilePermissions(httpContext.User, file, cancellationToken);
+            checkFileInfo.ReadOnly = permissions.HasFlag(WopiFilePermissions.ReadOnly);
+            checkFileInfo.RestrictedWebViewOnly = permissions.HasFlag(WopiFilePermissions.RestrictedWebViewOnly);
+            checkFileInfo.UserCanAttend = permissions.HasFlag(WopiFilePermissions.UserCanAttend);
+            checkFileInfo.UserCanNotWriteRelative = capabilities?.SupportsUpdate == false || permissions.HasFlag(WopiFilePermissions.UserCanNotWriteRelative);
+            checkFileInfo.UserCanPresent = permissions.HasFlag(WopiFilePermissions.UserCanPresent);
+            checkFileInfo.UserCanRename = permissions.HasFlag(WopiFilePermissions.UserCanRename);
+            checkFileInfo.UserCanWrite = permissions.HasFlag(WopiFilePermissions.UserCanWrite);
+            checkFileInfo.WebEditingDisabled = permissions.HasFlag(WopiFilePermissions.WebEditingDisabled);
         }
         else
         {
@@ -138,20 +138,26 @@ public static class WopiExtensions
     /// </summary>
     /// <param name="container"><see cref="IWopiFolder"/> to return info</param>
     /// <param name="httpContext">current HttpContext</param>
+    /// <param name="cancellationToken">cancellation token</param>
     /// <returns>WopiCheckContainerInfo</returns>
     public static async Task<WopiCheckContainerInfo> GetWopiCheckContainerInfo(
-        this IWopiFolder container, 
-        HttpContext httpContext)
+        this IWopiFolder container,
+        HttpContext httpContext,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(container);
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        var securityHandler = httpContext.RequestServices.GetRequiredService<IWopiSecurityHandler>();
+        var permissions = await securityHandler.GetContainerPermissions(httpContext.User, container, cancellationToken);
 
         var checkContainerInfo = new WopiCheckContainerInfo()
         {
             Name = container.Name,
-            UserCanCreateChildContainer = httpContext.IsPermitted(Permission.Create),
-            UserCanDelete = httpContext.IsPermitted(Permission.Delete),
-            UserCanRename = httpContext.IsPermitted(Permission.Rename),
-            UserCanCreateChildFile = httpContext.IsPermitted(Permission.CreateChildFile),
+            UserCanCreateChildContainer = permissions.HasFlag(WopiContainerPermissions.UserCanCreateChildContainer),
+            UserCanCreateChildFile = permissions.HasFlag(WopiContainerPermissions.UserCanCreateChildFile),
+            UserCanDelete = permissions.HasFlag(WopiContainerPermissions.UserCanDelete),
+            UserCanRename = permissions.HasFlag(WopiContainerPermissions.UserCanRename),
             IsEduUser = false,
         };
 

--- a/src/WopiHost.Core/README.md
+++ b/src/WopiHost.Core/README.md
@@ -350,10 +350,10 @@ WOPI uses token-based authentication. Implement `IWopiSecurityHandler` to provid
 ```csharp
 public class CustomSecurityHandler : IWopiSecurityHandler
 {
-    public async Task<WopiUserPermissions> GetUserPermissionsAsync(string userId, string resourceId)
+    public async Task<WopiFilePermissions> GetFilePermissionsAsync(string userId, string resourceId)
     {
         // Implement permission logic
-        return WopiUserPermissions.Read | WopiUserPermissions.Write;
+        return WopiFilePermissions.Read | WopiFilePermissions.Write;
     }
     
     public async Task<bool> ValidateTokenAsync(string token, string resourceId)
@@ -379,9 +379,9 @@ public class CustomAuthorizationRequirement : IWopiAuthorizationRequirement
 {
     public string RequiredPermission { get; set; }
     
-    public bool IsSatisfiedBy(WopiUserPermissions permissions)
+    public bool IsSatisfiedBy(WopiFilePermissions permissions)
     {
-        return permissions.HasFlag(WopiUserPermissions.Write);
+        return permissions.HasFlag(WopiFilePermissions.Write);
     }
 }
 ```

--- a/src/WopiHost.Core/Security/Authorization/WopiAuthorizationHandler.cs
+++ b/src/WopiHost.Core/Security/Authorization/WopiAuthorizationHandler.cs
@@ -29,16 +29,6 @@ public class WopiAuthorizationHandler(IWopiSecurityHandler securityHandler)
             requirement.ResourceId = fileIdRaw.ToString();
         }
 
-        // check additional permissions
-        foreach (var checkPermission in requirement.CheckPermissions)
-        {
-            var checkRequirement = new WopiAuthorizeAttribute(requirement.ResourceType, checkPermission)
-            {
-                ResourceId = requirement.ResourceId
-            };
-            resource.Items.Add(checkPermission, await securityHandler.IsAuthorized(context.User, checkRequirement));
-        }
-
         // check if the user is authorized
         if (await securityHandler.IsAuthorized(context.User, requirement))
         {

--- a/src/WopiHost.Core/Security/Authorization/WopiAuthorizeAttribute.cs
+++ b/src/WopiHost.Core/Security/Authorization/WopiAuthorizeAttribute.cs
@@ -22,11 +22,6 @@ public class WopiAuthorizeAttribute(
     public Permission Permission { get; } = permission;
 
     /// <summary>
-    /// Permissions to check and return in HttpContext.Items collection
-    /// </summary>
-    public Permission[] CheckPermissions { get; set; } = [];
-
-    /// <summary>
     /// Gets the type of the resource.
     /// </summary>
     public WopiResourceType ResourceType { get; } = resourceType;

--- a/src/WopiHost.FileSystemProvider/README.md
+++ b/src/WopiHost.FileSystemProvider/README.md
@@ -151,7 +151,7 @@ public class NetworkDriveSecurityHandler : IWopiSecurityHandler
 {
     private readonly IUserService _userService;
     
-    public async Task<WopiUserPermissions> GetUserPermissionsAsync(string userId, string resourceId)
+    public async Task<WopiFilePermissions> GetFilePermissionsAsync(string userId, string resourceId)
     {
         var user = await _userService.GetUserAsync(userId);
         var filePath = DecodeFilePath(resourceId);
@@ -160,9 +160,9 @@ public class NetworkDriveSecurityHandler : IWopiSecurityHandler
         var hasReadAccess = await CheckNetworkFileAccess(filePath, user, FileAccess.Read);
         var hasWriteAccess = await CheckNetworkFileAccess(filePath, user, FileAccess.Write);
         
-        var permissions = WopiUserPermissions.None;
-        if (hasReadAccess) permissions |= WopiUserPermissions.Read;
-        if (hasWriteAccess) permissions |= WopiUserPermissions.Write;
+        var permissions = WopiFilePermissions.None;
+        if (hasReadAccess) permissions |= WopiFilePermissions.Read;
+        if (hasWriteAccess) permissions |= WopiFilePermissions.Write;
         
         return permissions;
     }
@@ -400,10 +400,10 @@ File system-based security handler.
 
 #### Methods
 
-##### GetUserPermissionsAsync
+##### GetFilePermissionsAsync
 
 ```csharp
-public Task<WopiUserPermissions> GetUserPermissionsAsync(string userId, string resourceId)
+public Task<WopiFilePermissions> GetFilePermissionsAsync(string userId, string resourceId)
 ```
 
 Gets user permissions for a resource based on file system ACLs.

--- a/src/WopiHost.FileSystemProvider/WopiSecurityHandler.cs
+++ b/src/WopiHost.FileSystemProvider/WopiSecurityHandler.cs
@@ -44,20 +44,30 @@ public class WopiSecurityHandler(ILoggerFactory loggerFactory) : IWopiSecurityHa
                 new(ClaimTypes.Email, "anonymous@domain.tld"),
 
                 ////TDOO: this needs to be done per file
-                //new(WopiClaimTypes.USER_PERMISSIONS, (WopiUserPermissions.UserCanWrite | WopiUserPermissions.UserCanRename | WopiUserPermissions.UserCanAttend | WopiUserPermissions.UserCanPresent).ToString())
+                //new(WopiClaimTypes.USER_PERMISSIONS, (WopiFilePermissions.UserCanWrite | WopiFilePermissions.UserCanRename | WopiFilePermissions.UserCanAttend | WopiFilePermissions.UserCanPresent).ToString())
             ])
         )
         }
     };
 
     /// <inheritdoc/>
-    public Task<WopiUserPermissions> GetUserPermissions(ClaimsPrincipal principal, IWopiFile file, CancellationToken cancellationToken = default)
+    public Task<WopiFilePermissions> GetFilePermissions(ClaimsPrincipal principal, IWopiFile file, CancellationToken cancellationToken = default)
     {
-        //var permissions = Enum.Parse<WopiUserPermissions>(principal.FindFirstValue(WopiClaimTypes.USER_PERMISSIONS) ?? string.Empty);
-        return Task.FromResult(WopiUserPermissions.UserCanWrite | 
-            WopiUserPermissions.UserCanRename | 
-            WopiUserPermissions.UserCanAttend | 
-            WopiUserPermissions.UserCanPresent);
+        //var permissions = Enum.Parse<WopiFilePermissions>(principal.FindFirstValue(WopiClaimTypes.USER_PERMISSIONS) ?? string.Empty);
+        return Task.FromResult(WopiFilePermissions.UserCanWrite |
+            WopiFilePermissions.UserCanRename |
+            WopiFilePermissions.UserCanAttend |
+            WopiFilePermissions.UserCanPresent);
+    }
+
+    /// <inheritdoc/>
+    public Task<WopiContainerPermissions> GetContainerPermissions(ClaimsPrincipal principal, IWopiFolder container, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(
+            WopiContainerPermissions.UserCanCreateChildContainer |
+            WopiContainerPermissions.UserCanCreateChildFile |
+            WopiContainerPermissions.UserCanDelete |
+            WopiContainerPermissions.UserCanRename);
     }
 
     /// <inheritdoc/>

--- a/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
@@ -17,6 +17,7 @@ public class ContainersControllerTests
     private readonly Mock<IWopiStorageProvider> storageProviderMock;
     private readonly Mock<IWopiLockProvider> lockProviderMock;
     private readonly Mock<IWopiWritableStorageProvider> writableStorageProviderMock;
+    private readonly Mock<IWopiSecurityHandler> securityHandlerMock;
     private readonly ContainersController _controller;
 
     public ContainersControllerTests()
@@ -24,6 +25,10 @@ public class ContainersControllerTests
         storageProviderMock = new Mock<IWopiStorageProvider>();
         lockProviderMock = new Mock<IWopiLockProvider>();
         writableStorageProviderMock = new Mock<IWopiWritableStorageProvider>();
+        securityHandlerMock = new Mock<IWopiSecurityHandler>();
+        securityHandlerMock
+            .Setup(_ => _.GetContainerPermissions(It.IsAny<System.Security.Claims.ClaimsPrincipal>(), It.IsAny<IWopiFolder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(WopiContainerPermissions.UserCanCreateChildContainer | WopiContainerPermissions.UserCanCreateChildFile | WopiContainerPermissions.UserCanDelete | WopiContainerPermissions.UserCanRename);
         var url = new Mock<IUrlHelper>();
         url
             .Setup(_ => _.RouteUrl(It.IsAny<UrlRouteContext>()))
@@ -47,7 +52,7 @@ public class ContainersControllerTests
             {
                 HttpContext = new DefaultHttpContext()
                 {
-                    ServiceScopeFactory = TestUtils.CreateServiceScope()
+                    ServiceScopeFactory = TestUtils.CreateServiceScope(securityHandlerMock.Object)
                 }
             }
         };

--- a/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
@@ -58,7 +58,6 @@ public class ContainersControllerTests
         };
     }
 
-
     [Fact]
     public async Task CheckContainerInfo_ReturnsNotFound_WhenContainerDoesNotExist()
     {
@@ -79,7 +78,6 @@ public class ContainersControllerTests
         var container = new Mock<IWopiFolder>();
         container.Setup(c => c.Name).Returns("TestContainer");
         storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => container.Object);
-
 
         // Act
         var result = await _controller.CheckContainerInfo("existing");

--- a/test/WopiHost.Core.Tests/Extensions/WopiExtensionsTests.cs
+++ b/test/WopiHost.Core.Tests/Extensions/WopiExtensionsTests.cs
@@ -178,8 +178,8 @@ public class WopiExtensionsTests
         mockFile.Setup(f => f.Length).Returns(12345);
         var mockSecurityHandler = new Mock<IWopiSecurityHandler>();
         mockSecurityHandler
-            .Setup(_ => _.GetUserPermissions(It.IsAny<ClaimsPrincipal>(), It.IsAny<IWopiFile>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(WopiUserPermissions.None);
+            .Setup(_ => _.GetFilePermissions(It.IsAny<ClaimsPrincipal>(), It.IsAny<IWopiFile>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(WopiFilePermissions.None);
         var httpContext = new DefaultHttpContext()
         {
             ServiceScopeFactory = TestUtils.CreateServiceScope(mockSecurityHandler.Object),
@@ -326,7 +326,12 @@ public class WopiExtensionsTests
         // Arrange
         var mockFolder = new Mock<IWopiFolder>();
         mockFolder.Setup(f => f.Name).Returns("test");
-        var eventFired = false; var wopiHostOptions = Options.Create(new WopiHostOptions
+        var mockSecurityHandler = new Mock<IWopiSecurityHandler>();
+        mockSecurityHandler
+            .Setup(_ => _.GetContainerPermissions(It.IsAny<ClaimsPrincipal>(), It.IsAny<IWopiFolder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(WopiContainerPermissions.None);
+        var eventFired = false;
+        var wopiHostOptions = Options.Create(new WopiHostOptions
         {
             StorageProviderAssemblyName = "test",
             ClientUrl = new Uri("http://localhost:5000"),
@@ -334,7 +339,7 @@ public class WopiExtensionsTests
         });
         var httpContext = new DefaultHttpContext()
         {
-            ServiceScopeFactory = TestUtils.CreateServiceScope<IOptions<WopiHostOptions>>(wopiHostOptions),
+            ServiceScopeFactory = TestUtils.CreateServiceScope<IOptions<WopiHostOptions>, IWopiSecurityHandler>(wopiHostOptions, mockSecurityHandler.Object),
         };
 
         // Act
@@ -343,5 +348,156 @@ public class WopiExtensionsTests
         // Assert
         Assert.Equal("test", result.Name);
         Assert.True(eventFired);
+    }
+
+    [Fact]
+    public async Task GetWopiCheckContainerInfo_WithAllPermissions_ReturnsAllTrue()
+    {
+        // Arrange
+        var mockFolder = new Mock<IWopiFolder>();
+        mockFolder.Setup(f => f.Name).Returns("MyContainer");
+        var mockSecurityHandler = new Mock<IWopiSecurityHandler>();
+        mockSecurityHandler
+            .Setup(_ => _.GetContainerPermissions(It.IsAny<ClaimsPrincipal>(), It.IsAny<IWopiFolder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+                WopiContainerPermissions.UserCanCreateChildContainer |
+                WopiContainerPermissions.UserCanCreateChildFile |
+                WopiContainerPermissions.UserCanDelete |
+                WopiContainerPermissions.UserCanRename);
+        var httpContext = new DefaultHttpContext()
+        {
+            ServiceScopeFactory = TestUtils.CreateServiceScope(mockSecurityHandler.Object),
+        };
+
+        // Act
+        var result = await mockFolder.Object.GetWopiCheckContainerInfo(httpContext);
+
+        // Assert
+        Assert.Equal("MyContainer", result.Name);
+        Assert.True(result.UserCanCreateChildContainer);
+        Assert.True(result.UserCanCreateChildFile);
+        Assert.True(result.UserCanDelete);
+        Assert.True(result.UserCanRename);
+        Assert.False(result.IsEduUser);
+    }
+
+    [Fact]
+    public async Task GetWopiCheckContainerInfo_WithNoPermissions_ReturnsAllFalse()
+    {
+        // Arrange
+        var mockFolder = new Mock<IWopiFolder>();
+        mockFolder.Setup(f => f.Name).Returns("RestrictedContainer");
+        var mockSecurityHandler = new Mock<IWopiSecurityHandler>();
+        mockSecurityHandler
+            .Setup(_ => _.GetContainerPermissions(It.IsAny<ClaimsPrincipal>(), It.IsAny<IWopiFolder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(WopiContainerPermissions.None);
+        var httpContext = new DefaultHttpContext()
+        {
+            ServiceScopeFactory = TestUtils.CreateServiceScope(mockSecurityHandler.Object),
+        };
+
+        // Act
+        var result = await mockFolder.Object.GetWopiCheckContainerInfo(httpContext);
+
+        // Assert
+        Assert.Equal("RestrictedContainer", result.Name);
+        Assert.False(result.UserCanCreateChildContainer);
+        Assert.False(result.UserCanCreateChildFile);
+        Assert.False(result.UserCanDelete);
+        Assert.False(result.UserCanRename);
+    }
+
+    [Fact]
+    public async Task GetWopiCheckContainerInfo_WithPartialPermissions_ReturnsCorrectFlags()
+    {
+        // Arrange
+        var mockFolder = new Mock<IWopiFolder>();
+        mockFolder.Setup(f => f.Name).Returns("PartialContainer");
+        var mockSecurityHandler = new Mock<IWopiSecurityHandler>();
+        mockSecurityHandler
+            .Setup(_ => _.GetContainerPermissions(It.IsAny<ClaimsPrincipal>(), It.IsAny<IWopiFolder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(WopiContainerPermissions.UserCanCreateChildFile | WopiContainerPermissions.UserCanRename);
+        var httpContext = new DefaultHttpContext()
+        {
+            ServiceScopeFactory = TestUtils.CreateServiceScope(mockSecurityHandler.Object),
+        };
+
+        // Act
+        var result = await mockFolder.Object.GetWopiCheckContainerInfo(httpContext);
+
+        // Assert
+        Assert.False(result.UserCanCreateChildContainer);
+        Assert.True(result.UserCanCreateChildFile);
+        Assert.False(result.UserCanDelete);
+        Assert.True(result.UserCanRename);
+    }
+
+    [Fact]
+    public async Task GetWopiCheckFileInfo_WithAllPermissions_ReturnsAllTrue()
+    {
+        // Arrange
+        var mockFile = new Mock<IWopiFile>();
+        mockFile.Setup(f => f.Name).Returns("test");
+        mockFile.Setup(f => f.Owner).Returns("owner");
+        mockFile.Setup(f => f.Extension).Returns("txt");
+        mockFile.Setup(f => f.LastWriteTimeUtc).Returns(DateTime.UtcNow);
+        mockFile.Setup(f => f.Exists).Returns(true);
+        mockFile.Setup(f => f.Length).Returns(100);
+        var mockSecurityHandler = new Mock<IWopiSecurityHandler>();
+        mockSecurityHandler
+            .Setup(_ => _.GetFilePermissions(It.IsAny<ClaimsPrincipal>(), It.IsAny<IWopiFile>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+                WopiFilePermissions.ReadOnly |
+                WopiFilePermissions.RestrictedWebViewOnly |
+                WopiFilePermissions.UserCanAttend |
+                WopiFilePermissions.UserCanNotWriteRelative |
+                WopiFilePermissions.UserCanPresent |
+                WopiFilePermissions.UserCanRename |
+                WopiFilePermissions.UserCanWrite |
+                WopiFilePermissions.WebEditingDisabled);
+        var httpContext = new DefaultHttpContext()
+        {
+            ServiceScopeFactory = TestUtils.CreateServiceScope(mockSecurityHandler.Object),
+            User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                [
+                    new(ClaimTypes.NameIdentifier, "userId"),
+                    new(ClaimTypes.Name, "test")
+                ], "test auth scheme")),
+        };
+
+        // Act
+        var result = await mockFile.Object.GetWopiCheckFileInfo(httpContext);
+
+        // Assert
+        Assert.True(result.ReadOnly);
+        Assert.True(result.RestrictedWebViewOnly);
+        Assert.True(result.UserCanAttend);
+        Assert.True(result.UserCanNotWriteRelative);
+        Assert.True(result.UserCanPresent);
+        Assert.True(result.UserCanRename);
+        Assert.True(result.UserCanWrite);
+        Assert.True(result.WebEditingDisabled);
+    }
+
+    [Fact]
+    public async Task GetWopiCheckContainerInfo_ThrowsOnNullContainer()
+    {
+        // Arrange
+        IWopiFolder? container = null;
+        var httpContext = new DefaultHttpContext();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(() => container!.GetWopiCheckContainerInfo(httpContext));
+    }
+
+    [Fact]
+    public async Task GetWopiCheckContainerInfo_ThrowsOnNullHttpContext()
+    {
+        // Arrange
+        var mockFolder = new Mock<IWopiFolder>();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(() => mockFolder.Object.GetWopiCheckContainerInfo(null!));
     }
 }

--- a/test/WopiHost.Core.Tests/Security/Authorization/WopiAuthorizationHandlerTests.cs
+++ b/test/WopiHost.Core.Tests/Security/Authorization/WopiAuthorizationHandlerTests.cs
@@ -94,12 +94,11 @@ public class WopiAuthorizationHandlerTests
     }
 
     [Fact]
-    public async Task HandleRequirementAsync_ShouldAddPermissionsToHttpContextItems()
+    public async Task HandleRequirementAsync_ShouldNotAddExtraItemsToHttpContext()
     {
         // Arrange
         var httpContext = new DefaultHttpContext();
         httpContext.Request.RouteValues["id"] = "fileId";
-        _requirement.CheckPermissions = [Permission.Read, Permission.Update];
         var context = new AuthorizationHandlerContext([_requirement], new ClaimsPrincipal(), httpContext);
         _mockSecurityHandler
             .Setup(s => s.IsAuthorized(It.IsAny<ClaimsPrincipal>(), _requirement, It.IsAny<CancellationToken>()))
@@ -109,7 +108,6 @@ public class WopiAuthorizationHandlerTests
         await _handler.HandleAsync(context);
 
         // Assert
-        Assert.True(httpContext.Items.ContainsKey(Permission.Read));
-        Assert.True(httpContext.Items.ContainsKey(Permission.Update));
+        Assert.Empty(httpContext.Items);
     }
 }

--- a/test/WopiHost.Core.Tests/TestUtils.cs
+++ b/test/WopiHost.Core.Tests/TestUtils.cs
@@ -38,4 +38,25 @@ public static class TestUtils
 
         return serviceScopeFactory.Object;
     }
+
+    public static IServiceScopeFactory CreateServiceScope<T1, T2>(T1 instance1, T2 instance2)
+    {
+        var serviceProvider = new Mock<IServiceProvider>();
+        serviceProvider
+            .Setup(x => x.GetService(typeof(T1)))
+            .Returns(instance1);
+        serviceProvider
+            .Setup(x => x.GetService(typeof(T2)))
+            .Returns(instance2);
+
+        var serviceScope = new Mock<IServiceScope>();
+        serviceScope.Setup(x => x.ServiceProvider).Returns(serviceProvider.Object);
+
+        var serviceScopeFactory = new Mock<IServiceScopeFactory>();
+        serviceScopeFactory
+            .Setup(x => x.CreateScope())
+            .Returns(serviceScope.Object);
+
+        return serviceScopeFactory.Object;
+    }
 }

--- a/test/WopiHost.Core.Tests/TestUtils.cs
+++ b/test/WopiHost.Core.Tests/TestUtils.cs
@@ -20,7 +20,6 @@ public static class TestUtils
         return serviceScopeFactory.Object;
     }
 
-
     public static IServiceScopeFactory CreateServiceScope<T1>(T1 instance1)
     {
         var serviceProvider = new Mock<IServiceProvider>();

--- a/test/WopiHost.FileSystemProvider.Tests/WopiHost.FileSystemProvider.Tests.csproj
+++ b/test/WopiHost.FileSystemProvider.Tests/WopiHost.FileSystemProvider.Tests.csproj
@@ -6,6 +6,9 @@
 		<ProjectReference Include="..\..\src\WopiHost.FileSystemProvider\WopiHost.FileSystemProvider.csproj" />
 	</ItemGroup>
 	<ItemGroup>
+		<PackageReference Include="Moq" />
+	</ItemGroup>
+	<ItemGroup>
 	  <PackageReference Update="coverlet.collector">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/WopiHost.FileSystemProvider.Tests/WopiSecurityHandlerTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/WopiSecurityHandlerTests.cs
@@ -1,7 +1,121 @@
-﻿namespace WopiHost.FileSystemProvider.Tests;
+using System.Security.Claims;
+using Microsoft.Extensions.Logging;
+using Moq;
+using WopiHost.Abstractions;
+
+namespace WopiHost.FileSystemProvider.Tests;
 
 public class WopiSecurityHandlerTests
 {
+    private readonly WopiSecurityHandler _handler;
+
+    public WopiSecurityHandlerTests()
+    {
+        var loggerFactory = new Mock<ILoggerFactory>();
+        loggerFactory
+            .Setup(x => x.CreateLogger(It.IsAny<string>()))
+            .Returns(new Mock<ILogger>().Object);
+        _handler = new WopiSecurityHandler(loggerFactory.Object);
+    }
+
     [Fact]
-    public void DummyTest() => Assert.True(true);
+    public async Task GetFilePermissions_ReturnsExpectedPermissions()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity([new(ClaimTypes.NameIdentifier, "user1")], "test"));
+        var file = new Mock<IWopiFile>();
+
+        // Act
+        var result = await _handler.GetFilePermissions(principal, file.Object);
+
+        // Assert
+        Assert.True(result.HasFlag(WopiFilePermissions.UserCanWrite));
+        Assert.True(result.HasFlag(WopiFilePermissions.UserCanRename));
+        Assert.True(result.HasFlag(WopiFilePermissions.UserCanAttend));
+        Assert.True(result.HasFlag(WopiFilePermissions.UserCanPresent));
+        Assert.False(result.HasFlag(WopiFilePermissions.ReadOnly));
+        Assert.False(result.HasFlag(WopiFilePermissions.WebEditingDisabled));
+    }
+
+    [Fact]
+    public async Task GetContainerPermissions_ReturnsExpectedPermissions()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity([new(ClaimTypes.NameIdentifier, "user1")], "test"));
+        var container = new Mock<IWopiFolder>();
+
+        // Act
+        var result = await _handler.GetContainerPermissions(principal, container.Object);
+
+        // Assert
+        Assert.True(result.HasFlag(WopiContainerPermissions.UserCanCreateChildContainer));
+        Assert.True(result.HasFlag(WopiContainerPermissions.UserCanCreateChildFile));
+        Assert.True(result.HasFlag(WopiContainerPermissions.UserCanDelete));
+        Assert.True(result.HasFlag(WopiContainerPermissions.UserCanRename));
+    }
+
+    [Fact]
+    public async Task IsAuthorized_ReturnsTrue_WhenUserIsAuthenticated()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity([new(ClaimTypes.NameIdentifier, "user1")], "test"));
+        var requirement = new Mock<IWopiAuthorizationRequirement>();
+
+        // Act
+        var result = await _handler.IsAuthorized(principal, requirement.Object);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task IsAuthorized_ReturnsFalse_WhenUserIsNotAuthenticated()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+        var requirement = new Mock<IWopiAuthorizationRequirement>();
+
+        // Act
+        var result = await _handler.IsAuthorized(principal, requirement.Object);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task GenerateAccessToken_ReturnsValidToken()
+    {
+        // Act
+        var token = await _handler.GenerateAccessToken("Anonymous", "resource1");
+
+        // Assert
+        Assert.NotNull(token);
+        var tokenString = _handler.WriteToken(token);
+        Assert.False(string.IsNullOrEmpty(tokenString));
+    }
+
+    [Fact]
+    public async Task GetPrincipal_ReturnsNull_ForInvalidToken()
+    {
+        // Act
+        var result = await _handler.GetPrincipal("invalid-token");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetPrincipal_ReturnsPrincipal_ForValidToken()
+    {
+        // Arrange
+        var token = await _handler.GenerateAccessToken("Anonymous", "resource1");
+        var tokenString = _handler.WriteToken(token);
+
+        // Act
+        var result = await _handler.GetPrincipal(tokenString);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.Identity?.IsAuthenticated);
+    }
 }


### PR DESCRIPTION
## Summary
- Renames `WopiUserPermissions` → `WopiFilePermissions` and `GetUserPermissions()` → `GetFilePermissions()` on `IWopiSecurityHandler`
- Introduces `WopiContainerPermissions` flags enum with a new `GetContainerPermissions()` method on `IWopiSecurityHandler`
- Removes the `CheckPermissions` / `IsPermitted` `HttpContext.Items` hack — `CheckContainerInfo` now uses `GetContainerPermissions()` directly, symmetric to how `CheckFileInfo` uses `GetFilePermissions()`
- Cleans up `WopiAuthorizeAttribute` (removed `CheckPermissions` property) and `WopiAuthorizationHandler` (removed the additional permissions loop)

## Breaking changes
- `WopiUserPermissions` renamed to `WopiFilePermissions`
- `IWopiSecurityHandler.GetUserPermissions()` renamed to `GetFilePermissions()`
- `IWopiSecurityHandler.GetContainerPermissions()` added (new interface method — implementors must add it)
- `WopiAuthorizeAttribute.CheckPermissions` removed
- `HttpContext.IsPermitted()` extension removed

## Test plan
- [x] All existing tests updated to use the new types/method names
- [x] New tests for `GetWopiCheckContainerInfo` with all/no/partial container permissions
- [x] New tests for `GetWopiCheckFileInfo` with all file permissions enabled
- [x] New null-guard tests for `GetWopiCheckContainerInfo`
- [x] Real tests for `WopiSecurityHandler` in FileSystemProvider (replacing dummy test) — covers `GetFilePermissions`, `GetContainerPermissions`, `IsAuthorized`, `GenerateAccessToken`, `GetPrincipal`
- [x] All 163 Core tests + 11 FileSystemProvider tests pass across net8.0/net9.0/net10.0

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)