### PR TITLE
fix: track co-authoring sessions to prevent duplicate user names

### DIFF
--- a/sample/WopiHost/ServiceCollectionExtensions.cs
+++ b/sample/WopiHost/ServiceCollectionExtensions.cs
@@ -43,12 +43,6 @@ public static class ServiceCollectionExtensions
             throw new InvalidProgramException($"Cobalt Assembly {assemblyPath} not found.");
         }
         var cobaltAssembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
-
-        // Register CoauthoringSessionTracker as singleton for shared state across Cobalt requests
-        var trackerType = cobaltAssembly.GetType("WopiHost.Cobalt.CoauthoringSessionTracker")
-            ?? throw new InvalidProgramException("CoauthoringSessionTracker type not found in Cobalt assembly.");
-        services.AddSingleton(trackerType);
-
         services
             .Scan(scan => scan.FromAssemblies(cobaltAssembly)
             .AddClasses(classes => classes

--- a/sample/WopiHost/ServiceCollectionExtensions.cs
+++ b/sample/WopiHost/ServiceCollectionExtensions.cs
@@ -43,6 +43,12 @@ public static class ServiceCollectionExtensions
             throw new InvalidProgramException($"Cobalt Assembly {assemblyPath} not found.");
         }
         var cobaltAssembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
+
+        // Register CoauthoringSessionTracker as singleton for shared state across Cobalt requests
+        var trackerType = cobaltAssembly.GetType("WopiHost.Cobalt.CoauthoringSessionTracker")
+            ?? throw new InvalidProgramException("CoauthoringSessionTracker type not found in Cobalt assembly.");
+        services.AddSingleton(trackerType);
+
         services
             .Scan(scan => scan.FromAssemblies(cobaltAssembly)
             .AddClasses(classes => classes

--- a/src/WopiHost.Cobalt/CoauthoringSessionTracker.cs
+++ b/src/WopiHost.Cobalt/CoauthoringSessionTracker.cs
@@ -1,0 +1,124 @@
+using System.Collections.Concurrent;
+using Cobalt;
+
+namespace WopiHost.Cobalt;
+
+/// <summary>
+/// Tracks active co-authoring sessions per file to provide accurate editor counts
+/// and co-authoring status to OOS/OWA via the Cobalt protocol.
+/// </summary>
+/// <remarks>
+/// Fixes https://github.com/petrsvihlik/WopiHost/issues/139 — without shared session tracking,
+/// each Cobalt request creates a fresh <see cref="CobaltHostLockingStore"/> that always reports
+/// <see cref="CoauthStatusType.Alone"/> and an empty editors table, causing older OOS versions
+/// to show duplicate user names when the same person opens a document in multiple tabs.
+/// </remarks>
+public class CoauthoringSessionTracker
+{
+    /// <summary>
+    /// Represents a single editing session (one browser tab / WOPI session).
+    /// </summary>
+    /// <param name="UserId">The authenticated user's identifier.</param>
+    /// <param name="UserName">The user's display name.</param>
+    /// <param name="LastActivity">When this session was last refreshed.</param>
+    public record EditorSession(string UserId, string UserName, DateTimeOffset LastActivity);
+
+    private static readonly TimeSpan SessionTimeout = TimeSpan.FromMinutes(30);
+
+    // fileId → (userId → session)
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, EditorSession>> _sessions = new();
+
+    /// <summary>
+    /// Registers or refreshes a user's editing session for the given file.
+    /// Multiple tabs from the same user are deduplicated by user ID.
+    /// </summary>
+    public void AddOrRefreshSession(string fileId, string userId, string userName)
+    {
+        var fileSessions = _sessions.GetOrAdd(fileId, _ => new ConcurrentDictionary<string, EditorSession>());
+        fileSessions[userId] = new EditorSession(userId, userName, DateTimeOffset.UtcNow);
+    }
+
+    /// <summary>
+    /// Removes a user's editing session for the given file.
+    /// </summary>
+    public void RemoveSession(string fileId, string userId)
+    {
+        if (_sessions.TryGetValue(fileId, out var fileSessions))
+        {
+            fileSessions.TryRemove(userId, out _);
+            // Clean up empty file entries
+            if (fileSessions.IsEmpty)
+            {
+                _sessions.TryRemove(fileId, out _);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns the number of distinct active editors for a file.
+    /// </summary>
+    public int GetActiveEditorCount(string fileId)
+    {
+        if (!_sessions.TryGetValue(fileId, out var fileSessions))
+        {
+            return 0;
+        }
+
+        var cutoff = DateTimeOffset.UtcNow - SessionTimeout;
+        return fileSessions.Values.Count(s => s.LastActivity > cutoff);
+    }
+
+    /// <summary>
+    /// Returns whether the given user is the only active editor for the file.
+    /// </summary>
+    public bool IsAlone(string fileId, string userId)
+    {
+        if (!_sessions.TryGetValue(fileId, out var fileSessions))
+        {
+            return true;
+        }
+
+        var cutoff = DateTimeOffset.UtcNow - SessionTimeout;
+        var activeEditors = fileSessions.Values
+            .Where(s => s.LastActivity > cutoff)
+            .ToList();
+
+        return activeEditors.Count == 0 || activeEditors.All(s => s.UserId == userId);
+    }
+
+    /// <summary>
+    /// Returns the editors table for the Cobalt protocol.
+    /// </summary>
+    public Dictionary<string, EditorsTableEntry> GetEditorsTable(string fileId)
+    {
+        var result = new Dictionary<string, EditorsTableEntry>();
+        if (!_sessions.TryGetValue(fileId, out var fileSessions))
+        {
+            return result;
+        }
+
+        var cutoff = DateTimeOffset.UtcNow - SessionTimeout;
+        foreach (var session in fileSessions.Values.Where(s => s.LastActivity > cutoff))
+        {
+            result[session.UserId] = new EditorsTableEntry
+            {
+                HasEditPermission = true,
+                UserName = session.UserName,
+                UserLogin = session.UserId
+            };
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Returns the appropriate co-authoring status for a file.
+    /// </summary>
+    public CoauthStatusType GetCoauthStatus(string fileId, string userId)
+    {
+        var editorCount = GetActiveEditorCount(fileId);
+        return editorCount <= 1 && IsAlone(fileId, userId)
+            ? CoauthStatusType.Alone
+            : CoauthStatusType.Coauthoring;
+    }
+}

--- a/src/WopiHost.Cobalt/CoauthoringSessionTracker.cs
+++ b/src/WopiHost.Cobalt/CoauthoringSessionTracker.cs
@@ -25,8 +25,8 @@ public class CoauthoringSessionTracker
 
     private static readonly TimeSpan SessionTimeout = TimeSpan.FromMinutes(30);
 
-    // fileId → (userId → session)
-    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, EditorSession>> _sessions = new();
+    // fileId → (userId → session) — static so state is shared across all CobaltHostLockingStore instances
+    private static readonly ConcurrentDictionary<string, ConcurrentDictionary<string, EditorSession>> Sessions = new();
 
     /// <summary>
     /// Registers or refreshes a user's editing session for the given file.
@@ -34,7 +34,7 @@ public class CoauthoringSessionTracker
     /// </summary>
     public void AddOrRefreshSession(string fileId, string userId, string userName)
     {
-        var fileSessions = _sessions.GetOrAdd(fileId, _ => new ConcurrentDictionary<string, EditorSession>());
+        var fileSessions = Sessions.GetOrAdd(fileId, _ => new ConcurrentDictionary<string, EditorSession>());
         fileSessions[userId] = new EditorSession(userId, userName, DateTimeOffset.UtcNow);
     }
 
@@ -43,13 +43,13 @@ public class CoauthoringSessionTracker
     /// </summary>
     public void RemoveSession(string fileId, string userId)
     {
-        if (_sessions.TryGetValue(fileId, out var fileSessions))
+        if (Sessions.TryGetValue(fileId, out var fileSessions))
         {
             fileSessions.TryRemove(userId, out _);
             // Clean up empty file entries
             if (fileSessions.IsEmpty)
             {
-                _sessions.TryRemove(fileId, out _);
+                Sessions.TryRemove(fileId, out _);
             }
         }
     }
@@ -59,7 +59,7 @@ public class CoauthoringSessionTracker
     /// </summary>
     public int GetActiveEditorCount(string fileId)
     {
-        if (!_sessions.TryGetValue(fileId, out var fileSessions))
+        if (!Sessions.TryGetValue(fileId, out var fileSessions))
         {
             return 0;
         }
@@ -73,7 +73,7 @@ public class CoauthoringSessionTracker
     /// </summary>
     public bool IsAlone(string fileId, string userId)
     {
-        if (!_sessions.TryGetValue(fileId, out var fileSessions))
+        if (!Sessions.TryGetValue(fileId, out var fileSessions))
         {
             return true;
         }
@@ -92,7 +92,7 @@ public class CoauthoringSessionTracker
     public Dictionary<string, EditorsTableEntry> GetEditorsTable(string fileId)
     {
         var result = new Dictionary<string, EditorsTableEntry>();
-        if (!_sessions.TryGetValue(fileId, out var fileSessions))
+        if (!Sessions.TryGetValue(fileId, out var fileSessions))
         {
             return result;
         }

--- a/src/WopiHost.Cobalt/CobaltHostLockingStore.cs
+++ b/src/WopiHost.Cobalt/CobaltHostLockingStore.cs
@@ -3,9 +3,17 @@ using Cobalt;
 
 namespace WopiHost.Cobalt;
 
-public class CobaltHostLockingStore(ClaimsPrincipal principal) : HostLockingStore
+public class CobaltHostLockingStore(
+    ClaimsPrincipal principal,
+    string fileId,
+    CoauthoringSessionTracker sessionTracker) : HostLockingStore
 {
     private readonly ClaimsPrincipal _principal = principal;
+    private readonly string _fileId = fileId;
+    private readonly CoauthoringSessionTracker _sessionTracker = sessionTracker;
+
+    private string UserId => _principal?.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? string.Empty;
+    private string UserName => _principal?.FindFirst(ClaimTypes.Name)?.Value ?? string.Empty;
 
     public override WhoAmIRequest.OutputType HandleWhoAmI(WhoAmIRequest.InputType input)
     {
@@ -117,10 +125,11 @@ public class CobaltHostLockingStore(ClaimsPrincipal principal) : HostLockingStor
 
     public override JoinCoauthoringRequest.OutputType HandleJoinCoauthoring(JoinCoauthoringRequest.InputType input, int protocolMajorVersion, int protocolMinorVersion)
     {
+        _sessionTracker.AddOrRefreshSession(_fileId, UserId, UserName);
         var result = new JoinCoauthoringRequest.OutputType
         {
             Lock = LockType.SchemaLock,
-            CoauthStatus = CoauthStatusType.Alone,
+            CoauthStatus = _sessionTracker.GetCoauthStatus(_fileId, UserId),
             TransitionId = Guid.NewGuid()
         };
         return result;
@@ -128,6 +137,7 @@ public class CobaltHostLockingStore(ClaimsPrincipal principal) : HostLockingStor
 
     public override ExitCoauthoringRequest.OutputType HandleExitCoauthoring(ExitCoauthoringRequest.InputType input, int protocolMajorVersion, int protocolMinorVersion)
     {
+        _sessionTracker.RemoveSession(_fileId, UserId);
         var result = new ExitCoauthoringRequest.OutputType();
 
         return result;
@@ -135,10 +145,11 @@ public class CobaltHostLockingStore(ClaimsPrincipal principal) : HostLockingStor
 
     public override RefreshCoauthoringSessionRequest.OutputType HandleRefreshCoauthoring(RefreshCoauthoringSessionRequest.InputType input, int protocolMajorVersion, int protocolMinorVersion)
     {
+        _sessionTracker.AddOrRefreshSession(_fileId, UserId, UserName);
         var result = new RefreshCoauthoringSessionRequest.OutputType
         {
             Lock = LockType.SchemaLock,
-            CoauthStatus = CoauthStatusType.Alone
+            CoauthStatus = _sessionTracker.GetCoauthStatus(_fileId, UserId)
         };
 
         return result;
@@ -169,16 +180,18 @@ public class CobaltHostLockingStore(ClaimsPrincipal principal) : HostLockingStor
     {
         var result = new GetCoauthoringStatusRequest.OutputType
         {
-            CoauthStatus = CoauthStatusType.Alone
+            CoauthStatus = _sessionTracker.GetCoauthStatus(_fileId, UserId)
         };
 
         return result;
     }
 
-    public override Dictionary<string, EditorsTableEntry> QueryEditorsTable() => [];
+    public override Dictionary<string, EditorsTableEntry> QueryEditorsTable() =>
+        _sessionTracker.GetEditorsTable(_fileId);
 
     public override JoinEditingSessionRequest.OutputType HandleJoinEditingSession(JoinEditingSessionRequest.InputType input)
     {
+        _sessionTracker.AddOrRefreshSession(_fileId, UserId, UserName);
         var result = new JoinEditingSessionRequest.OutputType();
 
         return result;
@@ -186,6 +199,7 @@ public class CobaltHostLockingStore(ClaimsPrincipal principal) : HostLockingStor
 
     public override RefreshEditingSessionRequest.OutputType HandleRefreshEditingSession(RefreshEditingSessionRequest.InputType input)
     {
+        _sessionTracker.AddOrRefreshSession(_fileId, UserId, UserName);
         var result = new RefreshEditingSessionRequest.OutputType();
 
         return result;
@@ -193,6 +207,7 @@ public class CobaltHostLockingStore(ClaimsPrincipal principal) : HostLockingStor
 
     public override LeaveEditingSessionRequest.OutputType HandleLeaveEditingSession(LeaveEditingSessionRequest.InputType input)
     {
+        _sessionTracker.RemoveSession(_fileId, UserId);
         var result = new LeaveEditingSessionRequest.OutputType();
 
         return result;
@@ -216,7 +231,7 @@ public class CobaltHostLockingStore(ClaimsPrincipal principal) : HostLockingStor
 
     public override AmIAloneRequest.OutputType HandleAmIAlone(AmIAloneRequest.InputType input)
     {
-        var result = new AmIAloneRequest.OutputType { AmIAlone = true };
+        var result = new AmIAloneRequest.OutputType { AmIAlone = _sessionTracker.IsAlone(_fileId, UserId) };
 
         return result;
     }

--- a/src/WopiHost.Cobalt/CobaltSession.cs
+++ b/src/WopiHost.Cobalt/CobaltSession.cs
@@ -4,8 +4,9 @@ using WopiHost.Abstractions;
 
 namespace WopiHost.Cobalt;
 
-public class CobaltProcessor(CoauthoringSessionTracker sessionTracker) : ICobaltProcessor
+public class CobaltProcessor : ICobaltProcessor
 {
+    private readonly CoauthoringSessionTracker _sessionTracker = new();
     private async Task<CobaltFile> GetCobaltFile(IWopiFile file, ClaimsPrincipal principal)
     {
         var disposal = new DisposalEscrow(file.Owner);
@@ -41,7 +42,7 @@ public class CobaltProcessor(CoauthoringSessionTracker sessionTracker) : ICobalt
 
         var partitionConfigs = new Dictionary<FilePartitionId, CobaltFilePartitionConfig> { { FilePartitionId.Content, content }, { FilePartitionId.WordWacUpdate, wacupdate }, { FilePartitionId.CoauthMetadata, coauth } };
 
-        var tempCobaltFile = new CobaltFile(disposal, partitionConfigs, new CobaltHostLockingStore(principal, file.Identifier, sessionTracker), null);
+        var tempCobaltFile = new CobaltFile(disposal, partitionConfigs, new CobaltHostLockingStore(principal, file.Identifier, _sessionTracker), null);
 
         if (file.Exists)
         {

--- a/src/WopiHost.Cobalt/CobaltSession.cs
+++ b/src/WopiHost.Cobalt/CobaltSession.cs
@@ -4,7 +4,7 @@ using WopiHost.Abstractions;
 
 namespace WopiHost.Cobalt;
 
-public class CobaltProcessor : ICobaltProcessor
+public class CobaltProcessor(CoauthoringSessionTracker sessionTracker) : ICobaltProcessor
 {
     private async Task<CobaltFile> GetCobaltFile(IWopiFile file, ClaimsPrincipal principal)
     {
@@ -41,7 +41,7 @@ public class CobaltProcessor : ICobaltProcessor
 
         var partitionConfigs = new Dictionary<FilePartitionId, CobaltFilePartitionConfig> { { FilePartitionId.Content, content }, { FilePartitionId.WordWacUpdate, wacupdate }, { FilePartitionId.CoauthMetadata, coauth } };
 
-        var tempCobaltFile = new CobaltFile(disposal, partitionConfigs, new CobaltHostLockingStore(principal), null);
+        var tempCobaltFile = new CobaltFile(disposal, partitionConfigs, new CobaltHostLockingStore(principal, file.Identifier, sessionTracker), null);
 
         if (file.Exists)
         {


### PR DESCRIPTION
## Summary

Fixes #139

- Introduces `CoauthoringSessionTracker` — a shared singleton that tracks active editing sessions per file, deduplicating by user ID with a 30-minute expiry
- Updates `CobaltHostLockingStore` to use the tracker instead of hardcoding `CoauthStatusType.Alone` and returning an empty editors table
- Passes file ID and the tracker through `CobaltProcessor` → `CobaltHostLockingStore` so session state is shared across all Cobalt requests

Previously, each Cobalt request created a new `CobaltHostLockingStore` with no shared state, always reporting the user as "Alone" with an empty editors table. Older OOS versions (e.g. 16.0.10338.20039) treated each tab's session as a distinct editor, showing the same user name multiple times.

Now, `HandleJoinCoauthoring`, `HandleRefreshCoauthoring`, `QueryEditorsTable`, `HandleAmIAlone`, and related methods reflect accurate session state.

## Test plan

- [x] Solution builds across all target frameworks (net8.0, net9.0, net10.0)
- [x] All 157 existing tests pass
- [ ] Manual: open same document in multiple tabs with the same user — verify OOS shows the user name only once
- [ ] Manual: open same document with two different users — verify both names appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)