### PR TITLE
fix: remove AllowSynchronousIO workaround in Cobalt endpoint

### DIFF
--- a/src/WopiHost.Abstractions/ICobaltProcessor.cs
+++ b/src/WopiHost.Abstractions/ICobaltProcessor.cs
@@ -14,5 +14,5 @@ public interface ICobaltProcessor
     /// <param name="principal">User editing the file</param>
     /// <param name="newContent">Partitions with new content (diffs)</param>
     /// <returns>An octet stream.</returns>
-    Task<Action<Stream>> ProcessCobalt(IWopiFile file, ClaimsPrincipal principal, byte[] newContent);
+    Task<byte[]> ProcessCobalt(IWopiFile file, ClaimsPrincipal principal, byte[] newContent);
 }

--- a/src/WopiHost.Cobalt/CobaltSession.cs
+++ b/src/WopiHost.Cobalt/CobaltSession.cs
@@ -64,7 +64,7 @@ public class CobaltProcessor : ICobaltProcessor
     //}
 
     /// <inheritdoc/>
-    public async Task<Action<Stream>> ProcessCobalt(IWopiFile file, ClaimsPrincipal principal, byte[] newContent)
+    public async Task<byte[]> ProcessCobalt(IWopiFile file, ClaimsPrincipal principal, byte[] newContent)
     {
         // Refactoring tip: there are more ways of initializing Atom
         var atomRequest = new AtomFromByteArray(newContent);
@@ -79,6 +79,9 @@ public class CobaltProcessor : ICobaltProcessor
             using var stream = await file.GetWriteStream();
             new GenericFda(cobaltFile.CobaltEndpoint).GetContentStream().CopyTo(stream);
         }
-        return requestBatch.SerializeOutputToProtocol(protocolVersion).CopyTo;
+
+        using var ms = new MemoryStream();
+        requestBatch.SerializeOutputToProtocol(protocolVersion).CopyTo(ms);
+        return ms.ToArray();
     }
 }

--- a/src/WopiHost.Core/Controllers/FilesController.cs
+++ b/src/WopiHost.Core/Controllers/FilesController.cs
@@ -557,20 +557,13 @@ public class FilesController(
         var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken)
             ?? throw new InvalidOperationException("File not found");
 
-        // TODO: remove workaround https://github.com/aspnet/Announcements/issues/342 (use FileBufferingWriteStream)
-        var syncIoFeature = HttpContext.Features.Get<IHttpBodyControlFeature>();
-        if (syncIoFeature is not null)
-        {
-            syncIoFeature.AllowSynchronousIO = true;
-        }
-
-        var responseAction = await cobaltProcessor.ProcessCobalt(file, User, await HttpContext.Request.Body.ReadBytesAsync());
+        var responseBytes = await cobaltProcessor.ProcessCobalt(file, User, await HttpContext.Request.Body.ReadBytesAsync());
         if (!string.IsNullOrEmpty(correlationId))
         {
             HttpContext.Response.Headers.Append(WopiHeaders.CORRELATION_ID, correlationId);
             HttpContext.Response.Headers.Append("request-id", correlationId);
         }
-        return new Results.FileResult(responseAction, MediaTypeNames.Application.Octet);
+        return new Results.FileResult(responseBytes, MediaTypeNames.Application.Octet);
     }
 
     #region "Locking"

--- a/src/WopiHost.Core/Results/FileResult.cs
+++ b/src/WopiHost.Core/Results/FileResult.cs
@@ -8,11 +8,6 @@ namespace WopiHost.Core.Results;
 public class FileResult : ActionResult
 {
     /// <summary>
-    /// An action that returns a stream with data to be written to the response body.
-    /// </summary>
-    private Action<Stream>? CopyStream { get; }
-
-    /// <summary>
     /// Byte array with the content to be written to the response body.
     /// </summary>
     private byte[]? Content { get; set; }
@@ -52,30 +47,13 @@ public class FileResult : ActionResult
         Content = content;
     }
 
-    /// <summary>
-    /// Creates a new instance of <see cref="FileResult"/> that initializes the response body with a stream retrieved from the delegate.
-    /// </summary>
-    /// <param name="copyStream">An action that returns a stream with data to be written to the response body.</param>
-    /// <param name="contentType">Response content type header value.</param>
-    public FileResult(Action<Stream> copyStream, string contentType) : this(contentType)
-    {
-        CopyStream = copyStream;
-    }
-
     /// <inheritdoc/>
     public override async Task ExecuteResultAsync(ActionContext context)
     {
         var response = context.HttpContext.Response;
         response.ContentType = ContentType;
         var targetStream = response.Body;
-        if (CopyStream is not null)
-        {
-            await Task.Factory.StartNew(() =>
-            {
-                CopyStream(targetStream);
-            });
-        }
-        else if (Content is not null)
+        if (Content is not null)
         {
             await targetStream.WriteAsync(Content.AsMemory(0, Content.Length));
         }

--- a/test/WopiHost.Core.Tests/Results/FileResultTests.cs
+++ b/test/WopiHost.Core.Tests/Results/FileResultTests.cs
@@ -1,0 +1,93 @@
+using System.Net.Mime;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using FileResult = WopiHost.Core.Results.FileResult;
+
+namespace WopiHost.Core.Tests.Results;
+
+public class FileResultTests
+{
+    private static ActionContext CreateActionContext()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Response.Body = new MemoryStream();
+        return new ActionContext(httpContext, new RouteData(), new Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor());
+    }
+
+    private static async Task<byte[]> GetResponseBytes(ActionContext context)
+    {
+        context.HttpContext.Response.Body.Seek(0, SeekOrigin.Begin);
+        using var ms = new MemoryStream();
+        await context.HttpContext.Response.Body.CopyToAsync(ms);
+        return ms.ToArray();
+    }
+
+    [Fact]
+    public async Task ExecuteResultAsync_WithByteArray_WritesContentToResponseBody()
+    {
+        // Arrange
+        var expected = "hello cobalt"u8.ToArray();
+        var result = new FileResult(expected, MediaTypeNames.Application.Octet);
+        var context = CreateActionContext();
+
+        // Act
+        await result.ExecuteResultAsync(context);
+
+        // Assert
+        var actual = await GetResponseBytes(context);
+        Assert.Equal(expected, actual);
+        Assert.Equal(MediaTypeNames.Application.Octet, context.HttpContext.Response.ContentType);
+    }
+
+    [Fact]
+    public async Task ExecuteResultAsync_WithStream_WritesContentToResponseBody()
+    {
+        // Arrange
+        var expected = "stream content"u8.ToArray();
+        var sourceStream = new MemoryStream(expected);
+        var result = new FileResult(sourceStream, MediaTypeNames.Application.Octet);
+        var context = CreateActionContext();
+
+        // Act
+        await result.ExecuteResultAsync(context);
+
+        // Assert
+        var actual = await GetResponseBytes(context);
+        Assert.Equal(expected, actual);
+        Assert.Equal(MediaTypeNames.Application.Octet, context.HttpContext.Response.ContentType);
+    }
+
+    [Fact]
+    public async Task ExecuteResultAsync_WithSeekableStream_ResetsPositionBeforeCopying()
+    {
+        // Arrange
+        var expected = "seekable"u8.ToArray();
+        var sourceStream = new MemoryStream(expected);
+        sourceStream.Seek(sourceStream.Length, SeekOrigin.Begin); // move past content
+        var result = new FileResult(sourceStream, MediaTypeNames.Application.Octet);
+        var context = CreateActionContext();
+
+        // Act
+        await result.ExecuteResultAsync(context);
+
+        // Assert
+        var actual = await GetResponseBytes(context);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public async Task ExecuteResultAsync_WithEmptyByteArray_WritesEmptyResponse()
+    {
+        // Arrange
+        var result = new FileResult([], MediaTypeNames.Application.Octet);
+        var context = CreateActionContext();
+
+        // Act
+        await result.ExecuteResultAsync(context);
+
+        // Assert
+        var actual = await GetResponseBytes(context);
+        Assert.Empty(actual);
+    }
+}


### PR DESCRIPTION
## Summary
- Buffers Cobalt serialization output to a `byte[]` instead of passing a synchronous `Action<Stream>` delegate to the response body
- Removes the per-request `AllowSynchronousIO = true` workaround ([aspnet/Announcements#342](https://github.com/aspnet/Announcements/issues/342))
- Removes the unused `Action<Stream>` constructor and `Task.Factory.StartNew` wrapper from `FileResult`

## Test plan
- [x] Solution builds with 0 warnings, 0 errors
- [x] All 522 tests pass across net8.0, net9.0, and net10.0
- [ ] Verify Cobalt (MS-FSSHTTP) co-authoring flow with Office Online produces identical responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)