### PR TITLE
ci: enable Dependabot for NuGet and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 20
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "chore(ci)"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to open daily dependency-update PRs.
- Covers two ecosystems: `nuget` (resolves `Directory.Packages.props` automatically) and `github-actions` (pinned action versions in workflows).
- `open-pull-requests-limit: 20` on the NuGet stream so a backlog day doesn't silently drop updates.
- Security advisories fire out-of-band regardless of schedule/limit.

Expect a large initial wave of PRs once this lands; the steady state is a trickle. Grouping can be added later if the noise becomes a problem.

## Test plan
- [ ] Merge to `master`
- [ ] Within ~24h, confirm Dependabot opens its first batch of PRs
- [ ] Confirm `Directory.Packages.props` is being updated (not individual `.csproj` files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)