### PR TITLE
ci: auto-merge Dependabot PRs once checks pass

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 20
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,20 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Follow-up to #261. Adds a workflow that enables GitHub's native auto-merge on every Dependabot-authored PR, so they merge as soon as required status checks go green.

- Triggers on `pull_request_target` (`opened`/`reopened`) and filters to `dependabot[bot]`.
- Uses `gh pr merge --auto --squash` — the `--auto` flag makes the merge wait for required checks; failing CI blocks the merge.
- Includes `major` version bumps per request — relies on CI to catch breakage.

## Prerequisites (one-time, in repo Settings)
- [x] **Settings → General → Pull Requests → Allow auto-merge** must be enabled.
- [x] **Settings → Branches → master → Require status checks to pass before merging** should list at least the `build` job from `pull_request.yml`. Without this, auto-merge fires immediately without waiting for CI.

## Test plan
- [ ] Merge this PR
- [ ] Trigger Dependabot manually (Insights → Dependency graph → Dependabot → Check for updates)
- [ ] Confirm the next Dependabot PR shows "Auto-merge enabled" and merges itself once CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)