### PR TITLE
ci: switch validator default category from WopiCore to All

### DIFF
--- a/.github/workflows/wopi-validator.yml
+++ b/.github/workflows/wopi-validator.yml
@@ -26,7 +26,7 @@ on:
       test_category:
         description: 'Validator --testcategory (All, WopiCore, OfficeOnline, OfficeOnlinePlus, OfficeNativeClient)'
         required: false
-        default: 'WopiCore'
+        default: 'All'
 
 permissions:
   contents: read
@@ -35,7 +35,7 @@ permissions:
 env:
   VALIDATOR_REPO: microsoft/wopi-validator-core
   VALIDATOR_REF: ${{ inputs.validator_ref || 'main' }}
-  TEST_CATEGORY: ${{ inputs.test_category || 'WopiCore' }}
+  TEST_CATEGORY: ${{ inputs.test_category || 'All' }}
   HOST_URL: http://localhost:5000
   WOPI_FILE_ID: WOPITEST
   WOPI_ACCESS_TOKEN: Anonymous


### PR DESCRIPTION
## Summary
The current `wopi-validator.yml` defaults to `--testcategory WopiCore`, which **crashes the validator at parse time** with:

```
System.ArgumentException: Could not find a prereq test case named {0} (Parameter 'SupportsCoauthPrereq')
```

Because the crash produces zero `Pass:` / `Fail:` / `Skipped:` lines, the workflow's log-parsing exit-code logic computes `exit_code=0` and the run reports green even though no tests actually ran. The failure was only visible inside the `wopi-validator-output` artifact log.

## Root cause
In `microsoft/wopi-validator-core`'s `TestCases.xml`:
- `<TestCase Name="SupportsCoauthPrereq" Category="WopiCoauth">` — prereq is in `WopiCoauth` category
- `<TestGroup Name="CoauthLocks">` — references `SupportsCoauthPrereq` as a prereq, but the group itself has **no `Category` attribute**

When `--testcategory WopiCore` filters `WopiCoauth` prereqs out of the dictionary, the untagged `CoauthLocks` group still gets parsed and asks for the now-missing prereq → `ArgumentException`.

Reproduces against both:
- Current `main` (`5af4d50`, Nov 2025)
- The pre-dormancy commit (`4c995a0d8c`, Oct 2022)

So the bug is structural in the validator, not a recent regression — pinning to an older SHA wouldn't help.

## Fix
Switch the default `--testcategory` from `WopiCore` to `All`. With `All`, the parser populates the prereq dictionary fully and runs every group; tests in unsupported categories short-circuit via their own prereqs. Locally this yields:

```
92 Pass / 5 Fail / 122 Skipped
```

The 5 failures are real and already tracked in #264 (`ProofKeys` cluster + `FileUrl` cluster).

## What this PR doesn't do
The workflow's failure-surfacing stays warning-level (`::warning::`, not job-failing). Switching to hard-fail would put a red check on every PR until #264 is resolved. Easy follow-up to flip once the underlying tests pass.

## Test plan
- [ ] Merge to `master`
- [ ] Confirm next push run shows non-zero `Pass` count in the job summary (was always 0 before)
- [ ] Confirm `wopi-validator-output` artifact contains 92/5/122-style results, no `ArgumentException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)