### PR TITLE
fix: use forward-slash separator in StorageProvider RootPath

### DIFF
--- a/sample/WopiHost.Validator/appsettings.json
+++ b/sample/WopiHost.Validator/appsettings.json
@@ -2,7 +2,7 @@
   "Wopi": {
     "UseCobalt": false,
     "StorageProvider": {
-      "RootPath": "..\\wopi-docs"
+      "RootPath": "../wopi-docs"
     },
     "HostUrl": "http://localhost:52788",
     "ClientUrl": "https://ffc-onenote.officeapps.live.com",

--- a/sample/WopiHost.Web/appsettings.json
+++ b/sample/WopiHost.Web/appsettings.json
@@ -1,7 +1,7 @@
 ﻿{
   "Wopi": {
     "StorageProvider": {
-      "RootPath": "..\\wopi-docs"
+      "RootPath": "../wopi-docs"
     },
     "HostUrl": "http://wopihost",
     "ClientUrl": "https://ffc-onenote.officeapps.live.com",

--- a/sample/WopiHost/appsettings.json
+++ b/sample/WopiHost/appsettings.json
@@ -4,7 +4,7 @@
     "StorageProviderAssemblyName": "WopiHost.FileSystemProvider",
     "LockProviderAssemblyName": "WopiHost.MemoryLockProvider",
     "StorageProvider": {
-      "RootPath": "..\\wopi-docs"
+      "RootPath": "../wopi-docs"
     },
     "ClientUrl": "https://ffc-onenote.officeapps.live.com"
   },


### PR DESCRIPTION
## Summary
The three sample apps ship with `"RootPath": "..\wopi-docs"` in their `appsettings.json`. The escaped `\` decodes to a single backslash — which Windows happily treats as a path separator, but Linux treats as a **literal character in the filename**. So on Linux runners (e.g., `ubuntu-latest` in the new WOPI Validator workflow), `WopiFileSystemProvider` can't find the docs directory and throws on the first WOPI request:

```
System.IO.DirectoryNotFoundException: Could not find a part of the path
'/home/runner/.../sample/WopiHost.Validator/..\wopi-docs'.
   at WopiHost.FileSystemProvider.InMemoryFileIds.ScanAll(...) at line 100
```

ASP.NET Core then returns a 500 with the dev exception page, and the validator crashes trying to parse the HTML body as JSON (mid-`CheckFileInfoSchema` run).

Forward slashes are universally accepted by .NET path APIs on both Windows and Linux, so the one-character fix is `..\wopi-docs` → `../wopi-docs`.

## Why this only just surfaced
Until #283 / #284, the WOPI Validator workflow wasn't actually running tests against the host — the validator's parser was crashing on `--testcategory WopiCore` before sending any HTTP requests. Now that the validator gets past the parse step, this latent bug shows up as the first test-group failure on Linux CI.

## Files changed
- [sample/WopiHost/appsettings.json](sample/WopiHost/appsettings.json)
- [sample/WopiHost.Validator/appsettings.json](sample/WopiHost.Validator/appsettings.json)
- [sample/WopiHost.Web/appsettings.json](sample/WopiHost.Web/appsettings.json)

## Test plan
- [ ] Merge to `master`
- [ ] Confirm next push run of the WOPI Validator workflow gets past `CheckFileInfoSchema` without the `JsonReaderException` crash
- [ ] Expect to see the 92/5/122-style results that I reproduced locally on Windows (the 5 failures being the ones in #264)
- [ ] Verify Windows local development still works (forward slashes are valid Windows path separators in .NET)

🤖 Generated with [Claude Code](https://claude.com/claude-code)