### PR TITLE
ci: post sticky validator results comment on PRs

### DIFF
--- a/.github/workflows/wopi-validator.yml
+++ b/.github/workflows/wopi-validator.yml
@@ -27,6 +27,7 @@ on:
 permissions:
   contents: read
   id-token: write
+  pull-requests: write
 
 env:
   TEST_CATEGORY: ${{ inputs.test_category || 'All' }}
@@ -200,6 +201,25 @@ jobs:
             validator.log
             host.log
           if-no-files-found: warn
+
+      - name: Post results to PR
+        if: always() && github.event_name == 'pull_request_target'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: wopi-validator
+          message: |
+            ## WOPI Validator results
+
+            | Status | Count |
+            | --- | ---: |
+            | ✅ Pass | ${{ steps.validate.outputs.pass || 0 }} |
+            | ❌ Fail | ${{ steps.validate.outputs.fail || 0 }} |
+            | ⏭️ Skipped | ${{ steps.validate.outputs.skip || 0 }} |
+
+            **Validator:** `WopiValidator ${{ steps.publish-validator.outputs.version }}` (from nuget.org)
+            **Test category:** `${{ env.TEST_CATEGORY }}`
+
+            📋 [Full report and `wopi-validator-output` artifact ↗](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
       - name: Surface validator failure
         if: always() && steps.validate.outputs.exit_code != '0'


### PR DESCRIPTION
## Summary
Adds a sticky PR comment to the WOPI Validator workflow showing the same pass/fail/skipped numbers that already go into the job summary, plus the validator version and a link to the workflow run for the full report and `wopi-validator-output` artifact.

Uses [`marocchino/sticky-pull-request-comment`](https://github.com/marocchino/sticky-pull-request-comment), which keys on a hidden `header` marker so subsequent pushes update the comment in place rather than appending a new one. No noise as you iterate on a PR.

## What it shows
```
## WOPI Validator results

| Status | Count |
| --- | ---: |
| ✅ Pass | 92 |
| ❌ Fail | 5 |
| ⏭️ Skipped | 122 |

**Validator:** `WopiValidator 2.0.5` (from nuget.org)
**Test category:** `All`

📋 Full report and `wopi-validator-output` artifact ↗
```

## Scope
- Only fires on `pull_request_target`. Master pushes still write to `$GITHUB_STEP_SUMMARY` as before — no comment posted there (nothing to comment on).
- New permission required: `pull-requests: write` (added at workflow level alongside the existing `contents: read` / `id-token: write`).
- `if: always()` so the comment posts even when the validator step fails or the workflow is partially red. Empty step outputs fall back to `0` via `||`.

## Test plan
- [ ] Merge to `master`
- [ ] Open / push to any PR; confirm the comment appears once and updates in place on subsequent pushes
- [ ] Confirm Dependabot PRs also get the comment (they're authored by `dependabot[bot]` but the workflow's `pull_request_target` trigger still fires)

🤖 Generated with [Claude Code](https://claude.com/claude-code)