### PR TITLE
fix: address unresolved cleanups from #215

### DIFF
--- a/src/WopiHost.Core/Extensions/Extensions.cs
+++ b/src/WopiHost.Core/Extensions/Extensions.cs
@@ -136,15 +136,23 @@ internal static class Extensions
         string? routeName,
         object? values)
     {
-        var urlPart = helper.ActionContext.HttpContext.Request.GetProxyAwareUrlParts();
-        var routeUrl = helper.RouteUrl(routeName, values, urlPart.scheme);
-        
-        var uri = new Uri(routeUrl!);
-        var pathBase = uri.AbsolutePath.EndsWith('/') && uri.AbsolutePath.Length > 1
-            ? uri.AbsolutePath[..^1]
-            : uri.AbsolutePath;
-        var queryString = uri.Query;
+        var request = helper.ActionContext.HttpContext.Request;
+        var (scheme, host, forwardedPathBase, _, _) = request.GetProxyAwareUrlParts();
 
-        return $"{urlPart.scheme}://{urlPart.host}{pathBase}{queryString}";
+        var routePath = helper.RouteUrl(routeName, values);
+        if (routePath is null)
+        {
+            return null;
+        }
+
+        // helper.RouteUrl already includes Request.PathBase. Only prepend the
+        // forwarded path-base when it differs (e.g. proxy strips a prefix the
+        // app itself doesn't know about).
+        var requestPathBase = request.PathBase.Value ?? string.Empty;
+        var prefix = !string.IsNullOrEmpty(forwardedPathBase) && forwardedPathBase != requestPathBase
+            ? forwardedPathBase
+            : string.Empty;
+
+        return $"{scheme}://{host}{prefix}{routePath}";
     }
 }

--- a/src/WopiHost.Core/Security/Authentication/WopiProofValidator.cs
+++ b/src/WopiHost.Core/Security/Authentication/WopiProofValidator.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.AspNetCore.Http;
@@ -38,26 +39,35 @@ public class WopiProofValidator(IDiscoverer discoverer, ILogger<WopiProofValidat
                 logger.LogWarning("Missing required proof headers");
                 return false;
             }
-            
+
+            if (!long.TryParse(receivedTimeStamp.ToString(), CultureInfo.InvariantCulture, out var ticks))
+            {
+                logger.LogWarning("Invalid X-WOPI-TimeStamp header value");
+                return false;
+            }
+
             var sourceProofKeys = await discoverer.GetProofKeysAsync();
             if (sourceProofKeys.Value is null || sourceProofKeys.OldValue is null)
             {
                 return false;
             }
-            
-            var receivedProofOld = request.Headers[WopiHeaders.PROOF_OLD].FirstOrDefault() ?? String.Empty;
-            var receivedAccessToken = accessToken;
-            
-            if (DateTime.UtcNow - new DateTime(Convert.ToInt64(receivedTimeStamp)) > TimeSpan.FromMinutes(20))
+
+            var receivedProofOld = request.Headers[WopiHeaders.PROOF_OLD].FirstOrDefault() ?? string.Empty;
+
+            // Per WOPI spec: X-WOPI-TimeStamp is .NET DateTime.Ticks (UTC).
+            // Reject timestamps older than 20 minutes; allow a small future skew.
+            var requestTime = new DateTime(ticks, DateTimeKind.Utc);
+            var age = _timeProvider.GetUtcNow().UtcDateTime - requestTime;
+            if (age > TimeSpan.FromMinutes(20) || age < TimeSpan.FromMinutes(-5))
             {
                 return false;
             }
 
             var hostUrl = request.GetProxyAwareRequestUrl().ToUpperInvariant();
 
-            var hostUrlBytes = Encoding.UTF8.GetBytes(hostUrl.ToUpperInvariant());
-            var accessTokenBytes = Encoding.UTF8.GetBytes(receivedAccessToken);
-            var timeStampBytes = BitConverter.GetBytes(Convert.ToInt64(receivedTimeStamp));
+            var hostUrlBytes = Encoding.UTF8.GetBytes(hostUrl);
+            var accessTokenBytes = Encoding.UTF8.GetBytes(accessToken);
+            var timeStampBytes = BitConverter.GetBytes(ticks);
             Array.Reverse(timeStampBytes);
 
             var expectedProof = new List<byte>(

--- a/src/WopiHost.Core/Security/Authentication/WopiProofValidator.cs
+++ b/src/WopiHost.Core/Security/Authentication/WopiProofValidator.cs
@@ -34,37 +34,27 @@ public class WopiProofValidator(IDiscoverer discoverer, ILogger<WopiProofValidat
         {
             var request = httpContext.Request;
             if (!request.Headers.TryGetValue(WopiHeaders.PROOF, out var receivedProof) ||
-                !request.Headers.TryGetValue(WopiHeaders.TIMESTAMP, out var receivedTimeStamp))
+                !request.Headers.TryGetValue(WopiHeaders.TIMESTAMP, out var receivedTimeStamp) ||
+                !long.TryParse(receivedTimeStamp.ToString(), CultureInfo.InvariantCulture, out var ticks))
             {
-                logger.LogWarning("Missing required proof headers");
-                return false;
-            }
-
-            if (!long.TryParse(receivedTimeStamp.ToString(), CultureInfo.InvariantCulture, out var ticks))
-            {
-                logger.LogWarning("Invalid X-WOPI-TimeStamp header value");
+                logger.LogWarning("Missing or invalid proof/timestamp headers");
                 return false;
             }
 
             var sourceProofKeys = await discoverer.GetProofKeysAsync();
-            if (sourceProofKeys.Value is null || sourceProofKeys.OldValue is null)
-            {
-                return false;
-            }
-
-            var receivedProofOld = request.Headers[WopiHeaders.PROOF_OLD].FirstOrDefault() ?? string.Empty;
 
             // Per WOPI spec: X-WOPI-TimeStamp is .NET DateTime.Ticks (UTC).
             // Reject timestamps older than 20 minutes; allow a small future skew.
-            var requestTime = new DateTime(ticks, DateTimeKind.Utc);
-            var age = _timeProvider.GetUtcNow().UtcDateTime - requestTime;
-            if (age > TimeSpan.FromMinutes(20) || age < TimeSpan.FromMinutes(-5))
+            var age = _timeProvider.GetUtcNow().UtcDateTime - new DateTime(ticks, DateTimeKind.Utc);
+            if (sourceProofKeys.Value is null
+                || sourceProofKeys.OldValue is null
+                || age > TimeSpan.FromMinutes(20)
+                || age < TimeSpan.FromMinutes(-5))
             {
                 return false;
             }
 
             var hostUrl = request.GetProxyAwareRequestUrl().ToUpperInvariant();
-
             var hostUrlBytes = Encoding.UTF8.GetBytes(hostUrl);
             var accessTokenBytes = Encoding.UTF8.GetBytes(accessToken);
             var timeStampBytes = BitConverter.GetBytes(ticks);
@@ -82,10 +72,11 @@ public class WopiProofValidator(IDiscoverer discoverer, ILogger<WopiProofValidat
             expectedProof.AddRange(ToBigEndian(timeStampBytes.Length));
             expectedProof.AddRange(timeStampBytes);
             byte[] expectedBytes = [.. expectedProof];
-            
-            return (VerifyProof(expectedBytes, receivedProof.ToString(), sourceProofKeys.Value) ||
-                    VerifyProof(expectedBytes, receivedProof.ToString(), sourceProofKeys.OldValue) ||
-                    VerifyProof(expectedBytes, receivedProofOld, sourceProofKeys.Value));
+
+            var receivedProofOld = request.Headers[WopiHeaders.PROOF_OLD].FirstOrDefault() ?? string.Empty;
+            return VerifyProof(expectedBytes, receivedProof.ToString(), sourceProofKeys.Value)
+                || VerifyProof(expectedBytes, receivedProof.ToString(), sourceProofKeys.OldValue)
+                || VerifyProof(expectedBytes, receivedProofOld, sourceProofKeys.Value);
         }
         catch (Exception ex)
         {

--- a/src/WopiHost.FileSystemProvider/WopiFile.cs
+++ b/src/WopiHost.FileSystemProvider/WopiFile.cs
@@ -27,7 +27,7 @@ public class WopiFile(string filePath, string fileIdentifier) : IWopiFile
     public string Extension => fileInfo.Extension.TrimStart('.');
 
     /// <inheritdoc/>
-    public string? Version => fileVersionInfo.FileVersion ?? fileInfo.LastWriteTimeUtc.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture);
+    public string? Version => fileVersionInfo.FileVersion ?? fileInfo.LastWriteTimeUtc.Ticks.ToString(CultureInfo.InvariantCulture);
 
     /// <inheritdoc/>
 #pragma warning disable CA1819 // Properties should not return arrays

--- a/test/WopiHost.Core.Tests/Security/Authentication/WopiProofValidatorTests.cs
+++ b/test/WopiHost.Core.Tests/Security/Authentication/WopiProofValidatorTests.cs
@@ -1,0 +1,283 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using WopiHost.Core.Infrastructure;
+using WopiHost.Core.Security.Authentication;
+using WopiHost.Discovery;
+using WopiHost.Discovery.Models;
+
+namespace WopiHost.Core.Tests.Security.Authentication;
+
+public class WopiProofValidatorTests
+{
+    private const string AccessToken = "test-access-token";
+    private const string Scheme = "https";
+    private const string Host = "wopi.example.com";
+    private const string Path = "/wopi/files/abc123";
+    private const string QueryString = "?access_token=test-access-token";
+
+    private readonly Mock<IDiscoverer> _discoverer = new();
+    private readonly FixedTimeProvider _time = new(new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero));
+
+    [Fact]
+    public async Task Returns_false_when_proof_header_missing()
+    {
+        SetupDiscoveryWithRandomKeys();
+        var validator = CreateValidator();
+        var ctx = BuildHttpContext(includeProof: false);
+
+        var result = await validator.ValidateProofAsync(ctx, AccessToken);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task Returns_false_when_timestamp_header_missing()
+    {
+        SetupDiscoveryWithRandomKeys();
+        var validator = CreateValidator();
+        var ctx = BuildHttpContext(includeTimestamp: false);
+
+        var result = await validator.ValidateProofAsync(ctx, AccessToken);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task Returns_false_when_timestamp_is_not_a_number()
+    {
+        SetupDiscoveryWithRandomKeys();
+        var validator = CreateValidator();
+        var ctx = BuildHttpContext(timestampOverride: "not-a-number", proofOverride: "AAAA");
+
+        var result = await validator.ValidateProofAsync(ctx, AccessToken);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task Returns_false_when_discovery_returns_null_keys()
+    {
+        _discoverer
+            .Setup(d => d.GetProofKeysAsync())
+            .ReturnsAsync(new WopiProofKeys { Value = null, OldValue = null });
+        var validator = CreateValidator();
+        var ctx = BuildHttpContext(proofOverride: "AAAA");
+
+        var result = await validator.ValidateProofAsync(ctx, AccessToken);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task Returns_false_when_timestamp_is_older_than_20_minutes()
+    {
+        using var current = new RSACryptoServiceProvider(2048);
+        using var old = new RSACryptoServiceProvider(2048);
+        SetupDiscovery(current, old);
+
+        var staleTime = _time.GetUtcNow().UtcDateTime - TimeSpan.FromMinutes(21);
+        var ctx = BuildHttpContext(timestampOverride: staleTime.Ticks.ToString(CultureInfo.InvariantCulture));
+        SignAndApply(ctx.Request, current, staleTime.Ticks);
+
+        var validator = CreateValidator();
+        var result = await validator.ValidateProofAsync(ctx, AccessToken);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task Returns_false_when_timestamp_is_too_far_in_the_future()
+    {
+        using var current = new RSACryptoServiceProvider(2048);
+        using var old = new RSACryptoServiceProvider(2048);
+        SetupDiscovery(current, old);
+
+        var futureTime = _time.GetUtcNow().UtcDateTime + TimeSpan.FromMinutes(10);
+        var ctx = BuildHttpContext(timestampOverride: futureTime.Ticks.ToString(CultureInfo.InvariantCulture));
+        SignAndApply(ctx.Request, current, futureTime.Ticks);
+
+        var validator = CreateValidator();
+        var result = await validator.ValidateProofAsync(ctx, AccessToken);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task Returns_true_for_valid_signature_with_current_key()
+    {
+        using var current = new RSACryptoServiceProvider(2048);
+        using var old = new RSACryptoServiceProvider(2048);
+        SetupDiscovery(current, old);
+
+        var ticks = _time.GetUtcNow().UtcDateTime.Ticks;
+        var ctx = BuildHttpContext(timestampOverride: ticks.ToString(CultureInfo.InvariantCulture));
+        SignAndApply(ctx.Request, current, ticks);
+
+        var validator = CreateValidator();
+        var result = await validator.ValidateProofAsync(ctx, AccessToken);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task Returns_true_for_proof_signed_with_old_key_during_rotation()
+    {
+        using var current = new RSACryptoServiceProvider(2048);
+        using var old = new RSACryptoServiceProvider(2048);
+        SetupDiscovery(current, old);
+
+        var ticks = _time.GetUtcNow().UtcDateTime.Ticks;
+        var ctx = BuildHttpContext(timestampOverride: ticks.ToString(CultureInfo.InvariantCulture));
+        // X-WOPI-Proof signed with the OLD key (validator tries Value then OldValue)
+        SignAndApply(ctx.Request, old, ticks);
+
+        var validator = CreateValidator();
+        var result = await validator.ValidateProofAsync(ctx, AccessToken);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task Returns_true_when_only_old_proof_header_matches_current_key()
+    {
+        using var current = new RSACryptoServiceProvider(2048);
+        using var old = new RSACryptoServiceProvider(2048);
+        SetupDiscovery(current, old);
+
+        var ticks = _time.GetUtcNow().UtcDateTime.Ticks;
+        var ctx = BuildHttpContext(timestampOverride: ticks.ToString(CultureInfo.InvariantCulture));
+
+        var canonical = BuildCanonicalProof(AccessToken, BuildExpectedHostUrl(), ticks);
+        // X-WOPI-Proof bogus, but X-WOPI-ProofOld signed with current key
+        ctx.Request.Headers[WopiHeaders.PROOF] = Convert.ToBase64String(new byte[256]);
+        ctx.Request.Headers[WopiHeaders.PROOF_OLD] =
+            Convert.ToBase64String(current.SignData(canonical, "SHA256"));
+
+        var validator = CreateValidator();
+        var result = await validator.ValidateProofAsync(ctx, AccessToken);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task Returns_false_for_tampered_signature()
+    {
+        using var current = new RSACryptoServiceProvider(2048);
+        using var old = new RSACryptoServiceProvider(2048);
+        using var attacker = new RSACryptoServiceProvider(2048);
+        SetupDiscovery(current, old);
+
+        var ticks = _time.GetUtcNow().UtcDateTime.Ticks;
+        var ctx = BuildHttpContext(timestampOverride: ticks.ToString(CultureInfo.InvariantCulture));
+        // signed with a key the discoverer doesn't know about
+        SignAndApply(ctx.Request, attacker, ticks);
+
+        var validator = CreateValidator();
+        var result = await validator.ValidateProofAsync(ctx, AccessToken);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task Returns_false_when_discoverer_throws()
+    {
+        _discoverer
+            .Setup(d => d.GetProofKeysAsync())
+            .ThrowsAsync(new InvalidOperationException("discovery offline"));
+        var validator = CreateValidator();
+        var ctx = BuildHttpContext(proofOverride: "AAAA");
+
+        var result = await validator.ValidateProofAsync(ctx, AccessToken);
+
+        Assert.False(result);
+    }
+
+    private WopiProofValidator CreateValidator()
+        => new(_discoverer.Object, NullLogger<WopiProofValidator>.Instance, _time);
+
+    private void SetupDiscoveryWithRandomKeys()
+    {
+        using var current = new RSACryptoServiceProvider(2048);
+        using var old = new RSACryptoServiceProvider(2048);
+        SetupDiscovery(current, old);
+    }
+
+    private void SetupDiscovery(RSACryptoServiceProvider current, RSACryptoServiceProvider old)
+    {
+        _discoverer
+            .Setup(d => d.GetProofKeysAsync())
+            .ReturnsAsync(new WopiProofKeys
+            {
+                Value = Convert.ToBase64String(current.ExportCspBlob(false)),
+                OldValue = Convert.ToBase64String(old.ExportCspBlob(false))
+            });
+    }
+
+    private static DefaultHttpContext BuildHttpContext(
+        bool includeProof = true,
+        bool includeTimestamp = true,
+        string? timestampOverride = null,
+        string? proofOverride = null)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Scheme = Scheme;
+        ctx.Request.Host = new HostString(Host);
+        ctx.Request.Path = Path;
+        ctx.Request.QueryString = new QueryString(QueryString);
+
+        if (includeTimestamp)
+        {
+            ctx.Request.Headers[WopiHeaders.TIMESTAMP] =
+                new StringValues(timestampOverride ?? DateTime.UtcNow.Ticks.ToString(CultureInfo.InvariantCulture));
+        }
+        if (includeProof)
+        {
+            ctx.Request.Headers[WopiHeaders.PROOF] = new StringValues(proofOverride ?? string.Empty);
+        }
+        return ctx;
+    }
+
+    private static string BuildExpectedHostUrl()
+        => $"{Scheme}://{Host}{Path}{QueryString}".ToUpperInvariant();
+
+    private static byte[] BuildCanonicalProof(string accessToken, string hostUrl, long ticks)
+    {
+        var tokenBytes = Encoding.UTF8.GetBytes(accessToken);
+        var hostBytes = Encoding.UTF8.GetBytes(hostUrl);
+        var tsBytes = BitConverter.GetBytes(ticks);
+        Array.Reverse(tsBytes);
+
+        var buffer = new List<byte>(4 + tokenBytes.Length + 4 + hostBytes.Length + 4 + tsBytes.Length);
+        buffer.AddRange(BigEndian(tokenBytes.Length));
+        buffer.AddRange(tokenBytes);
+        buffer.AddRange(BigEndian(hostBytes.Length));
+        buffer.AddRange(hostBytes);
+        buffer.AddRange(BigEndian(tsBytes.Length));
+        buffer.AddRange(tsBytes);
+        return [.. buffer];
+    }
+
+    private static byte[] BigEndian(int value)
+    {
+        var bytes = BitConverter.GetBytes(value);
+        Array.Reverse(bytes);
+        return bytes;
+    }
+
+    private static void SignAndApply(HttpRequest request, RSACryptoServiceProvider signer, long ticks)
+    {
+        var canonical = BuildCanonicalProof(AccessToken, BuildExpectedHostUrl(), ticks);
+        var signature = signer.SignData(canonical, "SHA256");
+        request.Headers[WopiHeaders.PROOF] = Convert.ToBase64String(signature);
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}


### PR DESCRIPTION
## Summary
Closes the three unresolved boxes in #215.

- **`WopiProofValidator`** — actually use the injected `TimeProvider`, parse `X-WOPI-TimeStamp` with `long.TryParse` + `DateTimeKind.Utc`, reject timestamps too far in the future (5-min skew on top of the 20-min staleness check), and drop dead code (double `ToUpperInvariant`, redundant local).
- **`ProxyAwareRouteUrl`** — prepend `X-Forwarded-PathBase` when it differs from `Request.PathBase` so generated WOPI URLs match what the proof signs over. Removed the misleading `pathBase` local (actually full absolute path) and the silent trailing-slash trim.
- **`WopiFile.Version`** — `LastWriteTimeUtc.Ticks` instead of `"yyyy-MM-ddTHH:mm:ss.fffZ"`. Same intent (back-to-back PUTs in the WOPI validator need distinct versions) with 100ns resolution and no string-format gymnastics.
- **`WopiProofValidatorTests`** — 11 new tests: missing headers, malformed timestamp, expired/future timestamps, valid current key, valid old key (rotation), valid `X-WOPI-ProofOld` matching current key, tampered signature, discoverer throws.

The Copilot inline comment on #212 suggesting `DateTimeOffset.FromUnixTimeSeconds` is intentionally **not** applied — per the WOPI spec, `X-WOPI-TimeStamp` is `DateTime.Ticks`, not Unix seconds.

## Test plan
- [x] `dotnet build WOPI.slnx` clean (0 warnings, 0 errors)
- [x] `dotnet test WOPI.slnx --framework net9.0` — all 263 tests pass (incl. 11 new)
- [ ] CI runs net8/9/10 on Ubuntu

🤖 Generated with [Claude Code](https://claude.com/claude-code)