### PR TITLE
fix: populate CheckFileInfo.FileUrl with self-pointing URL by default

### DIFF
--- a/sample/WopiHost.Validator/Infrastructure/WopiEvents.cs
+++ b/sample/WopiHost.Validator/Infrastructure/WopiEvents.cs
@@ -22,7 +22,7 @@ public static class WopiEvents
             wopiCheckFileInfo.CloseUrl = new("https://example.com/close");
             wopiCheckFileInfo.DownloadUrl = new("https://example.com/download");
             wopiCheckFileInfo.FileSharingUrl = new("https://example.com/share");
-            wopiCheckFileInfo.FileUrl = new("https://example.com/file");
+            // FileUrl is populated by the framework with a self-pointing GetFile URL.
             wopiCheckFileInfo.FileVersionUrl = new("https://example.com/version");
             wopiCheckFileInfo.HostEditUrl = new("https://example.com/edit");
             wopiCheckFileInfo.HostEmbeddedViewUrl = new("https://example.com/embedded");

--- a/src/WopiHost.Core/Controllers/FilesController.cs
+++ b/src/WopiHost.Core/Controllers/FilesController.cs
@@ -89,7 +89,7 @@ public class FilesController(
     /// <param name="maximumExpectedSize"></param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>FileStreamResult</returns>
-    [HttpGet("{id}/contents")]
+    [HttpGet("{id}/contents", Name = WopiRouteNames.GetFile)]
     [WopiAuthorize(WopiResourceType.File, Permission.Read)]
     public async Task<IActionResult> GetFile(
         string id,

--- a/src/WopiHost.Core/Extensions/WopiExtensions.cs
+++ b/src/WopiHost.Core/Extensions/WopiExtensions.cs
@@ -2,9 +2,11 @@
 using System.Security.Claims;
 using System.Security.Cryptography;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using WopiHost.Abstractions;
+using WopiHost.Core.Infrastructure;
 using WopiHost.Core.Models;
 
 namespace WopiHost.Core.Extensions;
@@ -123,7 +125,40 @@ public static class WopiExtensions
             checkFileInfo.UserInfo = userInfo;
         }
 
-        // allow changes and/or extensions before returning 
+        // Populate a sensible default FileUrl pointing at this host's GetFile endpoint
+        // with the request's access token in the query string. Per WOPI spec, FileUrl
+        // must be a token-bearing URL that lets the client GET file content without
+        // sending WOPI-specific headers. Hosts can override in OnCheckFileInfo (e.g.,
+        // to point at a CDN).
+        var linkGenerator = httpContext.RequestServices.GetService<LinkGenerator>();
+        if (linkGenerator is not null)
+        {
+            var (scheme, host, _, _, _) = httpContext.Request.GetProxyAwareUrlParts();
+            if (!string.IsNullOrEmpty(scheme) && !string.IsNullOrEmpty(host))
+            {
+                // Preserve the file identifier's casing — the storage provider's lookup
+                // is case-sensitive and the global LowercaseUrls=true would otherwise
+                // mangle ids like "WOPITEST".
+                var url = linkGenerator.GetUriByName(
+                    WopiRouteNames.GetFile,
+                    new
+                    {
+                        id = file.Identifier,
+                        access_token = httpContext.Request.GetAccessToken(),
+                    },
+                    scheme,
+                    new HostString(host),
+                    pathBase: default,
+                    fragment: default,
+                    options: new LinkOptions { LowercaseUrls = false });
+                if (url is not null)
+                {
+                    checkFileInfo.FileUrl = new Uri(url);
+                }
+            }
+        }
+
+        // allow changes and/or extensions before returning
         var wopiHostOptions = httpContext.RequestServices.GetService<IOptions<WopiHostOptions>>();
         if (wopiHostOptions is not null)
         {

--- a/src/WopiHost.Core/Infrastructure/WopiRouteNames.cs
+++ b/src/WopiHost.Core/Infrastructure/WopiRouteNames.cs
@@ -18,6 +18,11 @@ public static class WopiRouteNames
     public const string CheckFileInfo = nameof(CheckFileInfo);
 
     /// <summary>
+    /// Endpoint name for <see cref="FilesController.GetFile(string, int?, CancellationToken)"/>
+    /// </summary>
+    public const string GetFile = nameof(GetFile);
+
+    /// <summary>
     /// Endpoint name for <see cref="ContainersController.CheckContainerInfo(string, CancellationToken)"/>
     /// </summary>
     public const string CheckContainerInfo = nameof(CheckContainerInfo);

--- a/test/WopiHost.Core.Tests/Extensions/WopiExtensionsTests.cs
+++ b/test/WopiHost.Core.Tests/Extensions/WopiExtensionsTests.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using System.Security.Cryptography;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Options;
 using Moq;
 using WopiHost.Abstractions;
@@ -133,6 +134,101 @@ public class WopiExtensionsTests
 
         // Assert
         Assert.Equal(13, result.FileNameMaxLength);
+    }
+
+    private sealed class StubLinkGenerator(string returnValue) : LinkGenerator
+    {
+        public override string? GetPathByAddress<TAddress>(HttpContext httpContext, TAddress address, RouteValueDictionary values, RouteValueDictionary? ambientValues = null, PathString? pathBase = null, FragmentString fragment = default, LinkOptions? options = null) => returnValue;
+        public override string? GetPathByAddress<TAddress>(TAddress address, RouteValueDictionary values, PathString pathBase = default, FragmentString fragment = default, LinkOptions? options = null) => returnValue;
+        public override string? GetUriByAddress<TAddress>(HttpContext httpContext, TAddress address, RouteValueDictionary values, RouteValueDictionary? ambientValues = null, string? scheme = null, HostString? host = null, PathString? pathBase = null, FragmentString fragment = default, LinkOptions? options = null) => returnValue;
+        public override string? GetUriByAddress<TAddress>(TAddress address, RouteValueDictionary values, string? scheme, HostString host, PathString pathBase = default, FragmentString fragment = default, LinkOptions? options = null) => returnValue;
+    }
+
+    [Fact]
+    public async Task GetWopiCheckFileInfo_PopulatesFileUrl_WhenLinkGeneratorRegistered()
+    {
+        // Arrange
+        var mockFile = new Mock<IWopiFile>();
+        mockFile.Setup(f => f.Name).Returns("test");
+        mockFile.Setup(f => f.Owner).Returns("owner");
+        mockFile.Setup(f => f.Extension).Returns("txt");
+        mockFile.Setup(f => f.Identifier).Returns("WOPITEST");
+        mockFile.Setup(f => f.LastWriteTimeUtc).Returns(DateTime.UtcNow);
+
+        const string expected = "https://localhost/wopi/files/WOPITEST/contents?access_token=tok";
+        var linkGenerator = new StubLinkGenerator(expected);
+
+        var httpContext = new DefaultHttpContext()
+        {
+            ServiceScopeFactory = TestUtils.CreateServiceScope<LinkGenerator>(linkGenerator),
+        };
+        httpContext.Request.Scheme = "https";
+        httpContext.Request.Host = new HostString("localhost");
+
+        // Act
+        var result = await mockFile.Object.GetWopiCheckFileInfo(httpContext);
+
+        // Assert
+        Assert.NotNull(result.FileUrl);
+        Assert.Equal(expected, result.FileUrl.ToString());
+    }
+
+    [Fact]
+    public async Task GetWopiCheckFileInfo_OnCheckFileInfo_CanOverrideFileUrl()
+    {
+        // Arrange
+        var mockFile = new Mock<IWopiFile>();
+        mockFile.Setup(f => f.Name).Returns("test");
+        mockFile.Setup(f => f.Owner).Returns("owner");
+        mockFile.Setup(f => f.Extension).Returns("txt");
+        mockFile.Setup(f => f.Identifier).Returns("WOPITEST");
+        mockFile.Setup(f => f.LastWriteTimeUtc).Returns(DateTime.UtcNow);
+
+        var linkGenerator = new StubLinkGenerator("https://localhost/wopi/files/WOPITEST/contents?access_token=tok");
+
+        var cdnUrl = new Uri("https://cdn.example.com/file");
+        var wopiHostOptions = Options.Create(new WopiHostOptions
+        {
+            StorageProviderAssemblyName = "test",
+            ClientUrl = new Uri("http://localhost:5000"),
+            OnCheckFileInfo = context => { context.CheckFileInfo.FileUrl = cdnUrl; return Task.FromResult(context.CheckFileInfo); },
+        });
+
+        var httpContext = new DefaultHttpContext()
+        {
+            ServiceScopeFactory = TestUtils.CreateServiceScope<LinkGenerator, IOptions<WopiHostOptions>>(linkGenerator, wopiHostOptions),
+        };
+        httpContext.Request.Scheme = "https";
+        httpContext.Request.Host = new HostString("localhost");
+
+        // Act
+        var result = await mockFile.Object.GetWopiCheckFileInfo(httpContext);
+
+        // Assert: host's override wins over framework default.
+        Assert.Equal(cdnUrl, result.FileUrl);
+    }
+
+    [Fact]
+    public async Task GetWopiCheckFileInfo_FileUrl_StaysNull_WhenLinkGeneratorMissing()
+    {
+        // Arrange
+        var mockFile = new Mock<IWopiFile>();
+        mockFile.Setup(f => f.Name).Returns("test");
+        mockFile.Setup(f => f.Owner).Returns("owner");
+        mockFile.Setup(f => f.Extension).Returns("txt");
+        mockFile.Setup(f => f.Identifier).Returns("WOPITEST");
+        mockFile.Setup(f => f.LastWriteTimeUtc).Returns(DateTime.UtcNow);
+
+        var httpContext = new DefaultHttpContext()
+        {
+            ServiceScopeFactory = TestUtils.CreateServiceScope(),
+        };
+
+        // Act
+        var result = await mockFile.Object.GetWopiCheckFileInfo(httpContext);
+
+        // Assert
+        Assert.Null(result.FileUrl);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #294, closes #295.

## Summary
The WOPI validator's `FileUrlUsage` and `FileUrlViewOnly` test groups assume `CheckFileInfo.FileUrl` is a URL the client can follow with a plain `GET` to retrieve file content. The validator sample shipped a literal `"https://example.com/file"` placeholder that the validator dutifully fetched, getting back a 404 from the public example.com page.

Per the [WOPI spec — CheckFileInfo file URLs](https://learn.microsoft.com/en-us/microsoft-365/cloud-storage-partner-program/rest/files/checkfileinfo/checkfileinfo-response#file-urls), `FileUrl` should be a token-bearing URL that lets the client `GET` file content without WOPI-specific headers. Moving that default into the framework so every host gets it for free — and keeping the `WopiCheckFileInfoContext` abstraction clean (no `HttpContext` leak).

## Implementation
- **Name the GetFile endpoint** (`WopiRouteNames.GetFile`) so `LinkGenerator` can resolve it.
- **Populate `FileUrl` in `WopiExtensions.GetWopiCheckFileInfo`** by resolving `LinkGenerator` from the request's services and composing a URL pointing at this same host's `GetFile` endpoint. Reuses the existing `GetProxyAwareUrlParts` so `X-Forwarded-*` is respected.
- **Preserve identifier casing** by passing `LinkOptions { LowercaseUrls = false }`. The framework-wide `LowercaseUrls = true` would otherwise mangle `WOPITEST` → `wopitest`, and the storage provider's lookup is case-sensitive.
- **Run the default before `OnCheckFileInfo`** so hosts can still override (e.g., to point at a CDN). Tested.
- **Drop the placeholder** from `sample/WopiHost.Validator/Infrastructure/WopiEvents.cs` — the framework default now wins.

## Why not extend `WopiCheckFileInfoContext`?
Two options to give the event handler access to `HttpContext`: (a) extend the context record, or (b) inject `IHttpContextAccessor`. Both leak ASP.NET Core specifics into a clean abstraction (`Abstractions` doesn't depend on AspNetCore today). The framework already has `HttpContext` available where it matters — `GetWopiCheckFileInfo` — so the cleanest seam is there. Hosts that want to override still can, via the existing `OnCheckFileInfo` callback.

## Verification
- **Validator e2e**: `bash scripts/run-validator.sh All` locally goes from 92 / 5 / 122 (Pass / Fail / Skipped) → **94 / 3 / 122**. The 2 FileUrl failures both flip to pass.
- **Remaining 3 failures**: the ProofKeys cluster from #291 / #292 / #293, untouched here.
- **Unit tests**: 3 new tests cover (a) framework default fires when `LinkGenerator` is registered, (b) `OnCheckFileInfo` override wins, (c) `FileUrl` stays null when `LinkGenerator` is not registered (preserves existing test behavior). 175/175 in `WopiHost.Core.Tests` (net10), 256/256 across the solution.

## Files changed
- [src/WopiHost.Core/Infrastructure/WopiRouteNames.cs](src/WopiHost.Core/Infrastructure/WopiRouteNames.cs) — add `GetFile` constant
- [src/WopiHost.Core/Controllers/FilesController.cs](src/WopiHost.Core/Controllers/FilesController.cs) — name the existing `GET /{id}/contents` route
- [src/WopiHost.Core/Extensions/WopiExtensions.cs](src/WopiHost.Core/Extensions/WopiExtensions.cs) — populate `FileUrl` default
- [sample/WopiHost.Validator/Infrastructure/WopiEvents.cs](sample/WopiHost.Validator/Infrastructure/WopiEvents.cs) — drop the placeholder `FileUrl = "https://example.com/file"`
- [test/WopiHost.Core.Tests/Extensions/WopiExtensionsTests.cs](test/WopiHost.Core.Tests/Extensions/WopiExtensionsTests.cs) — 3 new tests + a tiny `StubLinkGenerator` (Moq doesn't easily mock `LinkGenerator.GetUriByAddress<TAddress>`)

## Test plan
- [ ] Merge to `master`
- [ ] Watch the WOPI Validator workflow on the next push: `FileUrlUsage.GetFromFileUrlAfterPutFile` and `FileUrlViewOnly.GetFromFileUrl` should now pass; failure count drops from 5 to 3
- [ ] Sticky comment on Dependabot PRs should reflect the new pass count

🤖 Generated with [Claude Code](https://claude.com/claude-code)