### PR TITLE
test: align FileUrl test names with file conventions

### DIFF
--- a/test/WopiHost.Core.Tests/Extensions/WopiExtensionsTests.cs
+++ b/test/WopiHost.Core.Tests/Extensions/WopiExtensionsTests.cs
@@ -145,7 +145,7 @@ public class WopiExtensionsTests
     }
 
     [Fact]
-    public async Task GetWopiCheckFileInfo_PopulatesFileUrl_WhenLinkGeneratorRegistered()
+    public async Task GetWopiCheckFileInfo_PopulatesFileUrl_WhenLinkGeneratorIsRegistered()
     {
         // Arrange
         var mockFile = new Mock<IWopiFile>();
@@ -174,7 +174,7 @@ public class WopiExtensionsTests
     }
 
     [Fact]
-    public async Task GetWopiCheckFileInfo_OnCheckFileInfo_CanOverrideFileUrl()
+    public async Task GetWopiCheckFileInfo_OverridesFileUrl_WhenOnCheckFileInfoSetsIt()
     {
         // Arrange
         var mockFile = new Mock<IWopiFile>();
@@ -204,12 +204,12 @@ public class WopiExtensionsTests
         // Act
         var result = await mockFile.Object.GetWopiCheckFileInfo(httpContext);
 
-        // Assert: host's override wins over framework default.
+        // Assert
         Assert.Equal(cdnUrl, result.FileUrl);
     }
 
     [Fact]
-    public async Task GetWopiCheckFileInfo_FileUrl_StaysNull_WhenLinkGeneratorMissing()
+    public async Task GetWopiCheckFileInfo_LeavesFileUrlNull_WhenLinkGeneratorIsMissing()
     {
         // Arrange
         var mockFile = new Mock<IWopiFile>();


### PR DESCRIPTION
Trivial follow-up to #297. Aligns the three FileUrl tests added there with the existing `Method_VerbPhrase_WhenConditionPhrase` pattern in the same file (e.g., `GetEncodedSha256_ReturnsBase64Checksum_WhenChecksumIsProvided`).

| before | after |
|---|---|
| `_PopulatesFileUrl_WhenLinkGeneratorRegistered` | `_PopulatesFileUrl_WhenLinkGeneratorIsRegistered` |
| `_OnCheckFileInfo_CanOverrideFileUrl` | `_OverridesFileUrl_WhenOnCheckFileInfoSetsIt` |
| `_FileUrl_StaysNull_WhenLinkGeneratorMissing` | `_LeavesFileUrlNull_WhenLinkGeneratorIsMissing` |

Also dropped a one-off "// Assert: host's override wins…" inline explanation in favor of the bare `// Assert` that the rest of the file uses — the test name says enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)