### PR TITLE
feat(core): harden Ecosystem endpoints (CheckEcosystem + GetRootContainer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ public class RedisLockProvider : IWopiLockProvider
 
 ## Advanced Customization
 
-### CheckFileInfo & CheckContainerInfo Events
+### CheckFileInfo, CheckContainerInfo & CheckEcosystem Events
 Customize WOPI responses by registering for events in your `WopiHostOptions`:
 
 ```csharp
@@ -507,6 +507,14 @@ builder.Services.Configure<WopiHostOptions>(options =>
         // Add custom security properties
         containerInfo.CustomSecurityProperty = "CustomSecurityValue";
         return containerInfo;
+    };
+
+    // Override capability flags returned from GET /wopi/ecosystem.
+    // Spec: SupportsContainers should match the value returned from CheckFileInfo.
+    options.OnCheckEcosystem = context =>
+    {
+        context.CheckEcosystem.SupportsContainers = false;
+        return Task.FromResult(context.CheckEcosystem);
     };
 });
 ```

--- a/src/WopiHost.Abstractions/WopiCheckEcosystem.cs
+++ b/src/WopiHost.Abstractions/WopiCheckEcosystem.cs
@@ -1,0 +1,18 @@
+namespace WopiHost.Abstractions;
+
+/// <summary>
+/// Response model for the <c>CheckEcosystem</c> operation.
+/// Spec: <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/ecosystem/checkecosystem"/>.
+/// </summary>
+/// <remarks>
+/// All response properties are optional; per the WOPI spec an empty JSON response is valid.
+/// Hosts can extend this DTO if they need to return additional fields.
+/// </remarks>
+public class WopiCheckEcosystem
+{
+    /// <summary>
+    /// A Boolean value that should match the
+    /// <see cref="WopiCheckFileInfo.SupportsContainers"/> property in <c>CheckFileInfo</c>.
+    /// </summary>
+    public bool SupportsContainers { get; set; }
+}

--- a/src/WopiHost.Core/Controllers/EcosystemController.cs
+++ b/src/WopiHost.Core/Controllers/EcosystemController.cs
@@ -1,6 +1,8 @@
-﻿using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
 using System.Net.Mime;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using WopiHost.Abstractions;
 using WopiHost.Core.Extensions;
 using WopiHost.Core.Infrastructure;
@@ -10,47 +12,88 @@ using WopiHost.Core.Security.Authentication;
 namespace WopiHost.Core.Controllers;
 
 /// <summary>
-/// Implementation of WOPI server protocol https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/ecosystem/checkecosystem
+/// Implementation of the WOPI Ecosystem endpoints.
+/// Spec: <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/ecosystem/checkecosystem"/>.
 /// </summary>
-/// <remarks>
-/// Creates an instance of <see cref="EcosystemController"/>.
-/// </remarks>
 /// <param name="storageProvider">Storage provider instance for retrieving files and folders.</param>
+/// <param name="accessTokenService">Issues per-resource WOPI access tokens.</param>
+/// <param name="permissionProvider">Computes the permissions to bake into freshly issued tokens.</param>
+/// <param name="wopiHostOptions">Host configuration, including the <see cref="WopiHostOptions.OnCheckEcosystem"/> hook.</param>
 [Authorize]
 [ApiController]
 [Route("wopi/[controller]")]
 [ServiceFilter(typeof(WopiOriginValidationActionFilter))]
 public class EcosystemController(
-    IWopiStorageProvider storageProvider) : ControllerBase
+    IWopiStorageProvider storageProvider,
+    IWopiAccessTokenService accessTokenService,
+    IWopiPermissionProvider permissionProvider,
+    IOptions<WopiHostOptions> wopiHostOptions) : ControllerBase
 {
     /// <summary>
-    /// The GetRootContainer operation returns the root container. A WOPI client can use this operation to get a reference to the root container, from which the client can call EnumerateChildren (containers) to navigate a container hierarchy.
-    /// Specification: https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/ecosystem/getrootcontainer
-    /// Example URL: GET /wopi/ecosystem/root_container_pointer
+    /// The GetRootContainer operation returns the root container. A WOPI client can use this
+    /// operation to get a reference to the root container, from which it can call
+    /// EnumerateChildren (containers) to navigate the container hierarchy.
+    /// Spec: <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/ecosystem/getrootcontainer"/>.
+    /// Example URL: <c>GET /wopi/ecosystem/root_container_pointer</c>.
     /// </summary>
-    /// <param name="cancellationToken">cancellation token</param>
-    /// <returns></returns>
     [HttpGet("root_container_pointer")]
     [Produces(MediaTypeNames.Application.Json)]
     public async Task<IActionResult> GetRootContainer(CancellationToken cancellationToken = default)
     {
-        var root = await storageProvider.GetWopiResource<IWopiFolder>(storageProvider.RootContainerPointer.Identifier, cancellationToken)
-            ?? throw new InvalidOperationException("Root container not found");
+        var root = await storageProvider.GetWopiResource<IWopiFolder>(storageProvider.RootContainerPointer.Identifier, cancellationToken);
+        if (root is null)
+        {
+            return NotFound();
+        }
+
+        // Issue a per-container access token. Re-using the inbound token in
+        // ContainerPointer.Url violates the WOPI "preventing token trading" guidance:
+        // https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/concepts#preventing-token-trading
+        var permissions = await permissionProvider.GetContainerPermissionsAsync(User, root, cancellationToken);
+        var token = await accessTokenService.IssueAsync(new WopiAccessTokenRequest
+        {
+            UserId = User.GetUserId(),
+            UserDisplayName = User.FindFirstValue(ClaimTypes.Name),
+            UserEmail = User.FindFirstValue(ClaimTypes.Email),
+            ResourceId = root.Identifier,
+            ResourceType = WopiResourceType.Container,
+            ContainerPermissions = permissions,
+        }, cancellationToken);
+
         var rc = new RootContainerInfo
         {
-            ContainerPointer = new ChildContainer(root.Name, Url.GetWopiSrc(WopiResourceType.Container, root.Identifier))
+            ContainerPointer = new ChildContainer(
+                root.Name,
+                Url.GetWopiSrc(WopiResourceType.Container, root.Identifier, token.Token)),
+            // The spec strongly recommends including ContainerInfo so the WOPI client
+            // does not have to round-trip back to CheckContainerInfo.
+            ContainerInfo = await root.GetWopiCheckContainerInfo(HttpContext, cancellationToken),
         };
         return new JsonResult(rc);
     }
 
     /// <summary>
-    /// The CheckEcosystem operation is similar to the the CheckFileInfo operation, but does not require a file or container ID.
+    /// The CheckEcosystem operation is similar to CheckFileInfo, but does not require a file
+    /// or container ID.
+    /// Spec: <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/ecosystem/checkecosystem"/>.
     /// </summary>
-    /// <returns></returns>
     [HttpGet(Name = WopiRouteNames.CheckEcosystem)]
     [Produces(MediaTypeNames.Application.Json)]
-    public IActionResult CheckEcosystem()
+    public async Task<IActionResult> CheckEcosystem()
     {
-        return new JsonResult(new { new WopiHostCapabilities().SupportsContainers });
+        // Mirror the capability flags surfaced via CheckFileInfo. The spec says
+        // SupportsContainers here "should match" the CheckFileInfo value.
+        var capabilities = new WopiHostCapabilities();
+        var checkEcosystem = new WopiCheckEcosystem
+        {
+            SupportsContainers = capabilities.SupportsContainers,
+        };
+
+        // Allow the host to override before returning, mirroring OnCheckFileInfo /
+        // OnCheckContainerInfo / OnCheckFolderInfo.
+        checkEcosystem = await wopiHostOptions.Value.OnCheckEcosystem(
+            new WopiCheckEcosystemContext(User, checkEcosystem));
+
+        return new JsonResult(checkEcosystem);
     }
 }

--- a/src/WopiHost.Core/Models/RootContainerInfo.cs
+++ b/src/WopiHost.Core/Models/RootContainerInfo.cs
@@ -1,10 +1,10 @@
-﻿using WopiHost.Abstractions;
+using WopiHost.Abstractions;
 
 namespace WopiHost.Core.Models;
 
 /// <summary>
 /// Object describing the root container.
-/// Implemented in accordance with https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/ecosystem/getrootcontainer#required-response-properties
+/// Spec: <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/ecosystem/getrootcontainer#required-response-properties"/>.
 /// </summary>
 public class RootContainerInfo
 {
@@ -13,10 +13,10 @@ public class RootContainerInfo
 	/// </summary>
 	public required ChildContainer ContainerPointer { get; set; }
 
-	//TODO: initialize according to https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/ecosystem/getrootcontainer
 	/// <summary>
-	/// Hosts can optionally include the ContainerInfo property, which should match the CheckContainerInfo response for the root container.
-	///	If not provided, the WOPI client will call CheckContainerInfo to retrieve it.Including this property in the response is strongly recommended so that the WOPI client does not need to make an additional call to CheckContainerInfo.
+	/// Optional CheckContainerInfo data for the root container. Including this saves the WOPI
+	/// client an extra round-trip to <see cref="WopiCheckContainerInfo"/> and is strongly
+	/// recommended by the WOPI spec.
 	/// </summary>
 	public WopiCheckContainerInfo? ContainerInfo { get; set; }
 }

--- a/src/WopiHost.Core/Models/WopiCheckEcosystemContext.cs
+++ b/src/WopiHost.Core/Models/WopiCheckEcosystemContext.cs
@@ -1,0 +1,11 @@
+using System.Security.Claims;
+using WopiHost.Abstractions;
+
+namespace WopiHost.Core.Models;
+
+/// <summary>
+/// Context for the CheckEcosystem operation.
+/// </summary>
+/// <param name="User">the current user.</param>
+/// <param name="CheckEcosystem">the default created <see cref="WopiCheckEcosystem"/></param>
+public record WopiCheckEcosystemContext(ClaimsPrincipal? User, WopiCheckEcosystem CheckEcosystem);

--- a/src/WopiHost.Core/Models/WopiHostOptions.cs
+++ b/src/WopiHost.Core/Models/WopiHostOptions.cs
@@ -41,6 +41,11 @@ public class WopiHostOptions : IDiscoveryOptions
     public Func<WopiCheckFolderInfoContext, Task<WopiCheckFolderInfo>> OnCheckFolderInfo { get; set; } = c => Task.FromResult(c.CheckFolderInfo);
 
     /// <summary>
+    /// Callback for the CheckEcosystem operation.
+    /// </summary>
+    public Func<WopiCheckEcosystemContext, Task<WopiCheckEcosystem>> OnCheckEcosystem { get; set; } = c => Task.FromResult(c.CheckEcosystem);
+
+    /// <summary>
     /// Base URI of the WOPI Client server (Office Online Server / Office Web Apps).
     /// </summary>
     [Required]

--- a/src/WopiHost.Core/README.md
+++ b/src/WopiHost.Core/README.md
@@ -323,6 +323,8 @@ public class WopiHostOptions : IDiscoveryOptions
     public string? LockProviderAssemblyName { get; set; }
     public Func<WopiCheckFileInfoContext, Task<WopiCheckFileInfo>> OnCheckFileInfo { get; set; }
     public Func<WopiCheckContainerInfoContext, Task<WopiCheckContainerInfo>> OnCheckContainerInfo { get; set; }
+    public Func<WopiCheckFolderInfoContext, Task<WopiCheckFolderInfo>> OnCheckFolderInfo { get; set; }
+    public Func<WopiCheckEcosystemContext, Task<WopiCheckEcosystem>> OnCheckEcosystem { get; set; }
     public required Uri ClientUrl { get; set; }
 }
 ```

--- a/test/WopiHost.Core.Tests/Controllers/EcosystemControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/EcosystemControllerTests.cs
@@ -1,7 +1,10 @@
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Options;
 using Moq;
 using WopiHost.Abstractions;
 using WopiHost.Core.Controllers;
@@ -12,41 +15,84 @@ namespace WopiHost.Core.Tests.Controllers;
 public class EcosystemControllerTests
 {
     private readonly Mock<IWopiStorageProvider> _storage = new();
+    private readonly Mock<IWopiAccessTokenService> _tokens = new();
+    private readonly Mock<IWopiPermissionProvider> _permissions = new();
     private readonly Mock<IWopiFolder> _root = new();
 
     public EcosystemControllerTests()
     {
         _root.SetupGet(f => f.Identifier).Returns("root-id");
         _root.SetupGet(f => f.Name).Returns("Root");
-
         _storage.SetupGet(s => s.RootContainerPointer).Returns(_root.Object);
         _storage
             .Setup(s => s.GetWopiResource<IWopiFolder>("root-id", It.IsAny<CancellationToken>()))
             .ReturnsAsync(_root.Object);
+
+        _permissions
+            .Setup(p => p.GetContainerPermissionsAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<IWopiFolder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(WopiContainerPermissions.UserCanCreateChildFile);
+
+        _tokens
+            .Setup(t => t.IssueAsync(It.IsAny<WopiAccessTokenRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WopiAccessToken("FRESH-TOKEN", DateTimeOffset.UtcNow.AddMinutes(10)));
     }
 
-    private EcosystemController BuildController()
+    private EcosystemController BuildController(
+        ClaimsPrincipal? user = null,
+        WopiHostOptions? options = null,
+        UrlRouteContext? captureUrlRouteContext = null)
     {
-        // GetWopiSrc resolves the access token via AuthenticationService, so the
-        // HttpContext needs a ServiceScopeFactory wired up with one.
+        var optionsObj = Options.Create(options ?? DefaultOptions());
+
         var auth = new Mock<IAuthenticationService>();
         auth.Setup(a => a.AuthenticateAsync(It.IsAny<HttpContext>(), It.IsAny<string?>()))
             .ReturnsAsync(AuthenticateResult.NoResult());
+
+        var scope = TestUtils.CreateServiceScope(_permissions.Object, optionsObj, auth.Object);
         var ctx = new DefaultHttpContext
         {
-            ServiceScopeFactory = TestUtils.CreateServiceScope(auth.Object),
+            ServiceScopeFactory = scope,
+            User = user ?? AuthenticatedUser(),
         };
 
         var url = new Mock<IUrlHelper>();
-        url.Setup(u => u.RouteUrl(It.IsAny<UrlRouteContext>())).Returns("/wopi/containers/root-id");
+        var setup = url.Setup(u => u.RouteUrl(It.IsAny<UrlRouteContext>()));
+        if (captureUrlRouteContext is not null)
+        {
+            setup.Callback<UrlRouteContext>(rc =>
+            {
+                captureUrlRouteContext.RouteName = rc.RouteName;
+                captureUrlRouteContext.Values = rc.Values;
+                captureUrlRouteContext.Host = rc.Host;
+                captureUrlRouteContext.Protocol = rc.Protocol;
+                captureUrlRouteContext.Fragment = rc.Fragment;
+            }).Returns("/wopi/containers/root-id");
+        }
+        else
+        {
+            setup.Returns("/wopi/containers/root-id");
+        }
         url.Setup(u => u.ActionContext).Returns(new ActionContext { HttpContext = ctx });
 
-        return new EcosystemController(_storage.Object)
+        return new EcosystemController(_storage.Object, _tokens.Object, _permissions.Object, optionsObj)
         {
             Url = url.Object,
             ControllerContext = new ControllerContext { HttpContext = ctx },
         };
     }
+
+    private static WopiHostOptions DefaultOptions() => new()
+    {
+        StorageProviderAssemblyName = "Test",
+        ClientUrl = new Uri("http://localhost"),
+    };
+
+    private static ClaimsPrincipal AuthenticatedUser() => new(new ClaimsIdentity(
+    [
+        new Claim(ClaimTypes.NameIdentifier, "alice"),
+        new Claim(ClaimTypes.Name, "Alice Example"),
+        new Claim(ClaimTypes.Email, "alice@example.com"),
+    ], "Test"));
 
     [Fact]
     public async Task GetRootContainer_ReturnsRootContainerInfo()
@@ -59,22 +105,131 @@ public class EcosystemControllerTests
     }
 
     [Fact]
-    public async Task GetRootContainer_RootMissing_Throws()
+    public async Task GetRootContainer_PopulatesContainerInfo()
+    {
+        var result = await BuildController().GetRootContainer();
+
+        var info = Assert.IsType<RootContainerInfo>(((JsonResult)result).Value);
+        Assert.NotNull(info.ContainerInfo);
+        Assert.Equal("Root", info.ContainerInfo!.Name);
+    }
+
+    [Fact]
+    public async Task GetRootContainer_ContainerInfo_PropagatesUserCanFlagsFromPermissionProvider()
+    {
+        _permissions
+            .Setup(p => p.GetContainerPermissionsAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<IWopiFolder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(WopiContainerPermissions.UserCanCreateChildFile | WopiContainerPermissions.UserCanRename);
+
+        var result = await BuildController().GetRootContainer();
+
+        var info = Assert.IsType<RootContainerInfo>(((JsonResult)result).Value);
+        Assert.True(info.ContainerInfo!.UserCanCreateChildFile);
+        Assert.True(info.ContainerInfo!.UserCanRename);
+        Assert.False(info.ContainerInfo!.UserCanCreateChildContainer);
+        Assert.False(info.ContainerInfo!.UserCanDelete);
+    }
+
+    [Fact]
+    public async Task GetRootContainer_IssuesPerContainerToken_BoundToCallerAndRoot()
+    {
+        await BuildController().GetRootContainer();
+
+        _tokens.Verify(t => t.IssueAsync(
+            It.Is<WopiAccessTokenRequest>(r =>
+                r.UserId == "alice" &&
+                r.UserDisplayName == "Alice Example" &&
+                r.UserEmail == "alice@example.com" &&
+                r.ResourceId == "root-id" &&
+                r.ResourceType == WopiResourceType.Container &&
+                r.ContainerPermissions == WopiContainerPermissions.UserCanCreateChildFile),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetRootContainer_ContainerPointerUrl_CarriesFreshAccessToken_NotInbound()
+    {
+        // Token-trading prevention per https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/concepts#preventing-token-trading
+        // The handed-off URL must contain a token issued for this container, not the
+        // caller's inbound token.
+        var captured = new UrlRouteContext();
+
+        await BuildController(captureUrlRouteContext: captured).GetRootContainer();
+
+        Assert.Equal("CheckContainerInfo", captured.RouteName);
+        var values = new RouteValueDictionary(captured.Values);
+        Assert.Equal("FRESH-TOKEN", values["access_token"]);
+        Assert.Equal("root-id", values["id"]);
+    }
+
+    [Fact]
+    public async Task GetRootContainer_ReturnsNotFound_WhenStorageReturnsNull()
     {
         _storage
             .Setup(s => s.GetWopiResource<IWopiFolder>("root-id", It.IsAny<CancellationToken>()))
             .ReturnsAsync((IWopiFolder?)null);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            BuildController().GetRootContainer());
+        var result = await BuildController().GetRootContainer();
+
+        Assert.IsType<NotFoundResult>(result);
+        // No token should be issued when there is no resource to bind it to.
+        _tokens.Verify(t => t.IssueAsync(It.IsAny<WopiAccessTokenRequest>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public void CheckEcosystem_ReturnsCapabilitiesPayload()
+    public async Task CheckEcosystem_ReturnsTypedDtoWithSupportsContainersTrue()
     {
-        var result = BuildController().CheckEcosystem();
+        var result = await BuildController().CheckEcosystem();
 
         var json = Assert.IsType<JsonResult>(result);
-        Assert.NotNull(json.Value);
+        var dto = Assert.IsType<WopiCheckEcosystem>(json.Value);
+        Assert.True(dto.SupportsContainers);
+    }
+
+    [Fact]
+    public async Task CheckEcosystem_AgreesWithCheckFileInfoOnSupportsContainers_ByDefault()
+    {
+        // Spec: SupportsContainers in CheckEcosystem "should match" the CheckFileInfo value.
+        // Both default to WopiHostCapabilities.SupportsContainers (true) so they agree.
+        var defaults = new WopiHostCapabilities();
+
+        var dto = Assert.IsType<WopiCheckEcosystem>(((JsonResult)await BuildController().CheckEcosystem()).Value);
+        Assert.Equal(defaults.SupportsContainers, dto.SupportsContainers);
+    }
+
+    [Fact]
+    public async Task CheckEcosystem_RunsThroughOnCheckEcosystemHook()
+    {
+        var hookCalled = false;
+        var options = DefaultOptions();
+        options.OnCheckEcosystem = ctx =>
+        {
+            hookCalled = true;
+            ctx.CheckEcosystem.SupportsContainers = false;
+            return Task.FromResult(ctx.CheckEcosystem);
+        };
+
+        var result = await BuildController(options: options).CheckEcosystem();
+
+        var dto = Assert.IsType<WopiCheckEcosystem>(((JsonResult)result).Value);
+        Assert.True(hookCalled);
+        Assert.False(dto.SupportsContainers);
+    }
+
+    [Fact]
+    public async Task CheckEcosystem_HookReceivesCurrentUser()
+    {
+        ClaimsPrincipal? observed = null;
+        var options = DefaultOptions();
+        options.OnCheckEcosystem = ctx =>
+        {
+            observed = ctx.User;
+            return Task.FromResult(ctx.CheckEcosystem);
+        };
+
+        await BuildController(options: options).CheckEcosystem();
+
+        Assert.NotNull(observed);
+        Assert.Equal("alice", observed!.FindFirst(ClaimTypes.NameIdentifier)?.Value);
     }
 }

--- a/test/WopiHost.Core.Tests/TestUtils.cs
+++ b/test/WopiHost.Core.Tests/TestUtils.cs
@@ -58,4 +58,28 @@ public static class TestUtils
 
         return serviceScopeFactory.Object;
     }
+
+    public static IServiceScopeFactory CreateServiceScope<T1, T2, T3>(T1 instance1, T2 instance2, T3 instance3)
+    {
+        var serviceProvider = new Mock<IServiceProvider>();
+        serviceProvider
+            .Setup(x => x.GetService(typeof(T1)))
+            .Returns(instance1);
+        serviceProvider
+            .Setup(x => x.GetService(typeof(T2)))
+            .Returns(instance2);
+        serviceProvider
+            .Setup(x => x.GetService(typeof(T3)))
+            .Returns(instance3);
+
+        var serviceScope = new Mock<IServiceScope>();
+        serviceScope.Setup(x => x.ServiceProvider).Returns(serviceProvider.Object);
+
+        var serviceScopeFactory = new Mock<IServiceScopeFactory>();
+        serviceScopeFactory
+            .Setup(x => x.CreateScope())
+            .Returns(serviceScope.Object);
+
+        return serviceScopeFactory.Object;
+    }
 }


### PR DESCRIPTION
## Summary

Closes the Ecosystem half of #39 (Bootstrap continues to be tracked in #305).

- **CheckEcosystem** — replace the anonymous `new { ... SupportsContainers }` projection with a typed `WopiCheckEcosystem` DTO routed through a new `OnCheckEcosystem` hook on `WopiHostOptions`, mirroring `OnCheckFileInfo` / `OnCheckContainerInfo`.
- **GetRootContainer** — issue a per-container access token via `IWopiAccessTokenService` instead of reusing the inbound one (WOPI ["preventing token trading"](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/concepts#preventing-token-trading) guidance); populate the optional `ContainerInfo` via the existing `GetWopiCheckContainerInfo` extension so the WOPI client doesn't have to round-trip back to `CheckContainerInfo`; return 404 when the root resolves to null.
- **Tests** — expand `EcosystemControllerTests` from 3 smoke tests to 10 conformance tests covering: typed DTO shape, hook invocation, hook user propagation, capability consistency with `CheckFileInfo`, `ContainerInfo` population, permission propagation, per-container token binding (user/resource/permissions), token-trading prevention (asserts the URL carries the **fresh** token, not the inbound one), and the not-found path.

## Why no validator coverage

The Microsoft `wopi-validator-core` test suite (`TestCases.xml` / `FeatureTestCases.xml`) ships **zero** TestGroups exercising `CheckEcosystem` or `GetRootContainer` — the validator engine can emit those requests but no canned tests use them. Conformance for these endpoints is owned in `WopiHost.Core.Tests`, not the validator pipeline.

## Deferred (open questions in #39)

- Per-action `[WopiAuthorize]` — `WopiAuthorize` resolves the resource id from a route parameter named `id`; neither endpoint has one (`GetRootContainer`'s resource is implicitly `storageProvider.RootContainerPointer.Identifier`, a runtime value). Wiring this requires a new authz path.
- Token TTL choice for `ContainerPointer.Url` — uses the issuer's default.

## Test plan

- [x] `dotnet test test/WopiHost.Core.Tests` — 274/274 pass on net10.0 (10 ecosystem tests, was 3)
- [x] `dotnet test WOPI.slnx` — 457/457 pass on net10.0 across all projects (Core, Discovery, Url, MemoryLockProvider, FileSystemProvider)
- [x] `dotnet build src/WopiHost.Core` — clean, 0 warnings, 0 errors with `TreatWarningsAsErrors`

🤖 Generated with [Claude Code](https://claude.com/claude-code)