### PR TITLE
feat(core): prevent token-trading in GetEcosystem; stub GetFileWopiSrc

### DIFF
--- a/src/WopiHost.Abstractions/WopiEcosystemOperations.cs
+++ b/src/WopiHost.Abstractions/WopiEcosystemOperations.cs
@@ -1,0 +1,12 @@
+namespace WopiHost.Abstractions;
+
+/// <summary>
+/// Details all WOPI ecosystem operation keywords.
+/// </summary>
+public static class WopiEcosystemOperations
+{
+    /// <summary>
+    /// <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/ecosystem/getfilewopisrc"/>.
+    /// </summary>
+    public const string GetWopiSrcWithAccessToken = "GET_WOPI_SRC_WITH_ACCESS_TOKEN";
+}

--- a/src/WopiHost.Core/Controllers/ContainersController.cs
+++ b/src/WopiHost.Core/Controllers/ContainersController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using System.Net.Mime;
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using WopiHost.Abstractions;
@@ -382,20 +383,41 @@ public class ContainersController(
     /// Example URL path: /wopi/containers/(container_id)/ecosystem_pointer
     /// </summary>
     /// <param name="id">A string that specifies a container ID of a container managed by host. This string must be URL safe.</param>
+    /// <param name="accessTokenService">Issues the per-call access token embedded in the response URL.</param>
     /// <param name="cancellationToken">cancellation token</param>
     /// <returns>URL response pointing to <see cref="WopiRouteNames.CheckEcosystem"/></returns>
     [HttpGet("{id}/ecosystem_pointer")]
     [WopiAuthorize(WopiResourceType.Container, Permission.Read)]
     [Produces(MediaTypeNames.Application.Json)]
-    public async Task<IActionResult> GetEcosystem(string id, CancellationToken cancellationToken = default)
+    public async Task<IActionResult> GetEcosystem(
+        string id,
+        [FromServices] IWopiAccessTokenService accessTokenService,
+        CancellationToken cancellationToken = default)
     {
-        if (await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken) is null)
+        var container = await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken);
+        if (container is null)
         {
             return NotFound();
         }
-        // A URI for the WOPI server’s Ecosystem endpoint, with an access token appended. A GET request to this URL will invoke the CheckEcosystem operation.
+
+        // Issue a fresh, minimum-privilege access token to embed in the response URL.
+        // Reusing the inbound token violates WOPI "preventing token trading" guidance:
+        // https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/concepts#preventing-token-trading
+        // The URL points to CheckEcosystem, which has no resource gate — so the token
+        // grants WopiContainerPermissions.None and is bound to this container purely as
+        // the resource binding required by the access-token model.
+        var token = await accessTokenService.IssueAsync(new WopiAccessTokenRequest
+        {
+            UserId = User.GetUserId(),
+            UserDisplayName = User.FindFirstValue(ClaimTypes.Name),
+            UserEmail = User.FindFirstValue(ClaimTypes.Email),
+            ResourceId = container.Identifier,
+            ResourceType = WopiResourceType.Container,
+            ContainerPermissions = WopiContainerPermissions.None,
+        }, cancellationToken);
+
         return new JsonResult<UrlResponse>(
-            new(Url.GetWopiSrc(WopiRouteNames.CheckEcosystem)));
+            new(Url.GetWopiSrc(WopiRouteNames.CheckEcosystem, identifier: null, accessToken: token.Token)));
     }
 
     /// <summary>

--- a/src/WopiHost.Core/Controllers/EcosystemController.cs
+++ b/src/WopiHost.Core/Controllers/EcosystemController.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Mime;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
@@ -7,6 +8,7 @@ using WopiHost.Abstractions;
 using WopiHost.Core.Extensions;
 using WopiHost.Core.Infrastructure;
 using WopiHost.Core.Models;
+using WopiHost.Core.Results;
 using WopiHost.Core.Security.Authentication;
 
 namespace WopiHost.Core.Controllers;
@@ -70,6 +72,41 @@ public class EcosystemController(
             ContainerInfo = await root.GetWopiCheckContainerInfo(HttpContext, cancellationToken),
         };
         return new JsonResult(rc);
+    }
+
+    /// <summary>
+    /// The GetFileWopiSrc operation converts a host-specific file identifier (passed via
+    /// the <c>X-WOPI-HostNativeFileName</c> header) into a <c>WopiSrc</c> URL with an
+    /// access token appended.
+    /// Spec: <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/ecosystem/getfilewopisrc"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Reserved for future use.</b> Microsoft's documentation states:
+    /// <i>"This operation should not be called by WOPI clients at this time. It is reserved
+    /// for future use and subject to change."</i> The endpoint is wired up here so the route
+    /// matches the spec when Microsoft starts shipping clients that exercise it; until then
+    /// the action returns <c>501 Not Implemented</c> (which the spec allows).
+    /// </para>
+    /// <para>
+    /// The matching <see cref="IWopiHostCapabilities.SupportsGetFileWopiSrc"/> capability flag
+    /// defaults to <c>false</c> so WOPI clients do not advertise the operation. When Microsoft
+    /// un-reserves the operation, hosts can replace this stub by overriding the controller or
+    /// by introducing an <c>OnGetFileWopiSrc</c> hook on <see cref="WopiHostOptions"/> and
+    /// flipping <c>SupportsGetFileWopiSrc</c> to <c>true</c>.
+    /// </para>
+    /// </remarks>
+    /// <param name="hostNativeFileName">The host-specific file identifier passed in <c>X-WOPI-HostNativeFileName</c>.</param>
+    [HttpPost]
+    [WopiOverrideHeader(WopiEcosystemOperations.GetWopiSrcWithAccessToken)]
+    [Produces(MediaTypeNames.Application.Json)]
+    [ApiExplorerSettings(IgnoreApi = true)]
+    [Experimental(WopiDiagnostics.GetFileWopiSrcReserved, UrlFormat = "https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/ecosystem/getfilewopisrc")]
+    public IActionResult GetFileWopiSrc(
+        [FromHeader(Name = WopiHeaders.HOST_NATIVE_FILE_NAME)] string? hostNativeFileName = null)
+    {
+        _ = hostNativeFileName;
+        return new NotImplementedResult();
     }
 
     /// <summary>

--- a/src/WopiHost.Core/Controllers/FilesController.cs
+++ b/src/WopiHost.Core/Controllers/FilesController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Mime;
+using System.Security.Claims;
 using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -215,15 +216,19 @@ public class FilesController(
     /// <summary>
     /// The GetEcosystem operation returns the URI for the WOPI server's Ecosystem endpoint, given a file ID.
     /// Specification: https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/getecosystem
-    /// Example URL path: /wopi/files/(container_id)/ecosystem_pointer
+    /// Example URL path: /wopi/files/(file_id)/ecosystem_pointer
     /// </summary>
     /// <param name="id">A string that specifies a file ID of a file managed by host. This string must be URL safe.</param>
+    /// <param name="accessTokenService">Issues the per-call access token embedded in the response URL.</param>
     /// <param name="cancellationToken">cancellation token</param>
     /// <returns>URL response pointing to <see cref="WopiRouteNames.CheckEcosystem"/></returns>
     [HttpGet("{id}/ecosystem_pointer")]
     [WopiAuthorize(WopiResourceType.File, Permission.Read)]
     [Produces(MediaTypeNames.Application.Json)]
-    public async Task<IActionResult> GetEcosystem(string id, CancellationToken cancellationToken = default)
+    public async Task<IActionResult> GetEcosystem(
+        string id,
+        [FromServices] IWopiAccessTokenService accessTokenService,
+        CancellationToken cancellationToken = default)
     {
         // Get file
         var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken);
@@ -231,9 +236,25 @@ public class FilesController(
         {
             return NotFound();
         }
-        // A URI for the WOPI server's Ecosystem endpoint, with an access token appended. A GET request to this URL will invoke the CheckEcosystem operation.
+
+        // Issue a fresh, minimum-privilege access token to embed in the response URL.
+        // Reusing the inbound token violates WOPI "preventing token trading" guidance:
+        // https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/concepts#preventing-token-trading
+        // The URL points to CheckEcosystem, which has no resource gate — so the token
+        // grants WopiFilePermissions.None and is bound to this file purely as the
+        // resource binding required by the access-token model.
+        var token = await accessTokenService.IssueAsync(new WopiAccessTokenRequest
+        {
+            UserId = User.GetUserId(),
+            UserDisplayName = User.FindFirstValue(ClaimTypes.Name),
+            UserEmail = User.FindFirstValue(ClaimTypes.Email),
+            ResourceId = file.Identifier,
+            ResourceType = WopiResourceType.File,
+            FilePermissions = WopiFilePermissions.None,
+        }, cancellationToken);
+
         return new JsonResult<UrlResponse>(
-            new(Url.GetWopiSrc(WopiRouteNames.CheckEcosystem)));
+            new(Url.GetWopiSrc(WopiRouteNames.CheckEcosystem, identifier: null, accessToken: token.Token)));
     }
 
     /// <summary>

--- a/src/WopiHost.Core/Infrastructure/WopiDiagnostics.cs
+++ b/src/WopiHost.Core/Infrastructure/WopiDiagnostics.cs
@@ -1,0 +1,19 @@
+namespace WopiHost.Core.Infrastructure;
+
+/// <summary>
+/// Diagnostic identifiers used by <see cref="System.Diagnostics.CodeAnalysis.ExperimentalAttribute"/>
+/// to mark WopiHost APIs that are intentionally unstable or reserved for future use.
+/// </summary>
+/// <remarks>
+/// To call an API marked with one of these IDs, callers must opt in by suppressing the
+/// corresponding compiler warning, e.g. <c>#pragma warning disable WOPIHOST001</c>.
+/// </remarks>
+public static class WopiDiagnostics
+{
+    /// <summary>
+    /// <c>WOPIHOST001</c> — marks the <c>GetFileWopiSrc</c> endpoint as reserved for future use.
+    /// Microsoft's spec says clients should not call this operation at this time, so the host
+    /// returns <c>501 Not Implemented</c> by default.
+    /// </summary>
+    public const string GetFileWopiSrcReserved = "WOPIHOST001";
+}

--- a/src/WopiHost.Core/Infrastructure/WopiHeaders.cs
+++ b/src/WopiHost.Core/Infrastructure/WopiHeaders.cs
@@ -108,6 +108,12 @@ public static class WopiHeaders
     public const string ECOSYSTEM_OPERATION = "X-WOPI-EcosystemOperation";
 
     /// <summary>
+    /// A string representing the host-specific file identifier for a file. Used by
+    /// <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/ecosystem/getfilewopisrc">GetFileWopiSrc</see>.
+    /// </summary>
+    public const string HOST_NATIVE_FILE_NAME = "X-WOPI-HostNativeFileName";
+
+    /// <summary>
     /// An optional string value indicating the version of the file.
     /// </summary>
     public const string ITEM_VERSION = "X-WOPI-ItemVersion";

--- a/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
@@ -1,8 +1,10 @@
 using System.Collections.ObjectModel;
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Routing;
 using Moq;
 using WopiHost.Abstractions;
 using WopiHost.Core.Controllers;
@@ -18,6 +20,8 @@ public class ContainersControllerTests
     private readonly Mock<IWopiLockProvider> lockProviderMock;
     private readonly Mock<IWopiWritableStorageProvider> writableStorageProviderMock;
     private readonly Mock<IWopiPermissionProvider> permissionProviderMock;
+    private readonly Mock<IWopiAccessTokenService> accessTokenServiceMock;
+    private readonly Mock<IUrlHelper> urlMock;
     private readonly ContainersController _controller;
 
     public ContainersControllerTests()
@@ -27,13 +31,17 @@ public class ContainersControllerTests
         writableStorageProviderMock = new Mock<IWopiWritableStorageProvider>();
         permissionProviderMock = new Mock<IWopiPermissionProvider>();
         permissionProviderMock
-            .Setup(_ => _.GetContainerPermissionsAsync(It.IsAny<System.Security.Claims.ClaimsPrincipal>(), It.IsAny<IWopiFolder>(), It.IsAny<CancellationToken>()))
+            .Setup(_ => _.GetContainerPermissionsAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<IWopiFolder>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(WopiContainerPermissions.UserCanCreateChildContainer | WopiContainerPermissions.UserCanCreateChildFile | WopiContainerPermissions.UserCanDelete | WopiContainerPermissions.UserCanRename);
-        var url = new Mock<IUrlHelper>();
-        url
+        accessTokenServiceMock = new Mock<IWopiAccessTokenService>();
+        accessTokenServiceMock
+            .Setup(s => s.IssueAsync(It.IsAny<WopiAccessTokenRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WopiAccessToken("FRESH-TOKEN", DateTimeOffset.UtcNow.AddMinutes(10)));
+        urlMock = new Mock<IUrlHelper>();
+        urlMock
             .Setup(_ => _.RouteUrl(It.IsAny<UrlRouteContext>()))
             .Returns("https://localhost");
-        url
+        urlMock
             .Setup(_ => _.ActionContext)
             .Returns(new ActionContext
             {
@@ -47,12 +55,18 @@ public class ContainersControllerTests
             lockProviderMock.Object,
             writableStorageProviderMock.Object)
         {
-            Url = url.Object,
+            Url = urlMock.Object,
             ControllerContext = new ControllerContext
             {
                 HttpContext = new DefaultHttpContext()
                 {
-                    ServiceScopeFactory = TestUtils.CreateServiceScope(permissionProviderMock.Object)
+                    ServiceScopeFactory = TestUtils.CreateServiceScope(permissionProviderMock.Object),
+                    User = new ClaimsPrincipal(new ClaimsIdentity(
+                    [
+                        new Claim(ClaimTypes.NameIdentifier, "alice"),
+                        new Claim(ClaimTypes.Name, "Alice Example"),
+                        new Claim(ClaimTypes.Email, "alice@example.com"),
+                    ], "Test")),
                 }
             }
         };
@@ -490,21 +504,59 @@ public class ContainersControllerTests
     {
         storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
 
-        var result = await _controller.GetEcosystem("nonexistent");
+        var result = await _controller.GetEcosystem("nonexistent", accessTokenServiceMock.Object);
 
         Assert.IsType<NotFoundResult>(result);
+        accessTokenServiceMock.Verify(t => t.IssueAsync(It.IsAny<WopiAccessTokenRequest>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
     public async Task GetEcosystem_ReturnsLink()
     {
         var containerId = "existing-container";
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
+        var folderMock = new Mock<IWopiFolder>();
+        folderMock.SetupGet(f => f.Identifier).Returns(containerId);
+        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(folderMock.Object);
 
-        var result = await _controller.GetEcosystem(containerId);
+        var result = await _controller.GetEcosystem(containerId, accessTokenServiceMock.Object);
 
         var jsonResult = Assert.IsType<JsonResult<UrlResponse>>(result);
-        var response = Assert.IsType<UrlResponse>(jsonResult.Value);
+        Assert.IsType<UrlResponse>(jsonResult.Value);
+    }
+
+    [Fact]
+    public async Task GetEcosystem_IssuesFreshMinimumPrivilegeToken_NotInbound()
+    {
+        // Token-trading prevention: the URL handed back to the WOPI client must carry a
+        // FRESH access token, not the inbound one, and that token must grant the minimum
+        // privileges required by the URL it lives in (CheckEcosystem -> None).
+        // https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/concepts#preventing-token-trading
+        var containerId = "existing-container";
+        var folderMock = new Mock<IWopiFolder>();
+        folderMock.SetupGet(f => f.Identifier).Returns(containerId);
+        storageProviderMock
+            .Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(folderMock.Object);
+
+        UrlRouteContext? captured = null;
+        urlMock
+            .Setup(_ => _.RouteUrl(It.IsAny<UrlRouteContext>()))
+            .Callback<UrlRouteContext>(rc => captured = rc)
+            .Returns("https://localhost/wopi/ecosystem");
+
+        await _controller.GetEcosystem(containerId, accessTokenServiceMock.Object);
+
+        accessTokenServiceMock.Verify(t => t.IssueAsync(
+            It.Is<WopiAccessTokenRequest>(r =>
+                r.UserId == "alice" &&
+                r.ResourceId == containerId &&
+                r.ResourceType == WopiResourceType.Container &&
+                r.ContainerPermissions == WopiContainerPermissions.None),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        Assert.NotNull(captured);
+        var values = new RouteValueDictionary(captured!.Values);
+        Assert.Equal("FRESH-TOKEN", values["access_token"]);
     }
 
     [Fact]

--- a/test/WopiHost.Core.Tests/Controllers/EcosystemControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/EcosystemControllerTests.cs
@@ -9,6 +9,7 @@ using Moq;
 using WopiHost.Abstractions;
 using WopiHost.Core.Controllers;
 using WopiHost.Core.Models;
+using WopiHost.Core.Results;
 
 namespace WopiHost.Core.Tests.Controllers;
 
@@ -232,4 +233,17 @@ public class EcosystemControllerTests
         Assert.NotNull(observed);
         Assert.Equal("alice", observed!.FindFirst(ClaimTypes.NameIdentifier)?.Value);
     }
+
+    [Fact]
+#pragma warning disable WOPIHOST001 // GetFileWopiSrc is reserved for future use; suppression is the documented opt-in.
+    public void GetFileWopiSrc_ReturnsNotImplemented_BySpecReservation()
+    {
+        // The Microsoft spec explicitly tells WOPI clients not to call this operation today.
+        // Until that changes, the host returns 501 (which the spec allows) and the
+        // SupportsGetFileWopiSrc capability flag stays false so the operation is not advertised.
+        var result = BuildController().GetFileWopiSrc(hostNativeFileName: "anything");
+
+        Assert.IsType<NotImplementedResult>(result);
+    }
+#pragma warning restore WOPIHOST001
 }

--- a/test/WopiHost.Core.Tests/Controllers/FilesControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/FilesControllerTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -23,6 +24,7 @@ public class FilesControllerTests
     private readonly Mock<IWopiStorageProvider> storageProviderMock;
     private readonly Mock<IWopiWritableStorageProvider> writableStorageProviderMock;
     private readonly Mock<IWopiPermissionProvider> permissionProviderMock;
+    private readonly Mock<IWopiAccessTokenService> accessTokenServiceMock;
     private readonly Mock<IOptions<WopiHostOptions>> wopiHostOptionsMock;
     private readonly IMemoryCache memoryCache;
     private readonly Mock<IWopiLockProvider> lockProviderMock;
@@ -49,6 +51,10 @@ public class FilesControllerTests
             });
         memoryCache = new MemoryCache(new MemoryCacheOptions());
         lockProviderMock = new Mock<IWopiLockProvider>();
+        accessTokenServiceMock = new Mock<IWopiAccessTokenService>();
+        accessTokenServiceMock
+            .Setup(s => s.IssueAsync(It.IsAny<WopiAccessTokenRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WopiAccessToken("FRESH-TOKEN", DateTimeOffset.UtcNow.AddMinutes(10)));
 
         urlMock = new Mock<IUrlHelper>();
         urlMock
@@ -282,9 +288,10 @@ public class FilesControllerTests
     {
         storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
 
-        var result = await controller.GetEcosystem("file_id");
+        var result = await controller.GetEcosystem("file_id", accessTokenServiceMock.Object);
 
         Assert.IsType<NotFoundResult>(result);
+        accessTokenServiceMock.Verify(t => t.IssueAsync(It.IsAny<WopiAccessTokenRequest>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -295,11 +302,64 @@ public class FilesControllerTests
         storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
+        SetAuthenticatedUser();
 
-        var result = await controller.GetEcosystem(fileId);
+        var result = await controller.GetEcosystem(fileId, accessTokenServiceMock.Object);
 
         var jsonResult = Assert.IsType<JsonResult<UrlResponse>>(result);
         Assert.NotNull(jsonResult.Value);
+    }
+
+    [Fact]
+    public async Task GetEcosystem_IssuesFreshMinimumPrivilegeToken_NotInbound()
+    {
+        // Token-trading prevention: the URL handed back to the WOPI client must carry a
+        // FRESH access token, not the inbound one, and that token must grant the minimum
+        // privileges required by the URL it lives in (CheckEcosystem -> None).
+        // https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/concepts#preventing-token-trading
+        var fileId = "testFileId";
+        var fileMock = CreateFileMock(fileId);
+        storageProviderMock
+            .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(fileMock.Object);
+        SetAuthenticatedUser();
+
+        UrlRouteContext? captured = null;
+        urlMock
+            .Setup(_ => _.RouteUrl(It.IsAny<UrlRouteContext>()))
+            .Callback<UrlRouteContext>(rc => captured = rc)
+            .Returns("https://localhost/wopi/ecosystem");
+
+        await controller.GetEcosystem(fileId, accessTokenServiceMock.Object);
+
+        accessTokenServiceMock.Verify(t => t.IssueAsync(
+            It.Is<WopiAccessTokenRequest>(r =>
+                r.UserId == "alice" &&
+                r.ResourceId == fileId &&
+                r.ResourceType == WopiResourceType.File &&
+                r.FilePermissions == WopiFilePermissions.None),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        Assert.NotNull(captured);
+        var values = new RouteValueDictionary(captured!.Values);
+        Assert.Equal("FRESH-TOKEN", values["access_token"]);
+    }
+
+    private void SetAuthenticatedUser()
+    {
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                ServiceScopeFactory = TestUtils.CreateServiceScope(permissionProviderMock.Object),
+                User = new ClaimsPrincipal(new ClaimsIdentity(
+                [
+                    new Claim(ClaimTypes.NameIdentifier, "alice"),
+                    new Claim(ClaimTypes.Name, "Alice Example"),
+                    new Claim(ClaimTypes.Email, "alice@example.com"),
+                ], "Test")),
+            },
+        };
     }
 
     #endregion


### PR DESCRIPTION
## Summary

Follow-up to #306. Closes the remaining token-trading hazard in the existing `GetEcosystem` actions and stubs the last documented ecosystem endpoint.

### Token-trading fix in `GetEcosystem (files)` and `GetEcosystem (containers)`

[FilesController.cs](https://github.com/petrsvihlik/WopiHost/blob/master/src/WopiHost.Core/Controllers/FilesController.cs) and [ContainersController.cs](https://github.com/petrsvihlik/WopiHost/blob/master/src/WopiHost.Core/Controllers/ContainersController.cs) previously embedded the **inbound** `access_token` in the response URL by calling `Url.GetWopiSrc(WopiRouteNames.CheckEcosystem)` with no token argument — same hazard we just fixed in `GetRootContainer`. The spec calls this out under [Preventing 'token trading'](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/concepts#preventing-token-trading).

Both endpoints now issue a fresh, **minimum-privilege** access token via `IWopiAccessTokenService` (injected as `[FromServices]` to avoid breaking the controller constructors). The token is bound to the queried resource — required by the access-token model — but grants `WopiFilePermissions.None` / `WopiContainerPermissions.None` because the URL points to `CheckEcosystem`, which is not gated on resource permissions.

### `GetFileWopiSrc` stub (`POST /wopi/ecosystem`)

The fifth ecosystem endpoint per MS Learn. Microsoft documents it as:

> *This operation should not be called by WOPI clients at this time. It is reserved for future use and subject to change.*

So the route is wired up to match the spec when MS un-reserves it, but the stub returns **501 Not Implemented** (spec-allowed) and is marked:

- `[Experimental(WopiDiagnostics.GetFileWopiSrcReserved)]` (= `WOPIHOST001`) — surfaces as a compile-time warning to anyone calling the action method directly. Callers (e.g. unit tests) opt in via `#pragma warning disable WOPIHOST001`.
- `[ApiExplorerSettings(IgnoreApi = true)]` — hides from OpenAPI / Scalar.

Future enablement path is documented in the action's `<remarks>`: introduce an `OnGetFileWopiSrc` hook on `WopiHostOptions` and flip `SupportsGetFileWopiSrc` to `true`. The capability flag already exists (`IWopiHostCapabilities.SupportsGetFileWopiSrc`) and stays `false` so clients don't advertise the operation.

## Files

| File | Change |
|---|---|
| `src/WopiHost.Abstractions/WopiEcosystemOperations.cs` (new) | `GetWopiSrcWithAccessToken = "GET_WOPI_SRC_WITH_ACCESS_TOKEN"` constant |
| `src/WopiHost.Core/Infrastructure/WopiHeaders.cs` | Add `HOST_NATIVE_FILE_NAME` (`X-WOPI-HostNativeFileName`) |
| `src/WopiHost.Core/Infrastructure/WopiDiagnostics.cs` (new) | `WOPIHOST001` diagnostic ID for `[Experimental]` |
| `src/WopiHost.Core/Controllers/FilesController.cs` | Fresh token in `GetEcosystem` |
| `src/WopiHost.Core/Controllers/ContainersController.cs` | Fresh token in `GetEcosystem` |
| `src/WopiHost.Core/Controllers/EcosystemController.cs` | `GetFileWopiSrc` stub |
| `test/WopiHost.Core.Tests/Controllers/FilesControllerTests.cs` | Token-trading assertions; mock token service |
| `test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs` | Same |
| `test/WopiHost.Core.Tests/Controllers/EcosystemControllerTests.cs` | `GetFileWopiSrc` 501 test |

## Test plan

- [x] `dotnet test test/WopiHost.Core.Tests` — 277 / 277 pass on net10.0 (3 new tests: token-trading on files, token-trading on containers, GetFileWopiSrc returns 501)
- [x] `dotnet test WOPI.slnx` — 460 / 460 pass on net10.0 across all projects
- [x] `dotnet build src/WopiHost.Core` — clean, 0 warnings, 0 errors with `TreatWarningsAsErrors`

## API surface notes

- **Constructor signatures unchanged.** Used `[FromServices]` on the action method so `FilesController` / `ContainersController` ctors are stable for any host that subclasses or instantiates them directly.
- **Action method signatures changed.** `GetEcosystem(string id, CancellationToken)` is now `GetEcosystem(string id, IWopiAccessTokenService, CancellationToken)`. ASP.NET resolves the new param from DI at request time. Direct callers (tests) need to pass the service.
- **`SupportsGetFileWopiSrc` capability flag is unchanged** (still defaults to `false`) — clients won't try to call the new stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)