### PR TITLE
feat(core): make WOPI bootstrapper spec-compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,64 @@ builder.Services.Configure<WopiHostOptions>(options =>
 });
 ```
 
+### Bootstrap endpoint (Office for mobile)
+
+WopiHost exposes two authentication surfaces, and they speak different protocols:
+
+| Endpoint | Authentication | Used by |
+|---|---|---|
+| `/wopi/*` | `access_token` query parameter (host-issued WOPI access token) | Office for the Web, Office desktop |
+| `/wopibootstrapper` | OAuth2 `Authorization: Bearer <token>` from your IdP | Office mobile (iOS / Android) |
+
+The bootstrap operation lets a mobile client exchange an OAuth2 token from your identity
+provider for the WOPI tokens it needs to drive the rest of the protocol. Wire it up in two
+steps:
+
+**1. Register the `WopiBootstrap` authentication scheme** (any handler that validates your IdP's tokens):
+
+```csharp
+services.AddAuthentication()
+    .AddJwtBearer(WopiAuthenticationSchemes.Bootstrap, options =>
+    {
+        options.Authority = "https://idp.contoso.com";
+        options.Audience = "wopi";
+
+        // Spec mandates a specific WWW-Authenticate header on 401 so the mobile client
+        // knows where to send the user for OAuth2 sign-in. WopiBootstrapChallenge formats
+        // that header for you.
+        options.Events = new JwtBearerEvents
+        {
+            OnChallenge = context =>
+            {
+                context.HandleResponse();
+                WopiBootstrapChallenge.Apply(
+                    context.Response,
+                    authorizationUri: new Uri("https://idp.contoso.com/oauth2/authorize"),
+                    tokenIssuanceUri: new Uri("https://idp.contoso.com/oauth2/token"),
+                    providerId: "tpcontoso");
+                return Task.CompletedTask;
+            },
+        };
+    });
+```
+
+**2. Make sure the principal carries the claims the bootstrapper needs.**
+At minimum: `ClaimTypes.NameIdentifier` (or `ClaimTypes.Upn` as fallback) for `UserId`,
+optionally `ClaimTypes.Email` for `SignInName`, and `ClaimTypes.Name` for
+`UserFriendlyName`. Most IdPs ship these by default.
+
+Once wired, the controller handles the three operations the spec defines:
+
+| Method + header | Behavior |
+|---|---|
+| `GET /wopibootstrapper` | Returns the bare `{ Bootstrap }` payload |
+| `POST /wopibootstrapper` with `X-WOPI-EcosystemOperation: GET_ROOT_CONTAINER` | Returns `{ Bootstrap, RootContainerInfo }` (with a per-container token + populated `ContainerInfo`) |
+| `POST /wopibootstrapper` with `X-WOPI-EcosystemOperation: GET_NEW_ACCESS_TOKEN` and `X-WOPI-WopiSrc: <files\|containers URL>` | Returns `{ Bootstrap, AccessTokenInfo }` (a fresh, real-permission WOPI access token bound to the resource) |
+
+Missing or malformed `X-WOPI-WopiSrc`, or a resource the user cannot access, returns
+`404 Not Found` per spec — the bootstrapper never issues a token for a resource it
+cannot validate.
+
 ## Package-Specific Documentation
 
 Each WopiHost package includes comprehensive documentation with:

--- a/src/WopiHost.Core/Controllers/WopiBootstrapperController.cs
+++ b/src/WopiHost.Core/Controllers/WopiBootstrapperController.cs
@@ -13,17 +13,27 @@ using WopiHost.Core.Security.Authentication;
 namespace WopiHost.Core.Controllers;
 
 /// <summary>
-/// Bootstrap operation per
-/// https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/bootstrapper/bootstrap.
+/// WOPI bootstrapper endpoint per
+/// <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/bootstrapper/bootstrap"/>.
 /// </summary>
 /// <remarks>
 /// <para>
 /// Unlike the regular <c>/wopi/*</c> endpoints (which authenticate via the
 /// <c>access_token</c> query parameter), the bootstrapper is called by Office mobile clients
-/// with an OAuth2 Bearer token from the host's identity provider. Configure that scheme as
-/// <see cref="WopiAuthenticationSchemes.Bootstrap"/> and supply the IdP discovery URLs via the
-/// <c>WWW-Authenticate</c> challenge.
+/// with an OAuth2 Bearer token from the host's identity provider. Configure the corresponding
+/// scheme as <see cref="WopiAuthenticationSchemes.Bootstrap"/>, and use
+/// <see cref="WopiBootstrapChallenge"/> to emit the spec-compliant <c>WWW-Authenticate</c>
+/// challenge from the scheme's challenge handler.
 /// </para>
+/// <para>
+/// Three operations share this single endpoint, dispatched by HTTP method and the
+/// <c>X-WOPI-EcosystemOperation</c> header:
+/// </para>
+/// <list type="bullet">
+///   <item><description><c>GET /wopibootstrapper</c> — bare <c>Bootstrap</c> per <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/bootstrapper/bootstrap"/></description></item>
+///   <item><description><c>POST /wopibootstrapper</c> with <c>X-WOPI-EcosystemOperation: GET_ROOT_CONTAINER</c> per <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/bootstrapper/getrootcontainer"/></description></item>
+///   <item><description><c>POST /wopibootstrapper</c> with <c>X-WOPI-EcosystemOperation: GET_NEW_ACCESS_TOKEN</c> per <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/bootstrapper/getnewaccesstoken"/></description></item>
+/// </list>
 /// </remarks>
 [Authorize(AuthenticationSchemes = WopiAuthenticationSchemes.Bootstrap)]
 [ApiController]
@@ -35,89 +45,195 @@ public class WopiBootstrapperController(
     IWopiPermissionProvider permissionProvider) : ControllerBase
 {
     /// <summary>
-    /// Bootstrap entry point.
+    /// Bootstrap operation. Returns the bare <see cref="BootstrapInfo"/> needed for the WOPI
+    /// client to discover the host's ecosystem endpoint and the current user.
+    /// </summary>
+    [HttpGet]
+    [Produces(MediaTypeNames.Application.Json)]
+    public async Task<IActionResult> Bootstrap(CancellationToken cancellationToken = default)
+    {
+        var bootstrap = await BuildBootstrapInfoAsync(cancellationToken);
+        return new JsonResult(new BootstrapRootContainerInfo { Bootstrap = bootstrap });
+    }
+
+    /// <summary>
+    /// Dispatches POST-based ecosystem operations exposed on the bootstrapper.
     /// </summary>
     [HttpPost]
     [Produces(MediaTypeNames.Application.Json)]
-    public async Task<IActionResult> GetRootContainer(
+    public async Task<IActionResult> ExecuteEcosystemOperation(
         [FromHeader(Name = WopiHeaders.ECOSYSTEM_OPERATION)] string? ecosystemOperation = null,
         [FromHeader(Name = WopiHeaders.WOPI_SRC)] string? wopiSrc = null,
         CancellationToken cancellationToken = default)
     {
-        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)
-            ?? User.FindFirstValue(ClaimTypes.Upn)
-            ?? throw new InvalidOperationException("Bootstrap principal lacks an identifier claim.");
-
-        var bootstrapRoot = new BootstrapRootContainerInfo
+        return ecosystemOperation switch
         {
-            Bootstrap = new BootstrapInfo
-            {
-                EcosystemUrl = Url.GetWopiSrc(WopiRouteNames.CheckEcosystem),
-                SignInName = User.FindFirstValue(ClaimTypes.Email) ?? string.Empty,
-                UserFriendlyName = User.FindFirstValue(ClaimTypes.Name) ?? string.Empty,
-                UserId = userId,
-            }
+            "GET_ROOT_CONTAINER" => await GetRootContainerAsync(cancellationToken),
+            "GET_NEW_ACCESS_TOKEN" => await GetNewAccessTokenAsync(wopiSrc, cancellationToken),
+            _ => new NotImplementedResult(),
         };
+    }
 
-        if (ecosystemOperation == "GET_ROOT_CONTAINER")
+    private async Task<IActionResult> GetRootContainerAsync(CancellationToken cancellationToken)
+    {
+        var bootstrap = await BuildBootstrapInfoAsync(cancellationToken);
+
+        var rootPointer = storageProvider.RootContainerPointer;
+        var rootContainer = await storageProvider.GetWopiResource<IWopiFolder>(rootPointer.Identifier, cancellationToken);
+        if (rootContainer is null)
         {
-            var rootContainer = storageProvider.RootContainerPointer;
-            var token = await IssueContainerTokenAsync(userId, rootContainer, cancellationToken);
-            bootstrapRoot.RootContainerInfo = new RootContainerInfo
+            return NotFound();
+        }
+
+        var token = await IssueContainerTokenAsync(rootContainer, cancellationToken);
+        return new JsonResult(new BootstrapRootContainerInfo
+        {
+            Bootstrap = bootstrap,
+            RootContainerInfo = new RootContainerInfo
             {
                 ContainerPointer = new ChildContainer(
                     rootContainer.Name,
-                    Url.GetWopiSrc(WopiResourceType.Container, rootContainer.Identifier, token.Token))
-            };
-        }
-        else if (ecosystemOperation == "GET_NEW_ACCESS_TOKEN")
+                    Url.GetWopiSrc(WopiResourceType.Container, rootContainer.Identifier, token.Token)),
+                ContainerInfo = await rootContainer.GetWopiCheckContainerInfo(HttpContext, cancellationToken),
+            },
+        });
+    }
+
+    private async Task<IActionResult> GetNewAccessTokenAsync(string? wopiSrc, CancellationToken cancellationToken)
+    {
+        // Spec (https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/bootstrapper/getnewaccesstoken#request-headers):
+        //   "if the X-WOPI-WopiSrc header is not present, the host should return a 404 Not Found"
+        if (string.IsNullOrEmpty(wopiSrc) || !TryParseWopiSrc(wopiSrc, out var resourceType, out var resourceId))
         {
-            ArgumentException.ThrowIfNullOrEmpty(wopiSrc);
-            var resourceId = GetIdFromUrl(wopiSrc);
+            return NotFound();
+        }
+
+        var bootstrap = await BuildBootstrapInfoAsync(cancellationToken);
+        WopiAccessToken token;
+
+        if (resourceType == WopiResourceType.File)
+        {
             var file = await storageProvider.GetWopiResource<IWopiFile>(resourceId, cancellationToken);
-            var token = await IssueFileTokenAsync(userId, resourceId, file, cancellationToken);
-            bootstrapRoot.AccessTokenInfo = new AccessTokenInfo
+            // Spec: "must only provide a WOPI access token if the requested WopiSrc exists
+            // and the user is authorized to access it."
+            if (file is null)
             {
-                AccessToken = token.Token,
-                AccessTokenExpiry = token.ExpiresAt.ToUnixTimeSeconds(),
-            };
+                return NotFound();
+            }
+            token = await IssueFileTokenAsync(file, cancellationToken);
         }
         else
         {
-            return new NotImplementedResult();
+            var container = await storageProvider.GetWopiResource<IWopiFolder>(resourceId, cancellationToken);
+            if (container is null)
+            {
+                return NotFound();
+            }
+            token = await IssueContainerTokenAsync(container, cancellationToken);
         }
-        return new JsonResult(bootstrapRoot);
+
+        return new JsonResult(new BootstrapRootContainerInfo
+        {
+            Bootstrap = bootstrap,
+            AccessTokenInfo = new AccessTokenInfo
+            {
+                AccessToken = token.Token,
+                AccessTokenExpiry = token.ExpiresAt.ToUnixTimeSeconds(),
+            },
+        });
     }
 
-    private async Task<WopiAccessToken> IssueFileTokenAsync(string userId, string resourceId, IWopiFile? file, CancellationToken cancellationToken)
+    private async Task<BootstrapInfo> BuildBootstrapInfoAsync(CancellationToken cancellationToken)
     {
-        var perms = file is null ? WopiFilePermissions.None : await permissionProvider.GetFilePermissionsAsync(User, file, cancellationToken);
-        return await accessTokenService.IssueAsync(BuildRequest(userId, resourceId, WopiResourceType.File) with { FilePermissions = perms }, cancellationToken);
+        var userId = GetUserIdOrThrow();
+        var root = storageProvider.RootContainerPointer;
+
+        // Per WOPI "preventing token trading" guidance, the access token embedded in
+        // EcosystemUrl must be a fresh, minimum-privilege token. CheckEcosystem has no
+        // resource gate, so we bind the token to the root container with no permissions.
+        var ecosystemToken = await accessTokenService.IssueAsync(new WopiAccessTokenRequest
+        {
+            UserId = userId,
+            UserDisplayName = User.FindFirstValue(ClaimTypes.Name),
+            UserEmail = User.FindFirstValue(ClaimTypes.Email),
+            ResourceId = root.Identifier,
+            ResourceType = WopiResourceType.Container,
+            ContainerPermissions = WopiContainerPermissions.None,
+        }, cancellationToken);
+
+        return new BootstrapInfo
+        {
+            EcosystemUrl = Url.GetWopiSrc(WopiRouteNames.CheckEcosystem, identifier: null, accessToken: ecosystemToken.Token),
+            UserId = userId,
+            SignInName = User.FindFirstValue(ClaimTypes.Email) ?? string.Empty,
+            UserFriendlyName = User.FindFirstValue(ClaimTypes.Name) ?? string.Empty,
+        };
     }
 
-    private async Task<WopiAccessToken> IssueContainerTokenAsync(string userId, IWopiFolder container, CancellationToken cancellationToken)
+    private async Task<WopiAccessToken> IssueFileTokenAsync(IWopiFile file, CancellationToken cancellationToken)
+    {
+        var perms = await permissionProvider.GetFilePermissionsAsync(User, file, cancellationToken);
+        return await accessTokenService.IssueAsync(BuildRequest(file.Identifier, WopiResourceType.File) with
+        {
+            FilePermissions = perms,
+        }, cancellationToken);
+    }
+
+    private async Task<WopiAccessToken> IssueContainerTokenAsync(IWopiFolder container, CancellationToken cancellationToken)
     {
         var perms = await permissionProvider.GetContainerPermissionsAsync(User, container, cancellationToken);
-        return await accessTokenService.IssueAsync(BuildRequest(userId, container.Identifier, WopiResourceType.Container) with { ContainerPermissions = perms }, cancellationToken);
+        return await accessTokenService.IssueAsync(BuildRequest(container.Identifier, WopiResourceType.Container) with
+        {
+            ContainerPermissions = perms,
+        }, cancellationToken);
     }
 
-    private WopiAccessTokenRequest BuildRequest(string userId, string resourceId, WopiResourceType resourceType) => new()
+    private WopiAccessTokenRequest BuildRequest(string resourceId, WopiResourceType resourceType) => new()
     {
-        UserId = userId,
+        UserId = GetUserIdOrThrow(),
         UserDisplayName = User.FindFirstValue(ClaimTypes.Name),
         UserEmail = User.FindFirstValue(ClaimTypes.Email),
         ResourceId = resourceId,
         ResourceType = resourceType,
     };
 
-    private static string GetIdFromUrl(string resourceUrl)
+    private string GetUserIdOrThrow() =>
+        User.FindFirstValue(ClaimTypes.NameIdentifier)
+        ?? User.FindFirstValue(ClaimTypes.Upn)
+        ?? throw new InvalidOperationException("Bootstrap principal lacks an identifier claim.");
+
+    /// <summary>
+    /// Parses the <c>X-WOPI-WopiSrc</c> header into a <see cref="WopiResourceType"/> and the
+    /// resource identifier. Accepts paths shaped like <c>/wopi/files/{id}</c> or
+    /// <c>/wopi/containers/{id}</c>.
+    /// </summary>
+    internal static bool TryParseWopiSrc(string wopiSrc, out WopiResourceType resourceType, out string resourceId)
     {
-        var resourceId = resourceUrl[(resourceUrl.LastIndexOf('/') + 1)..];
-        var queryIndex = resourceId.IndexOf('?');
-        if (queryIndex > -1)
+        resourceType = default;
+        resourceId = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(wopiSrc) ||
+            !Uri.TryCreate(wopiSrc, UriKind.Absolute, out var uri))
         {
-            resourceId = resourceId[..queryIndex];
+            return false;
         }
-        return Uri.UnescapeDataString(resourceId);
+
+        var segments = uri.AbsolutePath.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        for (var i = 0; i < segments.Length - 1; i++)
+        {
+            if (segments[i].Equals("files", StringComparison.OrdinalIgnoreCase))
+            {
+                resourceType = WopiResourceType.File;
+                resourceId = Uri.UnescapeDataString(segments[i + 1]);
+                return true;
+            }
+            if (segments[i].Equals("containers", StringComparison.OrdinalIgnoreCase))
+            {
+                resourceType = WopiResourceType.Container;
+                resourceId = Uri.UnescapeDataString(segments[i + 1]);
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/WopiHost.Core/Models/BootstrapRootContainerInfo.cs
+++ b/src/WopiHost.Core/Models/BootstrapRootContainerInfo.cs
@@ -1,22 +1,36 @@
-﻿namespace WopiHost.Core.Models;
+using System.Text.Json.Serialization;
+
+namespace WopiHost.Core.Models;
 
 /// <summary>
-/// Implemented in accordance with: https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/bootstrapper/getrootcontainer#sample-response
+/// Response shape for the WOPI bootstrapper. Spec sample responses:
+/// <list type="bullet">
+///   <item><description><see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/bootstrapper/bootstrap#sample-response"/> — bare <c>Bootstrap</c></description></item>
+///   <item><description><see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/bootstrapper/getrootcontainer#sample-response"/> — <c>Bootstrap</c> + <c>RootContainerInfo</c></description></item>
+///   <item><description><see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/bootstrapper/getnewaccesstoken#sample-response"/> — <c>Bootstrap</c> + <c>AccessTokenInfo</c></description></item>
+/// </list>
 /// </summary>
+/// <remarks>
+/// The two operation-specific properties are skipped from the serialized JSON when null so
+/// the <c>GET /wopibootstrapper</c> response is the bare <c>{ "Bootstrap": {...} }</c> the
+/// spec calls for, rather than emitting <c>"RootContainerInfo": null</c>.
+/// </remarks>
 public class BootstrapRootContainerInfo
 {
-	/// <summary>
-	/// Object describing the root container.
-	/// </summary>
-	public RootContainerInfo? RootContainerInfo { get; set; }
+    /// <summary>
+    /// Object describing the root container. Populated for <c>GET_ROOT_CONTAINER</c> only.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public RootContainerInfo? RootContainerInfo { get; set; }
 
-	/// <summary>
-	/// Object with properties necessary for calling the /bootstrap operation.
-	/// </summary>
-	public BootstrapInfo? Bootstrap { get; set; }
+    /// <summary>
+    /// Object with properties necessary for the bootstrap exchange.
+    /// </summary>
+    public BootstrapInfo? Bootstrap { get; set; }
 
-	/// <summary>
-	/// A WOPI access token.
-	/// </summary>
-	public AccessTokenInfo? AccessTokenInfo { get; set; }
+    /// <summary>
+    /// A WOPI access token. Populated for <c>GET_NEW_ACCESS_TOKEN</c> only.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public AccessTokenInfo? AccessTokenInfo { get; set; }
 }

--- a/src/WopiHost.Core/Security/Authentication/WopiBootstrapChallenge.cs
+++ b/src/WopiHost.Core/Security/Authentication/WopiBootstrapChallenge.cs
@@ -1,0 +1,127 @@
+using System.Text;
+using Microsoft.AspNetCore.Http;
+
+namespace WopiHost.Core.Security.Authentication;
+
+/// <summary>
+/// Builds the <c>WWW-Authenticate</c> header value the WOPI bootstrap spec requires on a
+/// <c>401 Unauthorized</c> response from <c>/wopibootstrapper</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The bootstrapper authenticates using OAuth2 Bearer tokens from the host's identity
+/// provider. When the token is missing or invalid, the spec mandates a specific
+/// <c>WWW-Authenticate</c> challenge that points the WOPI client at the host's IdP.
+/// Hosts wire this into their authentication scheme — typically as a <c>JwtBearerEvents.OnChallenge</c>
+/// handler:
+/// </para>
+/// <code>
+/// services.AddAuthentication()
+///     .AddJwtBearer(WopiAuthenticationSchemes.Bootstrap, options =&gt;
+///     {
+///         options.Authority = "https://idp.contoso.com";
+///         options.Events = new JwtBearerEvents
+///         {
+///             OnChallenge = context =&gt;
+///             {
+///                 var header = WopiBootstrapChallenge.Build(
+///                     authorizationUri: new Uri("https://idp.contoso.com/oauth2/authorize"),
+///                     tokenIssuanceUri: new Uri("https://idp.contoso.com/oauth2/token"),
+///                     providerId: "tp_contoso");
+///                 context.Response.Headers.Append("WWW-Authenticate", header);
+///                 context.HandleResponse();
+///                 context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+///                 return Task.CompletedTask;
+///             }
+///         };
+///     });
+/// </code>
+/// <para>
+/// Spec: <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/bootstrapper/bootstrap#www-authenticate-response-header-format"/>.
+/// </para>
+/// </remarks>
+public static class WopiBootstrapChallenge
+{
+    /// <summary>
+    /// Builds the spec-compliant <c>WWW-Authenticate</c> header value.
+    /// </summary>
+    /// <param name="authorizationUri">The OAuth2 authorization endpoint URL.</param>
+    /// <param name="tokenIssuanceUri">The OAuth2 token endpoint URL.</param>
+    /// <param name="providerId">
+    /// Optional well-known identifier (registered with Microsoft 365) for the host.
+    /// Per spec, allowed characters are <c>[a-zA-Z0-9]</c>.
+    /// </param>
+    /// <param name="urlSchemes">
+    /// Optional URL-encoded JSON document mapping platforms to their URL schemes, e.g.
+    /// <c>{"iOS":["contoso"], "Android":["contoso"]}</c>. The string passed in must already
+    /// be URL-encoded as the spec requires; this method does not encode it.
+    /// </param>
+    public static string Build(
+        Uri authorizationUri,
+        Uri tokenIssuanceUri,
+        string? providerId = null,
+        string? urlSchemes = null)
+    {
+        ArgumentNullException.ThrowIfNull(authorizationUri);
+        ArgumentNullException.ThrowIfNull(tokenIssuanceUri);
+
+        if (!string.IsNullOrEmpty(providerId) && !IsValidProviderId(providerId))
+        {
+            throw new ArgumentException(
+                "providerId must contain only ASCII letters and digits per the WOPI spec.",
+                nameof(providerId));
+        }
+
+        var sb = new StringBuilder("Bearer ");
+        AppendParameter(sb, "authorization_uri", authorizationUri.AbsoluteUri, first: true);
+        AppendParameter(sb, "tokenIssuance_uri", tokenIssuanceUri.AbsoluteUri, first: false);
+        if (!string.IsNullOrEmpty(providerId))
+        {
+            AppendParameter(sb, "providerId", providerId, first: false);
+        }
+        if (!string.IsNullOrEmpty(urlSchemes))
+        {
+            AppendParameter(sb, "UrlSchemes", urlSchemes, first: false);
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Convenience: build the header value and append it to <paramref name="response"/>.
+    /// Sets the status code to <c>401</c>; callers can override afterwards if needed.
+    /// </summary>
+    public static void Apply(
+        HttpResponse response,
+        Uri authorizationUri,
+        Uri tokenIssuanceUri,
+        string? providerId = null,
+        string? urlSchemes = null)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+        response.StatusCode = StatusCodes.Status401Unauthorized;
+        response.Headers.Append(
+            "WWW-Authenticate",
+            Build(authorizationUri, tokenIssuanceUri, providerId, urlSchemes));
+    }
+
+    private static void AppendParameter(StringBuilder sb, string name, string value, bool first)
+    {
+        if (!first)
+        {
+            sb.Append(", ");
+        }
+        sb.Append(name).Append("=\"").Append(value).Append('"');
+    }
+
+    private static bool IsValidProviderId(string value)
+    {
+        foreach (var ch in value)
+        {
+            if (!char.IsAsciiLetterOrDigit(ch))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/test/WopiHost.Core.Tests/Controllers/WopiBootstrapperControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/WopiBootstrapperControllerTests.cs
@@ -1,8 +1,10 @@
 using System.Security.Claims;
+using System.Text.Json;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Routing;
 using Moq;
 using WopiHost.Abstractions;
 using WopiHost.Core.Controllers;
@@ -17,12 +19,16 @@ public class WopiBootstrapperControllerTests
     private readonly Mock<IWopiAccessTokenService> _tokens = new();
     private readonly Mock<IWopiPermissionProvider> _permissions = new();
     private readonly Mock<IWopiFolder> _rootFolder = new();
+    private readonly Mock<IUrlHelper> _url = new();
 
     public WopiBootstrapperControllerTests()
     {
         _rootFolder.SetupGet(f => f.Identifier).Returns("root-id");
         _rootFolder.SetupGet(f => f.Name).Returns("Root");
         _storage.SetupGet(s => s.RootContainerPointer).Returns(_rootFolder.Object);
+        _storage
+            .Setup(s => s.GetWopiResource<IWopiFolder>("root-id", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_rootFolder.Object);
 
         _permissions
             .Setup(p => p.GetFilePermissionsAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<IWopiFile>(), It.IsAny<CancellationToken>()))
@@ -30,21 +36,26 @@ public class WopiBootstrapperControllerTests
         _permissions
             .Setup(p => p.GetContainerPermissionsAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<IWopiFolder>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(WopiContainerPermissions.UserCanCreateChildFile);
+
+        // Default token issuance returns a deterministic value so tests can spot the
+        // difference between "fresh" tokens and any inbound state.
+        _tokens
+            .Setup(t => t.IssueAsync(It.IsAny<WopiAccessTokenRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WopiAccessToken("FRESH-TOKEN", DateTimeOffset.UtcNow.AddMinutes(10)));
     }
 
     private WopiBootstrapperController BuildController(ClaimsPrincipal? user = null)
     {
-        var url = new Mock<IUrlHelper>();
-        url.Setup(u => u.RouteUrl(It.IsAny<UrlRouteContext>())).Returns("https://wopi.example.com/wopi/anything");
-        var serviceScope = TestUtils.CreateServiceScope(new Mock<IAuthenticationService>().Object);
-        url.Setup(u => u.ActionContext).Returns(new ActionContext
+        _url.Setup(u => u.RouteUrl(It.IsAny<UrlRouteContext>())).Returns("https://wopi.example.com/wopi/anything");
+        var serviceScope = TestUtils.CreateServiceScope(_permissions.Object, new Mock<IAuthenticationService>().Object);
+        _url.Setup(u => u.ActionContext).Returns(new ActionContext
         {
             HttpContext = new DefaultHttpContext { ServiceScopeFactory = serviceScope }
         });
 
         return new WopiBootstrapperController(_storage.Object, _tokens.Object, _permissions.Object)
         {
-            Url = url.Object,
+            Url = _url.Object,
             ControllerContext = new ControllerContext
             {
                 HttpContext = new DefaultHttpContext
@@ -63,92 +74,257 @@ public class WopiBootstrapperControllerTests
         new Claim(ClaimTypes.Email, "alice@example.com"),
     ], "bootstrap"));
 
-    [Fact]
-    public async Task GetRootContainer_ReturnsRootContainerInfo()
-    {
-        _tokens
-            .Setup(t => t.IssueAsync(It.IsAny<WopiAccessTokenRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new WopiAccessToken("ROOT-TOKEN", DateTimeOffset.UtcNow.AddMinutes(10)));
+    // ---- Bootstrap (GET /wopibootstrapper) ---------------------------------------------------
 
-        var result = await BuildController().GetRootContainer(ecosystemOperation: "GET_ROOT_CONTAINER");
+    [Fact]
+    public async Task Bootstrap_GET_ReturnsBareBootstrapInfo()
+    {
+        var result = await BuildController().Bootstrap();
 
         var json = Assert.IsType<JsonResult>(result);
         var info = Assert.IsType<BootstrapRootContainerInfo>(json.Value);
-        Assert.NotNull(info.RootContainerInfo);
-        Assert.Equal("Root", info.RootContainerInfo!.ContainerPointer.Name);
-        Assert.Equal("alice", info.Bootstrap?.UserId);
-        Assert.Equal("Alice Example", info.Bootstrap?.UserFriendlyName);
-        Assert.Equal("alice@example.com", info.Bootstrap?.SignInName);
-
-        _tokens.Verify(t => t.IssueAsync(
-            It.Is<WopiAccessTokenRequest>(r =>
-                r.UserId == "alice" &&
-                r.ResourceId == "root-id" &&
-                r.ResourceType == WopiResourceType.Container &&
-                r.ContainerPermissions == WopiContainerPermissions.UserCanCreateChildFile),
-            It.IsAny<CancellationToken>()), Times.Once);
+        Assert.NotNull(info.Bootstrap);
+        Assert.Null(info.RootContainerInfo);
+        Assert.Null(info.AccessTokenInfo);
+        Assert.Equal("alice", info.Bootstrap!.UserId);
+        Assert.Equal("alice@example.com", info.Bootstrap.SignInName);
+        Assert.Equal("Alice Example", info.Bootstrap.UserFriendlyName);
     }
 
     [Fact]
-    public async Task GetNewAccessToken_ReturnsAccessTokenInfo_WithFilePermissionsBaked()
+    public async Task Bootstrap_GET_SerializesWithoutOptionalProperties()
+    {
+        // Spec sample: GET response is { "Bootstrap": {...} } only — no RootContainerInfo,
+        // no AccessTokenInfo. Verify the wire format honors that via JsonIgnore(WhenWritingNull).
+        var result = await BuildController().Bootstrap();
+        var json = Assert.IsType<JsonResult>(result);
+
+        var serialized = JsonSerializer.Serialize(json.Value);
+
+        Assert.Contains("\"Bootstrap\"", serialized);
+        Assert.DoesNotContain("RootContainerInfo", serialized);
+        Assert.DoesNotContain("AccessTokenInfo", serialized);
+    }
+
+    // ---- EcosystemUrl token-trading prevention ----------------------------------------------
+
+    [Fact]
+    public async Task BootstrapInfo_EcosystemUrl_CarriesFreshMinimumPrivilegeToken()
+    {
+        // Per WOPI "preventing token trading" guidance, the access token embedded in
+        // EcosystemUrl must be fresh and minimum-privilege. CheckEcosystem has no resource
+        // gate, so the token is bound to the root container with WopiContainerPermissions.None.
+        var capturedRequests = new List<WopiAccessTokenRequest>();
+        _tokens
+            .Setup(t => t.IssueAsync(It.IsAny<WopiAccessTokenRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<WopiAccessTokenRequest, CancellationToken>((req, _) => capturedRequests.Add(req))
+            .ReturnsAsync(new WopiAccessToken("ECOSYSTEM-TOKEN", DateTimeOffset.UtcNow.AddMinutes(10)));
+
+        await BuildController().Bootstrap();
+
+        var ecosystemRequest = Assert.Single(capturedRequests);
+        Assert.Equal("alice", ecosystemRequest.UserId);
+        Assert.Equal("root-id", ecosystemRequest.ResourceId);
+        Assert.Equal(WopiResourceType.Container, ecosystemRequest.ResourceType);
+        Assert.Equal(WopiContainerPermissions.None, ecosystemRequest.ContainerPermissions);
+    }
+
+    // ---- GET_ROOT_CONTAINER (POST) ----------------------------------------------------------
+
+    [Fact]
+    public async Task ExecuteEcosystemOperation_GET_ROOT_CONTAINER_ReturnsBootstrapAndRootContainerInfo()
+    {
+        var result = await BuildController().ExecuteEcosystemOperation(ecosystemOperation: "GET_ROOT_CONTAINER");
+
+        var json = Assert.IsType<JsonResult>(result);
+        var info = Assert.IsType<BootstrapRootContainerInfo>(json.Value);
+        Assert.NotNull(info.Bootstrap);
+        Assert.NotNull(info.RootContainerInfo);
+        Assert.Null(info.AccessTokenInfo);
+        Assert.Equal("Root", info.RootContainerInfo!.ContainerPointer.Name);
+        Assert.NotNull(info.RootContainerInfo.ContainerInfo);
+        Assert.Equal("Root", info.RootContainerInfo.ContainerInfo!.Name);
+    }
+
+    [Fact]
+    public async Task ExecuteEcosystemOperation_GET_ROOT_CONTAINER_ReturnsNotFound_WhenRootMissing()
+    {
+        _storage
+            .Setup(s => s.GetWopiResource<IWopiFolder>("root-id", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IWopiFolder?)null);
+
+        var result = await BuildController().ExecuteEcosystemOperation(ecosystemOperation: "GET_ROOT_CONTAINER");
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task ExecuteEcosystemOperation_GET_ROOT_CONTAINER_BindsContainerToken_WithRealPermissions()
+    {
+        var capturedRequests = new List<WopiAccessTokenRequest>();
+        _tokens
+            .Setup(t => t.IssueAsync(It.IsAny<WopiAccessTokenRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<WopiAccessTokenRequest, CancellationToken>((req, _) => capturedRequests.Add(req))
+            .ReturnsAsync(new WopiAccessToken("T", DateTimeOffset.UtcNow));
+
+        await BuildController().ExecuteEcosystemOperation(ecosystemOperation: "GET_ROOT_CONTAINER");
+
+        // The bootstrap shell issues a None-perms token; the root container response then
+        // issues a *separate* token with the user's real container permissions.
+        Assert.Equal(2, capturedRequests.Count);
+        var rootContainerToken = capturedRequests.Last();
+        Assert.Equal("root-id", rootContainerToken.ResourceId);
+        Assert.Equal(WopiResourceType.Container, rootContainerToken.ResourceType);
+        Assert.Equal(WopiContainerPermissions.UserCanCreateChildFile, rootContainerToken.ContainerPermissions);
+    }
+
+    // ---- GET_NEW_ACCESS_TOKEN (POST) --------------------------------------------------------
+
+    [Fact]
+    public async Task ExecuteEcosystemOperation_GET_NEW_ACCESS_TOKEN_File_ReturnsAccessTokenInfo()
     {
         var file = new Mock<IWopiFile>();
         file.SetupGet(f => f.Identifier).Returns("file-99");
         _storage.Setup(s => s.GetWopiResource<IWopiFile>("file-99", It.IsAny<CancellationToken>())).ReturnsAsync(file.Object);
 
         var expires = DateTimeOffset.UtcNow.AddMinutes(10);
+        var capturedRequests = new List<WopiAccessTokenRequest>();
         _tokens
             .Setup(t => t.IssueAsync(It.IsAny<WopiAccessTokenRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new WopiAccessToken("FILE-TOKEN", expires));
+            .Callback<WopiAccessTokenRequest, CancellationToken>((req, _) => capturedRequests.Add(req))
+            .ReturnsAsync((WopiAccessTokenRequest req, CancellationToken _) =>
+                req.ResourceType == WopiResourceType.File
+                    ? new WopiAccessToken("FILE-TOKEN", expires)
+                    : new WopiAccessToken("ECOSYSTEM-TOKEN", expires));
 
-        var result = await BuildController().GetRootContainer(
+        var result = await BuildController().ExecuteEcosystemOperation(
             ecosystemOperation: "GET_NEW_ACCESS_TOKEN",
             wopiSrc: "https://wopi.example.com/wopi/files/file-99");
 
-        var json = Assert.IsType<JsonResult>(result);
-        var info = Assert.IsType<BootstrapRootContainerInfo>(json.Value);
+        var info = Assert.IsType<BootstrapRootContainerInfo>(((JsonResult)result).Value);
         Assert.Equal("FILE-TOKEN", info.AccessTokenInfo?.AccessToken);
         Assert.Equal(expires.ToUnixTimeSeconds(), info.AccessTokenInfo?.AccessTokenExpiry);
+        Assert.Null(info.RootContainerInfo);
 
-        _tokens.Verify(t => t.IssueAsync(
-            It.Is<WopiAccessTokenRequest>(r =>
-                r.ResourceId == "file-99" &&
-                r.ResourceType == WopiResourceType.File &&
-                r.FilePermissions == WopiFilePermissions.UserCanWrite),
-            It.IsAny<CancellationToken>()), Times.Once);
+        // Verify a file token was issued with real permissions baked in.
+        var fileTokenReq = Assert.Single(capturedRequests, r => r.ResourceType == WopiResourceType.File);
+        Assert.Equal("file-99", fileTokenReq.ResourceId);
+        Assert.Equal(WopiFilePermissions.UserCanWrite, fileTokenReq.FilePermissions);
     }
 
     [Fact]
-    public async Task GetNewAccessToken_StripsQueryAndDecodesIdFromWopiSrc()
+    public async Task ExecuteEcosystemOperation_GET_NEW_ACCESS_TOKEN_Container_ReturnsAccessTokenInfo()
     {
-        _storage.Setup(s => s.GetWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(Mock.Of<IWopiFile>());
+        var folder = new Mock<IWopiFolder>();
+        folder.SetupGet(f => f.Identifier).Returns("container-7");
+        _storage.Setup(s => s.GetWopiResource<IWopiFolder>("container-7", It.IsAny<CancellationToken>())).ReturnsAsync(folder.Object);
+
+        var capturedRequests = new List<WopiAccessTokenRequest>();
         _tokens
             .Setup(t => t.IssueAsync(It.IsAny<WopiAccessTokenRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<WopiAccessTokenRequest, CancellationToken>((req, _) => capturedRequests.Add(req))
             .ReturnsAsync(new WopiAccessToken("T", DateTimeOffset.UtcNow));
 
-        await BuildController().GetRootContainer(
+        var result = await BuildController().ExecuteEcosystemOperation(
+            ecosystemOperation: "GET_NEW_ACCESS_TOKEN",
+            wopiSrc: "https://wopi.example.com/wopi/containers/container-7");
+
+        var info = Assert.IsType<BootstrapRootContainerInfo>(((JsonResult)result).Value);
+        Assert.NotNull(info.AccessTokenInfo);
+
+        // Container-bound token with real container permissions.
+        var containerReq = Assert.Single(capturedRequests, r => r.ResourceType == WopiResourceType.Container && r.ResourceId == "container-7");
+        Assert.Equal(WopiContainerPermissions.UserCanCreateChildFile, containerReq.ContainerPermissions);
+    }
+
+    [Fact]
+    public async Task ExecuteEcosystemOperation_GET_NEW_ACCESS_TOKEN_StripsQueryAndDecodesIdFromWopiSrc()
+    {
+        _storage.Setup(s => s.GetWopiResource<IWopiFile>("some file", It.IsAny<CancellationToken>())).ReturnsAsync(Mock.Of<IWopiFile>());
+
+        var result = await BuildController().ExecuteEcosystemOperation(
             ecosystemOperation: "GET_NEW_ACCESS_TOKEN",
             wopiSrc: "https://wopi.example.com/wopi/files/some%20file?access_token=ignored");
 
+        Assert.IsType<JsonResult>(result);
+        _storage.Verify(s => s.GetWopiResource<IWopiFile>("some file", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteEcosystemOperation_GET_NEW_ACCESS_TOKEN_ReturnsNotFound_WhenWopiSrcMissing()
+    {
+        // Spec: "if the X-WOPI-WopiSrc header is not present, the host should return a 404 Not Found"
+        var result = await BuildController().ExecuteEcosystemOperation(ecosystemOperation: "GET_NEW_ACCESS_TOKEN", wopiSrc: null);
+
+        Assert.IsType<NotFoundResult>(result);
+        _tokens.Verify(t => t.IssueAsync(It.IsAny<WopiAccessTokenRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteEcosystemOperation_GET_NEW_ACCESS_TOKEN_ReturnsNotFound_WhenWopiSrcIsMalformed()
+    {
+        // Not a /wopi/files/{id} or /wopi/containers/{id} URL.
+        var result = await BuildController().ExecuteEcosystemOperation(
+            ecosystemOperation: "GET_NEW_ACCESS_TOKEN",
+            wopiSrc: "https://wopi.example.com/elsewhere/file");
+
+        Assert.IsType<NotFoundResult>(result);
+        _tokens.Verify(t => t.IssueAsync(It.IsAny<WopiAccessTokenRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteEcosystemOperation_GET_NEW_ACCESS_TOKEN_ReturnsNotFound_WhenFileMissing()
+    {
+        // Spec: "must only provide a WOPI access token if the requested WopiSrc exists"
+        _storage
+            .Setup(s => s.GetWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IWopiFile?)null);
+
+        var result = await BuildController().ExecuteEcosystemOperation(
+            ecosystemOperation: "GET_NEW_ACCESS_TOKEN",
+            wopiSrc: "https://wopi.example.com/wopi/files/missing");
+
+        Assert.IsType<NotFoundResult>(result);
+        // The bootstrap-shell ecosystem token may have been issued before we discover
+        // the missing resource — assert no FILE token was issued.
         _tokens.Verify(t => t.IssueAsync(
-            It.Is<WopiAccessTokenRequest>(r => r.ResourceId == "some file"),
-            It.IsAny<CancellationToken>()), Times.Once);
+            It.Is<WopiAccessTokenRequest>(r => r.ResourceType == WopiResourceType.File),
+            It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public async Task GetNewAccessToken_RequiresWopiSrcHeader()
+    public async Task ExecuteEcosystemOperation_GET_NEW_ACCESS_TOKEN_ReturnsNotFound_WhenContainerMissing()
     {
-        await Assert.ThrowsAnyAsync<ArgumentException>(() =>
-            BuildController().GetRootContainer(ecosystemOperation: "GET_NEW_ACCESS_TOKEN", wopiSrc: null));
+        _storage
+            .Setup(s => s.GetWopiResource<IWopiFolder>("missing", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IWopiFolder?)null);
+
+        var result = await BuildController().ExecuteEcosystemOperation(
+            ecosystemOperation: "GET_NEW_ACCESS_TOKEN",
+            wopiSrc: "https://wopi.example.com/wopi/containers/missing");
+
+        Assert.IsType<NotFoundResult>(result);
     }
 
+    // ---- Unknown / missing operation --------------------------------------------------------
+
     [Fact]
-    public async Task UnknownEcosystemOperation_ReturnsNotImplemented()
+    public async Task ExecuteEcosystemOperation_UnknownOperation_ReturnsNotImplemented()
     {
-        var result = await BuildController().GetRootContainer(ecosystemOperation: "SOMETHING_ELSE");
+        var result = await BuildController().ExecuteEcosystemOperation(ecosystemOperation: "SOMETHING_ELSE");
 
         Assert.IsType<NotImplementedResult>(result);
     }
+
+    [Fact]
+    public async Task ExecuteEcosystemOperation_NoOperationHeader_ReturnsNotImplemented()
+    {
+        var result = await BuildController().ExecuteEcosystemOperation(ecosystemOperation: null);
+
+        Assert.IsType<NotImplementedResult>(result);
+    }
+
+    // ---- Principal claim handling -----------------------------------------------------------
 
     [Fact]
     public async Task PrincipalWithoutNameIdentifier_FallsBackToUpnClaim()
@@ -157,14 +333,10 @@ public class WopiBootstrapperControllerTests
         [
             new Claim(ClaimTypes.Upn, "upn-user"),
         ], "bootstrap"));
-        _tokens
-            .Setup(t => t.IssueAsync(It.IsAny<WopiAccessTokenRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new WopiAccessToken("T", DateTimeOffset.UtcNow));
 
-        var result = await BuildController(user).GetRootContainer(ecosystemOperation: "GET_ROOT_CONTAINER");
+        var result = await BuildController(user).ExecuteEcosystemOperation(ecosystemOperation: "GET_ROOT_CONTAINER");
 
-        var json = Assert.IsType<JsonResult>(result);
-        var info = Assert.IsType<BootstrapRootContainerInfo>(json.Value);
+        var info = Assert.IsType<BootstrapRootContainerInfo>(((JsonResult)result).Value);
         Assert.Equal("upn-user", info.Bootstrap?.UserId);
     }
 
@@ -174,31 +346,36 @@ public class WopiBootstrapperControllerTests
         var user = new ClaimsPrincipal(new ClaimsIdentity("bootstrap"));
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            BuildController(user).GetRootContainer(ecosystemOperation: "GET_ROOT_CONTAINER"));
+            BuildController(user).ExecuteEcosystemOperation(ecosystemOperation: "GET_ROOT_CONTAINER"));
     }
 
-    [Fact]
-    public async Task GetNewAccessToken_With_Unknown_File_Issues_Token_Without_Permissions()
+    // ---- TryParseWopiSrc edge cases ---------------------------------------------------------
+
+    [Theory]
+    [InlineData("https://wopi.example.com/wopi/files/abc", WopiResourceType.File, "abc")]
+    [InlineData("https://wopi.example.com/wopi/containers/abc", WopiResourceType.Container, "abc")]
+    [InlineData("https://wopi.example.com/wopi/files/abc?access_token=t", WopiResourceType.File, "abc")]
+    [InlineData("https://wopi.example.com/wopi/files/some%20file", WopiResourceType.File, "some file")]
+    [InlineData("https://wopi.example.com/some/wopi/Files/CASE_INSENSITIVE", WopiResourceType.File, "CASE_INSENSITIVE")]
+    public void TryParseWopiSrc_ValidUrls(string url, WopiResourceType expectedType, string expectedId)
     {
-        // Storage returns null when the wopiSrc resource doesn't exist; the helper still
-        // issues a token (with WopiFilePermissions.None) so the WOPI client can call back
-        // through the regular endpoints and get a proper 404.
-        _storage
-            .Setup(s => s.GetWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((IWopiFile?)null);
-        _tokens
-            .Setup(t => t.IssueAsync(It.IsAny<WopiAccessTokenRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new WopiAccessToken("T", DateTimeOffset.UtcNow));
+        var ok = WopiBootstrapperController.TryParseWopiSrc(url, out var type, out var id);
 
-        var result = await BuildController().GetRootContainer(
-            ecosystemOperation: "GET_NEW_ACCESS_TOKEN",
-            wopiSrc: "https://wopi.example.com/wopi/files/missing");
+        Assert.True(ok);
+        Assert.Equal(expectedType, type);
+        Assert.Equal(expectedId, id);
+    }
 
-        Assert.IsType<JsonResult>(result);
-        _tokens.Verify(t => t.IssueAsync(
-            It.Is<WopiAccessTokenRequest>(r =>
-                r.ResourceId == "missing" &&
-                r.FilePermissions == WopiFilePermissions.None),
-            It.IsAny<CancellationToken>()), Times.Once);
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-url")]
+    [InlineData("https://wopi.example.com/elsewhere/abc")]
+    [InlineData("https://wopi.example.com/wopi/files/")] // missing id
+    [InlineData("https://wopi.example.com/wopi/files")] // missing id segment entirely
+    public void TryParseWopiSrc_RejectsInvalidUrls(string url)
+    {
+        var ok = WopiBootstrapperController.TryParseWopiSrc(url, out _, out _);
+
+        Assert.False(ok);
     }
 }

--- a/test/WopiHost.Core.Tests/Security/Authentication/WopiBootstrapChallengeTests.cs
+++ b/test/WopiHost.Core.Tests/Security/Authentication/WopiBootstrapChallengeTests.cs
@@ -1,0 +1,112 @@
+using Microsoft.AspNetCore.Http;
+using WopiHost.Core.Security.Authentication;
+
+namespace WopiHost.Core.Tests.Security.Authentication;
+
+public class WopiBootstrapChallengeTests
+{
+    private static readonly Uri AuthUri = new("https://idp.contoso.com/oauth2/authorize");
+    private static readonly Uri TokenUri = new("https://idp.contoso.com/oauth2/token");
+
+    [Fact]
+    public void Build_RequiredParametersOnly_EmitsBearerWithBothUris()
+    {
+        var header = WopiBootstrapChallenge.Build(AuthUri, TokenUri);
+
+        Assert.Equal(
+            "Bearer authorization_uri=\"https://idp.contoso.com/oauth2/authorize\", tokenIssuance_uri=\"https://idp.contoso.com/oauth2/token\"",
+            header);
+    }
+
+    [Fact]
+    public void Build_WithProviderId_AppendsParameter()
+    {
+        var header = WopiBootstrapChallenge.Build(AuthUri, TokenUri, providerId: "tpcontoso");
+
+        Assert.EndsWith(", providerId=\"tpcontoso\"", header);
+    }
+
+    [Fact]
+    public void Build_WithUrlSchemes_AppendsAlreadyEncodedValueVerbatim()
+    {
+        // Spec: hosts pre-URL-encode the JSON. The helper must not re-encode.
+        var encoded = "%7B%22iOS%22%3A%5B%22contoso%22%5D%7D";
+        var header = WopiBootstrapChallenge.Build(AuthUri, TokenUri, urlSchemes: encoded);
+
+        Assert.EndsWith($", UrlSchemes=\"{encoded}\"", header);
+    }
+
+    [Fact]
+    public void Build_AllParameters_EmitsThemInSpecOrder()
+    {
+        var header = WopiBootstrapChallenge.Build(
+            AuthUri,
+            TokenUri,
+            providerId: "tpcontoso",
+            urlSchemes: "abc");
+
+        Assert.Equal(
+            "Bearer authorization_uri=\"https://idp.contoso.com/oauth2/authorize\", tokenIssuance_uri=\"https://idp.contoso.com/oauth2/token\", providerId=\"tpcontoso\", UrlSchemes=\"abc\"",
+            header);
+    }
+
+    [Theory]
+    [InlineData("has space")]
+    [InlineData("with-hyphen")]
+    [InlineData("with_underscore")]
+    [InlineData("punct.")]
+    [InlineData("emoji😀")]
+    public void Build_InvalidProviderId_Throws(string providerId)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            WopiBootstrapChallenge.Build(AuthUri, TokenUri, providerId: providerId));
+    }
+
+    [Theory]
+    [InlineData("contoso")]
+    [InlineData("Contoso")]
+    [InlineData("Tp123")]
+    [InlineData("ABCXYZ")]
+    public void Build_ValidProviderId_Accepted(string providerId)
+    {
+        var ex = Record.Exception(() => WopiBootstrapChallenge.Build(AuthUri, TokenUri, providerId: providerId));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Build_NullAuthorizationUri_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            WopiBootstrapChallenge.Build(authorizationUri: null!, tokenIssuanceUri: TokenUri));
+    }
+
+    [Fact]
+    public void Build_NullTokenIssuanceUri_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            WopiBootstrapChallenge.Build(authorizationUri: AuthUri, tokenIssuanceUri: null!));
+    }
+
+    [Fact]
+    public void Apply_Sets401AndAppendsHeader()
+    {
+        var ctx = new DefaultHttpContext();
+
+        WopiBootstrapChallenge.Apply(ctx.Response, AuthUri, TokenUri, providerId: "tpcontoso");
+
+        Assert.Equal(StatusCodes.Status401Unauthorized, ctx.Response.StatusCode);
+        var header = Assert.Single(ctx.Response.Headers["WWW-Authenticate"]!);
+        Assert.StartsWith("Bearer ", header);
+        Assert.Contains("authorization_uri=\"https://idp.contoso.com/oauth2/authorize\"", header);
+        Assert.Contains("tokenIssuance_uri=\"https://idp.contoso.com/oauth2/token\"", header);
+        Assert.Contains("providerId=\"tpcontoso\"", header);
+    }
+
+    [Fact]
+    public void Apply_NullResponse_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            WopiBootstrapChallenge.Apply(response: null!, AuthUri, TokenUri));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #305. Brings `/wopibootstrapper` to spec compliance with the [Microsoft Learn bootstrap docs](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/bootstrapper/bootstrap), and ships a helper for the spec-mandated `WWW-Authenticate` header.

## What was wrong

| Issue | Before | After |
|---|---|---|
| HTTP method for base Bootstrap | A single `[HttpPost]` handled all three operations | `[HttpGet]` for the bare Bootstrap; `[HttpPost]` for `GET_ROOT_CONTAINER` / `GET_NEW_ACCESS_TOKEN` (per spec) |
| GET response shape | `{ "Bootstrap": ..., "RootContainerInfo": null, "AccessTokenInfo": null }` (out of spec) | `{ "Bootstrap": ... }` only — optional props now `[JsonIgnore(WhenWritingNull)]` |
| `EcosystemUrl` access token | Reused inbound OAuth Bearer via `Url.GetWopiSrc(...)` fallback (which mobile clients can't replay against `/wopi/*` anyway) | Fresh, minimum-privilege WOPI access token bound to root container with `None` perms — mirrors the pattern from #306 / #307 |
| `GET_NEW_ACCESS_TOKEN` with missing `X-WOPI-WopiSrc` | `ArgumentException` → 500 | `404 Not Found` (spec: *"if the X-WOPI-WopiSrc header is not present, the host should return a 404 Not Found"*) |
| `GET_NEW_ACCESS_TOKEN` with non-existent resource | Issued a token anyway with `None` perms | `404 Not Found` (spec: *"must only provide a WOPI access token if the requested WopiSrc exists and the user is authorized to access it"*) |
| `GET_NEW_ACCESS_TOKEN` with container WopiSrc | Always treated as a file lookup (failed) | Detects `/wopi/files/{id}` vs `/wopi/containers/{id}` and dispatches accordingly |
| 401 `WWW-Authenticate` content | Whatever the host's auth handler defaults to | Helper provided that builds the spec format: `Bearer authorization_uri="...", tokenIssuance_uri="...", providerId="...", UrlSchemes="..."` |

## New: `WopiBootstrapChallenge` helper

Hosts plug it into their JwtBearer (or any) authentication scheme so 401 responses from `/wopibootstrapper` point mobile clients at the IdP:

```csharp
options.Events = new JwtBearerEvents
{
    OnChallenge = context =>
    {
        context.HandleResponse();
        WopiBootstrapChallenge.Apply(
            context.Response,
            authorizationUri: new Uri(\"https://idp.contoso.com/oauth2/authorize\"),
            tokenIssuanceUri: new Uri(\"https://idp.contoso.com/oauth2/token\"),
            providerId: \"tpcontoso\");
        return Task.CompletedTask;
    },
};
```

Validates `providerId` charset per spec (`[a-zA-Z0-9]` only, throws otherwise). `urlSchemes` is passed through verbatim — the spec requires the *caller* to URL-encode it.

## Files

| File | Change |
|---|---|
| `src/WopiHost.Core/Controllers/WopiBootstrapperController.cs` | Split GET / POST actions; fix 404 paths; container WopiSrc support; `TryParseWopiSrc` helper |
| `src/WopiHost.Core/Models/BootstrapRootContainerInfo.cs` | `[JsonIgnore(WhenWritingNull)]` on optional properties |
| `src/WopiHost.Core/Security/Authentication/WopiBootstrapChallenge.cs` (new) | `Build(...)` + `Apply(HttpResponse, ...)` |
| `test/WopiHost.Core.Tests/Controllers/WopiBootstrapperControllerTests.cs` | Expanded from 7 to 27 tests |
| `test/WopiHost.Core.Tests/Security/Authentication/WopiBootstrapChallengeTests.cs` (new) | 11 tests for the challenge helper |
| `README.md` | New \"Bootstrap endpoint (Office for mobile)\" section |

## Test plan

- [x] `dotnet test test/WopiHost.Core.Tests` — 313 / 313 pass on net10.0 (+36 vs. master)
- [x] `dotnet test WOPI.slnx` — 496 / 496 pass on net10.0
- [x] `dotnet build src/WopiHost.Core` — clean, 0 warnings, 0 errors with `TreatWarningsAsErrors`

## Out of scope (deferred follow-ups)

- **Sample IdP wiring in `sample/WopiHost`** — touches sample apps and is deployment-specific. Best done as a separate PR with a working OAuth provider.
- **Validator integration** — the Microsoft `wopi-validator-core` test suite has no Bootstrap test groups, same situation as the ecosystem endpoints. Conformance is owned by the in-repo tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)