### PR TITLE
ci(validator): pin known ProofKeys failures to hard-fail on regressions

### DIFF
--- a/.github/workflows/wopi-validator.yml
+++ b/.github/workflows/wopi-validator.yml
@@ -137,11 +137,47 @@ jobs:
           PASS=$(grep -cE '^  Pass:' validator.log || true)
           FAIL=$(grep -cE '^  Fail:' validator.log || true)
           SKIP=$(grep -cE '^  Skipped:' validator.log || true)
+
+          # Known-failure baseline (issues #291, #292, #293).
+          # The upstream Microsoft validator CLI has no --rsa-key option, so it
+          # never sends X-WOPI-Proof / X-WOPI-ProofOld / X-WOPI-TimeStamp
+          # headers — see microsoft/wopi-validator-core#22 and the rebase PR
+          # microsoft/wopi-validator-core#145 (of stalled #86). Our validator sample therefore
+          # registers NoOpProofValidator, which accepts every request and
+          # returns 200. The three tests below send mutated/old-timestamp
+          # proof headers and expect 500; with no proof headers in flight they
+          # cannot fail the way the test author intended. Pinning their names
+          # here lets us hard-fail CI on any *new* regression while accepting
+          # these as a known upstream limitation. Retire the pin once
+          # microsoft/wopi-validator-core#145 lands and a new WopiValidator
+          # NuGet release ships.
+          KNOWN_FAILURES=$(printf '%s\n' \
+            "ProofKeys.CurrentInvalid.OldValidSignedWithOldKey" \
+            "ProofKeys.CurrentInvalid.OldInvalid" \
+            "ProofKeys.TimestampOlderThan20Min" \
+            | sort -u)
+          ACTUAL_FAILURES=$(grep -E '^  Fail:' validator.log | sed -E 's/^  Fail:[[:space:]]*//' | sort -u)
+
+          UNEXPECTED_FAILURES=$(comm -23 <(printf '%s\n' "${ACTUAL_FAILURES}") <(printf '%s\n' "${KNOWN_FAILURES}"))
+          UNEXPECTEDLY_PASSING=$(comm -13 <(printf '%s\n' "${ACTUAL_FAILURES}") <(printf '%s\n' "${KNOWN_FAILURES}"))
+
+          if [ -n "${UNEXPECTED_FAILURES}" ] || [ -n "${UNEXPECTEDLY_PASSING}" ]; then
+            EXIT_CODE=1
+          else
+            EXIT_CODE=0
+          fi
+
           {
             echo "pass=${PASS}"
             echo "fail=${FAIL}"
             echo "skip=${SKIP}"
-            echo "exit_code=$([ "${FAIL}" -gt 0 ] && echo 1 || echo 0)"
+            echo "exit_code=${EXIT_CODE}"
+            echo "unexpected_failures<<__EOF_UF__"
+            echo "${UNEXPECTED_FAILURES}"
+            echo "__EOF_UF__"
+            echo "unexpectedly_passing<<__EOF_UP__"
+            echo "${UNEXPECTEDLY_PASSING}"
+            echo "__EOF_UP__"
           } >> "$GITHUB_OUTPUT"
 
       - name: Stop WopiHost.Validator
@@ -154,6 +190,9 @@ jobs:
 
       - name: Job summary
         if: always()
+        env:
+          UNEXPECTED_FAILURES: ${{ steps.validate.outputs.unexpected_failures }}
+          UNEXPECTEDLY_PASSING: ${{ steps.validate.outputs.unexpectedly_passing }}
         run: |
           PASS="${{ steps.validate.outputs.pass }}"
           FAIL="${{ steps.validate.outputs.fail }}"
@@ -176,8 +215,33 @@ jobs:
             echo "_Full \`validator.log\` and \`host.log\` are attached as the **wopi-validator-output** artifact on this run._"
             echo
 
+            if [ -n "${UNEXPECTED_FAILURES}" ]; then
+              echo "### ❌ Unexpected failures"
+              echo
+              echo "These tests are NOT in the pinned baseline and cause the job to fail."
+              echo
+              echo '```'
+              echo "${UNEXPECTED_FAILURES}"
+              echo '```'
+              echo
+            fi
+
+            if [ -n "${UNEXPECTEDLY_PASSING}" ]; then
+              echo "### ⚠️ Pinned tests that no longer fail"
+              echo
+              echo "These tests are in the known-failures pin but didn't appear in the failures of this run."
+              echo "If the upstream validator gained proof-key signing (or the tests were renamed/removed),"
+              echo "remove them from \`KNOWN_FAILURES\` in [\`.github/workflows/wopi-validator.yml\`](.github/workflows/wopi-validator.yml)"
+              echo "and the matching block in [\`scripts/run-validator.sh\`](scripts/run-validator.sh)."
+              echo
+              echo '```'
+              echo "${UNEXPECTEDLY_PASSING}"
+              echo '```'
+              echo
+            fi
+
             if [ "${FAIL}" -gt 0 ] && [ -f validator.log ]; then
-              echo "<details open><summary><b>Failures (${FAIL})</b></summary>"
+              echo "<details open><summary><b>All failures (${FAIL})</b></summary>"
               echo
               echo '```'
               awk '
@@ -187,6 +251,8 @@ jobs:
                 printing { print }
               ' validator.log
               echo '```'
+              echo
+              echo "_Failures matching the pinned baseline (issues #291, #292, #293) do not fail the job — see [\`NoOpProofValidator.cs\`](sample/WopiHost.Validator/Infrastructure/NoOpProofValidator.cs) for why._"
               echo
               echo "</details>"
               echo
@@ -234,5 +300,21 @@ jobs:
 
       - name: Surface validator failure
         if: always() && steps.validate.outputs.exit_code != '0'
+        env:
+          UNEXPECTED_FAILURES: ${{ steps.validate.outputs.unexpected_failures }}
+          UNEXPECTEDLY_PASSING: ${{ steps.validate.outputs.unexpectedly_passing }}
         run: |
-          echo "::warning::WOPI validator exited with code ${{ steps.validate.outputs.exit_code }}. See job summary and artifact for details."
+          if [ -n "${UNEXPECTED_FAILURES}" ]; then
+            echo "::error::WOPI validator reported unexpected failures (not in the pinned baseline):"
+            while IFS= read -r line; do
+              [ -z "${line}" ] || echo "::error::  - ${line}"
+            done <<< "${UNEXPECTED_FAILURES}"
+          fi
+          if [ -n "${UNEXPECTEDLY_PASSING}" ]; then
+            echo "::error::Pinned ProofKeys baseline contains tests that did NOT fail in this run — retire the pin or update the names:"
+            while IFS= read -r line; do
+              [ -z "${line}" ] || echo "::error::  - ${line}"
+            done <<< "${UNEXPECTEDLY_PASSING}"
+          fi
+          echo "See job summary and the wopi-validator-output artifact for full details."
+          exit 1

--- a/sample/WopiHost.Validator/Infrastructure/NoOpProofValidator.cs
+++ b/sample/WopiHost.Validator/Infrastructure/NoOpProofValidator.cs
@@ -7,12 +7,26 @@ namespace WopiHost.Validator.Infrastructure;
 /// Permissive proof validator used by the validator sample.
 /// </summary>
 /// <remarks>
+/// <para>
 /// The Microsoft WOPI validator (https://github.com/microsoft/wopi-validator-core)
 /// is not an Office Online client and does not sign requests with the
 /// X-WOPI-Proof / X-WOPI-ProofOld / X-WOPI-TimeStamp headers. Replacing
 /// <see cref="IWopiProofValidator"/> with this no-op implementation lets the
 /// validator hit this sample's WOPI endpoints. Production hosts must keep
 /// the default <see cref="WopiProofValidator"/>.
+/// </para>
+/// <para>
+/// Side-effect: three tests in the validator's ProofKeys group expect HTTP 500
+/// (mutated current/old keys, ancient timestamp) but receive HTTP 200 because
+/// this validator accepts every request. Those three are pinned as a
+/// known-failure baseline in <c>.github/workflows/wopi-validator.yml</c> and
+/// <c>scripts/run-validator.sh</c> so CI hard-fails only on regressions. The
+/// upstream tracker is https://github.com/microsoft/wopi-validator-core/pull/145
+/// (rebase of long-stalled https://github.com/microsoft/wopi-validator-core/pull/86) —
+/// once that lands and a new WopiValidator NuGet release ships, register the validator's
+/// public keys via <c>IDiscoverer</c> and switch back to
+/// <see cref="WopiProofValidator"/>; the pin can then be retired.
+/// </para>
 /// </remarks>
 public sealed class NoOpProofValidator : IWopiProofValidator
 {

--- a/scripts/run-validator.sh
+++ b/scripts/run-validator.sh
@@ -102,7 +102,35 @@ PASS=$(grep -cE '^  Pass:' "${VALIDATOR_LOG}" || true)
 FAIL=$(grep -cE '^  Fail:' "${VALIDATOR_LOG}" || true)
 SKIP=$(grep -cE '^  Skipped:' "${VALIDATOR_LOG}" || true)
 
+# Known-failure baseline (issues #291, #292, #293).
+# Mirrors .github/workflows/wopi-validator.yml so local runs and CI agree.
+# See sample/WopiHost.Validator/Infrastructure/NoOpProofValidator.cs and
+# https://github.com/microsoft/wopi-validator-core/pull/145 (rebase of #86) for context.
+KNOWN_FAILURES=$(printf '%s\n' \
+  "ProofKeys.CurrentInvalid.OldValidSignedWithOldKey" \
+  "ProofKeys.CurrentInvalid.OldInvalid" \
+  "ProofKeys.TimestampOlderThan20Min" \
+  | sort -u)
+ACTUAL_FAILURES=$( { grep -E '^  Fail:' "${VALIDATOR_LOG}" || true; } | sed -E 's/^  Fail:[[:space:]]*//' | sort -u)
+UNEXPECTED_FAILURES=$(comm -23 <(printf '%s\n' "${ACTUAL_FAILURES}") <(printf '%s\n' "${KNOWN_FAILURES}") || true)
+UNEXPECTEDLY_PASSING=$(comm -13 <(printf '%s\n' "${ACTUAL_FAILURES}") <(printf '%s\n' "${KNOWN_FAILURES}") || true)
+
 echo
 echo "==> Results: ${PASS} pass / ${FAIL} fail / ${SKIP} skipped"
 echo "==> Logs: ${VALIDATOR_LOG}, ${HOST_LOG}"
-[ "${FAIL}" -eq 0 ]
+
+EXIT_CODE=0
+if [[ -n "${UNEXPECTED_FAILURES}" ]]; then
+  echo
+  echo "==> ❌ Unexpected failures (not in pinned baseline):"
+  printf '      %s\n' "${UNEXPECTED_FAILURES}"
+  EXIT_CODE=1
+fi
+if [[ -n "${UNEXPECTEDLY_PASSING}" ]]; then
+  echo
+  echo "==> ⚠️  Pinned tests that did NOT fail this run — retire the pin or update names:"
+  printf '      %s\n' "${UNEXPECTEDLY_PASSING}"
+  EXIT_CODE=1
+fi
+
+exit "${EXIT_CODE}"


### PR DESCRIPTION
## Summary

- Pins the 3 known `ProofKeys` test failures (#291, #292, #293) as a `KNOWN_FAILURES` baseline in [`.github/workflows/wopi-validator.yml`](.github/workflows/wopi-validator.yml) and [`scripts/run-validator.sh`](scripts/run-validator.sh).
- The validator job now hard-fails on **any** regression — either a new test failing (`unexpected_failures`), or a pinned test no longer failing (`unexpectedly_passing` → signal to retire the pin). Removes the implicit soft-fail on the 3 known ProofKeys tests.
- Updates [`NoOpProofValidator`](sample/WopiHost.Validator/Infrastructure/NoOpProofValidator.cs) docstring with the rationale + upstream tracker link.

## Why

The 3 pinned tests (`ProofKeys.CurrentInvalid.OldValidSignedWithOldKey`, `ProofKeys.CurrentInvalid.OldInvalid`, `ProofKeys.TimestampOlderThan20Min`) expect HTTP `500` but receive `200` because the Microsoft validator CLI doesn't sign requests (no `--rsa-key` option), so all 7 `ProofKeys` tests send identical unsigned requests. The 4 that expect `200` pass with `NoOpProofValidator`; the 3 that expect `500` cannot. See #291 for the full root-cause walk.

Tracking upstream as [microsoft/wopi-validator-core#145](https://github.com/microsoft/wopi-validator-core/pull/145) (rebase of long-stalled [#86](https://github.com/microsoft/wopi-validator-core/pull/86)). Once that lands and a new `WopiValidator` NuGet release ships, register the validator's published public keys via `IDiscoverer`, switch back to `WopiProofValidator`, and retire the pin.

## Test plan

- [x] Pin logic verified against the current `validator.log` artifact (3 actual failures = 3 pinned, both diffs empty → exit 0)
- [x] Negative case verified with synthetic log: one new failure + one pinned-but-passing test → both diffs flag, exit 1
- [ ] CI run on this PR shows green; the 3 known failures still appear in the validator output but no longer fail the job
- [ ] Job summary surfaces the new "Unexpected failures" / "Pinned tests that no longer fail" sections only when those diffs are non-empty

Closes #291, closes #292, closes #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)