### PR TITLE
build: centralize bin/obj/package output under artifacts/

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,19 +50,21 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
     - name: Pack
-      run: dotnet pack --no-build --include-symbols --verbosity normal --configuration Release --output ./artifacts /p:PackageVersion="${{ steps.get_version.outputs.version-without-v }}"
+      # Output is centralized via UseArtifactsOutput (see Directory.Build.props);
+      # nupkg/snupkg files land in artifacts/package/release/.
+      run: dotnet pack --no-build --include-symbols --verbosity normal --configuration Release /p:PackageVersion="${{ steps.get_version.outputs.version-without-v }}"
     - name: Upload artifacts
       uses: actions/upload-artifact@v7
       with:
         name: "NuGet packages"
-        path: ./artifacts
+        path: artifacts/package/release
     - name: Publish artifacts to NuGet.org
-      run: dotnet nuget push './artifacts/*.nupkg' -s https://api.nuget.org/v3/index.json -k ${NUGET_API_KEY} --skip-duplicate
+      run: dotnet nuget push 'artifacts/package/release/*.nupkg' -s https://api.nuget.org/v3/index.json -k ${NUGET_API_KEY} --skip-duplicate
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
     - name: Upload artifacts to the GitHub release
       uses: Roang-zero1/github-upload-release-artifacts-action@v3
       with:
-        args: ./artifacts
+        args: artifacts/package/release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ bld/
 [Bb]in/
 [Oo]bj/
 
+# .NET SDK artifacts output (UseArtifactsOutput=true; see Directory.Build.props)
+/artifacts/
+
 # Visual Studo 2015 cache/options directory
 .vs/
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,11 @@
 		<AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
 		<ProduceReferenceAssembly>true</ProduceReferenceAssembly>
 		<LangVersion>latest</LangVersion>
+		<!-- Centralize bin/obj/package/publish output under repo-root artifacts/.
+		     ArtifactsPath is pinned here so that test projects (which have their
+		     own Directory.Build.props) don't end up with a separate test/artifacts/. -->
+		<UseArtifactsOutput>true</UseArtifactsOutput>
+		<ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
 	</PropertyGroup>
 
 	<!-- Package Validation Configuration for NuGet packages -->
@@ -16,6 +21,9 @@
 		<!-- Set baseline version to a reasonable previous version for breaking change detection -->
 		<!-- This should be updated to the actual previous stable version before release -->
 		<PackageValidationBaselineVersion>4.0.0</PackageValidationBaselineVersion>
+		<!-- Generate XML doc files alongside the assembly. Letting the SDK pick the
+		     path keeps it in sync with UseArtifactsOutput. -->
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
 	
 	<ItemGroup Condition="!$(MSBuildProjectName.EndsWith('Tests'))">

--- a/src/WopiHost.Abstractions/WopiHost.Abstractions.csproj
+++ b/src/WopiHost.Abstractions/WopiHost.Abstractions.csproj
@@ -18,7 +18,6 @@
 		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
 		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
 		<GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/WopiHost.Core/WopiHost.Core.csproj
+++ b/src/WopiHost.Core/WopiHost.Core.csproj
@@ -15,7 +15,6 @@
 		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
 		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
 		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/WopiHost.Discovery/WopiHost.Discovery.csproj
+++ b/src/WopiHost.Discovery/WopiHost.Discovery.csproj
@@ -18,7 +18,6 @@
 		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
 		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
 		<GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/WopiHost.FileSystemProvider/WopiHost.FileSystemProvider.csproj
+++ b/src/WopiHost.FileSystemProvider/WopiHost.FileSystemProvider.csproj
@@ -18,7 +18,6 @@
 		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
 		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
 		<GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/WopiHost.MemoryLockProvider/WopiHost.MemoryLockProvider.csproj
+++ b/src/WopiHost.MemoryLockProvider/WopiHost.MemoryLockProvider.csproj
@@ -18,7 +18,6 @@
 		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
 		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
 		<GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/WopiHost.Url/WopiHost.Url.csproj
+++ b/src/WopiHost.Url/WopiHost.Url.csproj
@@ -18,7 +18,6 @@
 		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
 		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
 		<GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,4 +1,10 @@
 <Project>
+	<!-- Chain to the repo-root Directory.Build.props so tests inherit shared
+	     settings (UseArtifactsOutput, TreatWarningsAsErrors, analyzers, etc.).
+	     Without this import MSBuild stops walking up at the first Directory.Build.props
+	     it finds, so root-level governance silently does not apply to tests. -->
+	<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))" />
+
 	<PropertyGroup>
 		<Authors>Petr Svihlik</Authors>
 		<IsPackable>false</IsPackable>


### PR DESCRIPTION
Closes #151.

## Summary

- Enable `UseArtifactsOutput` in [`Directory.Build.props`](Directory.Build.props) with `ArtifactsPath` pinned to repo-root `artifacts/`. All `bin/`, `obj/`, `publish/`, and `package/` output now lives under one folder.
- Fix [`test/Directory.Build.props`](test/Directory.Build.props): it shadowed the repo-root props without importing them, so test projects were silently missing `TreatWarningsAsErrors`, `EnforceCodeStyleInBuild`, analyzers, etc. Chained the parent import.
- Replace hardcoded `<DocumentationFile>bin\…\.xml</DocumentationFile>` in the 6 packable libs with a single `<GenerateDocumentationFile>true</GenerateDocumentationFile>` in the existing packable `PropertyGroup`, so XML docs follow `UseArtifactsOutput` automatically.
- Update [`.github/workflows/release.yml`](.github/workflows/release.yml) to consume the SDK-managed `artifacts/package/release/` path instead of forcing `dotnet pack --output ./artifacts`.
- Add `/artifacts/` to [`.gitignore`](.gitignore).

## Heads-up

The `test/Directory.Build.props` import fix means test projects now actually inherit `TreatWarningsAsErrors`, `EnforceCodeStyleInBuild`, and analyzer settings (which CLAUDE.md already claimed was the case but in practice was not). Current tests all build and pass clean, so nothing to fix today — but new test code will be held to the same bar as `src/`.

## Test plan

- [x] `dotnet build WOPI.slnx --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test WOPI.slnx --no-build --configuration Release` — 1099 tests pass across net8.0, net9.0, net10.0
- [x] `dotnet pack WOPI.slnx --no-build --configuration Release` — all 6 nupkgs + 6 snupkgs land in `artifacts/package/release/`
- [x] `find . -type d \( -name bin -o -name obj \) -not -path "*/artifacts/*"` after a clean rebuild → empty
- [ ] CI: `Build & Test`, `Pull Request`, `WOPI Validator` workflows green
- [ ] Smoke-test next release tag publish flow once merged (consumes `artifacts/package/release/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)