### PR TITLE
fix: Linux Owner support and AsyncExpiringLazy concurrency (#303)

### DIFF
--- a/.github/workflows/infersharp.yml
+++ b/.github/workflows/infersharp.yml
@@ -68,9 +68,12 @@ jobs:
 
       - name: Stage src/ libraries (net10.0)
         run: |
+          # UseArtifactsOutput (#313) centralizes outputs under
+          # artifacts/bin/<Project>/<config>_<tfm>/ — replaces the legacy
+          # src/<Project>/bin/Release/net10.0/ paths.
           mkdir -p infer-staging
           for proj in WopiHost.Abstractions WopiHost.Core WopiHost.Discovery WopiHost.Url WopiHost.Cobalt WopiHost.FileSystemProvider WopiHost.MemoryLockProvider; do
-            cp "src/$proj/bin/Release/net10.0/$proj.dll" "src/$proj/bin/Release/net10.0/$proj.pdb" infer-staging/
+            cp "artifacts/bin/$proj/release_net10.0/$proj.dll" "artifacts/bin/$proj/release_net10.0/$proj.pdb" infer-staging/
           done
           ls -la infer-staging/
 

--- a/src/WopiHost.Discovery/AsyncExpiringLazy{T}.cs
+++ b/src/WopiHost.Discovery/AsyncExpiringLazy{T}.cs
@@ -13,7 +13,10 @@
 /// <exception cref="ArgumentNullException">The <paramref name="valueProvider"/> must be initialized.</exception>
 public class AsyncExpiringLazy<T>(Func<TemporaryValue<T>, Task<TemporaryValue<T>>> valueProvider)
 {
-    private static readonly SemaphoreSlim SyncLock = new(initialCount: 1);
+    // Instance-scoped on purpose: a static lock would be shared across every
+    // AsyncExpiringLazy<T> with the same closed generic type, serializing
+    // unrelated callers (also fixed in #303).
+    private readonly SemaphoreSlim _syncLock = new(initialCount: 1);
     private readonly Func<TemporaryValue<T>, Task<TemporaryValue<T>>> _valueProvider = valueProvider ?? throw new ArgumentNullException(nameof(valueProvider));
     private TemporaryValue<T> _value;
     private bool IsValueCreatedInternal => _value.Result != null && _value.ValidUntil > DateTimeOffset.UtcNow;
@@ -23,14 +26,14 @@ public class AsyncExpiringLazy<T>(Func<TemporaryValue<T>, Task<TemporaryValue<T>
     /// </summary>
     public async Task<bool> IsValueCreated()
     {
-        await SyncLock.WaitAsync().ConfigureAwait(false);
+        await _syncLock.WaitAsync().ConfigureAwait(false);
         try
         {
             return IsValueCreatedInternal;
         }
         finally
         {
-            SyncLock.Release();
+            _syncLock.Release();
         }
     }
 
@@ -39,29 +42,25 @@ public class AsyncExpiringLazy<T>(Func<TemporaryValue<T>, Task<TemporaryValue<T>
     /// </summary>
     public async Task<T> Value()
     {
-        await SyncLock.WaitAsync().ConfigureAwait(false);
+        // Hold the lock for the entire operation so concurrent first-time
+        // callers do not each invoke the (typically network-bound) value
+        // provider. Releasing between the cache check and the fetch was the
+        // bug fixed in #303.
+        await _syncLock.WaitAsync().ConfigureAwait(false);
         try
         {
             if (IsValueCreatedInternal)
             {
                 return _value.Result;
             }
-        }
-        finally
-        {
-            SyncLock.Release();
-        }
 
-        await SyncLock.WaitAsync().ConfigureAwait(false);
-        try
-        {
             var result = await _valueProvider(_value).ConfigureAwait(false);
             _value = result;
             return _value.Result;
         }
         finally
         {
-            SyncLock.Release();
+            _syncLock.Release();
         }
     }
 
@@ -70,8 +69,8 @@ public class AsyncExpiringLazy<T>(Func<TemporaryValue<T>, Task<TemporaryValue<T>
     /// </summary>
     public async Task Invalidate()
     {
-        await SyncLock.WaitAsync().ConfigureAwait(false);
+        await _syncLock.WaitAsync().ConfigureAwait(false);
         _value = default;
-        SyncLock.Release();
+        _syncLock.Release();
     }
 }

--- a/src/WopiHost.FileSystemProvider/LinuxFileOwner.cs
+++ b/src/WopiHost.FileSystemProvider/LinuxFileOwner.cs
@@ -1,0 +1,114 @@
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace WopiHost.FileSystemProvider;
+
+/// <summary>
+/// Resolves the owning user name for a file on Linux via libc's
+/// <c>statx</c> (file UID) and <c>getpwuid_r</c> (UID → name).
+/// </summary>
+/// <remarks>
+/// <c>statx</c> is used instead of <c>stat</c> because its struct layout is
+/// kernel-defined and stable across architectures; the historical <c>stat</c>
+/// struct differs between x86_64, arm64, and 32-bit ABIs which makes direct
+/// P/Invoke fragile. Available on glibc ≥ 2.28 and musl ≥ 1.2.
+/// </remarks>
+[SupportedOSPlatform("linux")]
+internal static class LinuxFileOwner
+{
+    private const int AT_FDCWD = -100;
+    private const uint STATX_UID = 0x00000008;
+    private const int ERANGE = 34;
+    private const int InitialPasswdBufferSize = 1024;
+    private const int MaxPasswdBufferSize = 64 * 1024;
+
+    public static string GetOwnerName(string filePath)
+    {
+        if (Statx(AT_FDCWD, filePath, 0, STATX_UID, out var stx) != 0)
+        {
+            var errno = Marshal.GetLastPInvokeError();
+            throw new IOException(
+                FormattableString.Invariant($"statx failed for '{filePath}' (errno {errno})."));
+        }
+
+        return ResolveUserName(stx.stx_uid)
+            ?? stx.stx_uid.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string? ResolveUserName(uint uid)
+    {
+        var bufferSize = InitialPasswdBufferSize;
+        while (true)
+        {
+            var passwd = default(Passwd);
+            var buffer = Marshal.AllocHGlobal(bufferSize);
+            try
+            {
+                var rc = GetPwUid_R(uid, ref passwd, buffer, (nuint)bufferSize, out var resultPtr);
+                if (rc == 0)
+                {
+                    return resultPtr == IntPtr.Zero
+                        ? null
+                        : Marshal.PtrToStringUTF8(passwd.pw_name);
+                }
+
+                if (rc == ERANGE && bufferSize < MaxPasswdBufferSize)
+                {
+                    bufferSize *= 2;
+                    continue;
+                }
+
+                throw new IOException(
+                    FormattableString.Invariant($"getpwuid_r failed for uid {uid} (errno {rc})."));
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
+        }
+    }
+
+    // Only the leading fields are read; allocate the full kernel-defined
+    // 256-byte size so statx has room to write the rest of the record.
+    [StructLayout(LayoutKind.Sequential, Size = 256)]
+    private struct StatxBuf
+    {
+        public uint stx_mask;
+        public uint stx_blksize;
+        public ulong stx_attributes;
+        public uint stx_nlink;
+        public uint stx_uid;
+        public uint stx_gid;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Passwd
+    {
+        public IntPtr pw_name;
+        public IntPtr pw_passwd;
+        public uint pw_uid;
+        public uint pw_gid;
+        public IntPtr pw_gecos;
+        public IntPtr pw_dir;
+        public IntPtr pw_shell;
+    }
+
+#pragma warning disable CA5392 // Use DefaultDllImportSearchPaths attribute for P/Invokes
+    [DllImport("libc", EntryPoint = "statx", SetLastError = true)]
+    private static extern int Statx(
+        int dirfd,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string pathname,
+        int flags,
+        uint mask,
+        out StatxBuf statxbuf);
+
+    [DllImport("libc", EntryPoint = "getpwuid_r", SetLastError = false)]
+    private static extern int GetPwUid_R(
+        uint uid,
+        ref Passwd pwd,
+        IntPtr buf,
+        nuint buflen,
+        out IntPtr result);
+#pragma warning restore CA5392
+}

--- a/src/WopiHost.FileSystemProvider/WopiFile.cs
+++ b/src/WopiHost.FileSystemProvider/WopiFile.cs
@@ -54,7 +54,8 @@ public class WopiFile(string filePath, string fileIdentifier) : IWopiFile
 
     /// <summary>
     /// A string that uniquely identifies the owner of the file.
-    /// Supported only on Windows and Linux.
+    /// Supported only on Windows and Linux. Throws
+    /// <see cref="PlatformNotSupportedException"/> on other platforms.
     /// https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416
     /// </summary>
     [SupportedOSPlatform("linux")]
@@ -67,14 +68,12 @@ public class WopiFile(string filePath, string fileIdentifier) : IWopiFile
             {
                 return fileInfo.GetAccessControl().GetOwner(typeof(NTAccount))?.ToString() ?? string.Empty;
             }
-            //else if (OperatingSystem.IsLinux())
-            //{
-            //    return Mono.Unix.UnixFileSystemInfo.GetFileSystemEntry(FilePath).OwnerUser.UserName; //TODO: test
-            //}
-            else
+            if (OperatingSystem.IsLinux())
             {
-                return "UNSUPPORTED_PLATFORM";
+                return LinuxFileOwner.GetOwnerName(fileInfo.FullName);
             }
+            throw new PlatformNotSupportedException(
+                "WopiFile.Owner is only supported on Windows and Linux.");
         }
     }
 }

--- a/test/WopiHost.Discovery.Tests/AsyncExpiringLazyTests.cs
+++ b/test/WopiHost.Discovery.Tests/AsyncExpiringLazyTests.cs
@@ -101,6 +101,83 @@ public class AsyncExpiringLazyTests
     }
 
     [Fact]
+    public async Task Value_ConcurrentFirstTimeCallers_InvokeProviderExactlyOnce()
+    {
+        // Regression test for #303: previously Value() released the lock between
+        // the cache-miss check and the fetch, so N concurrent first-time callers
+        // each fanned out and ran the (network-bound) provider.
+        var calls = 0;
+        var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var sut = CreateSut(async _ =>
+        {
+            Interlocked.Increment(ref calls);
+            await gate.Task;
+            return new TemporaryValue<string>
+            {
+                Result = "hello",
+                ValidUntil = DateTimeOffset.UtcNow.AddHours(1),
+            };
+        });
+
+        var callers = Enumerable.Range(0, 16)
+            .Select(_ => Task.Run(() => sut.Value()))
+            .ToArray();
+
+        // Give all callers a chance to queue up on the lock before releasing
+        // the provider. Without this delay the first caller can complete
+        // before the others race for the lock.
+        await Task.Delay(100);
+
+        gate.SetResult(true);
+
+        var results = await Task.WhenAll(callers);
+
+        Assert.Equal(1, calls);
+        Assert.All(results, r => Assert.Equal("hello", r));
+    }
+
+    [Fact]
+    public async Task Value_TwoInstances_DoNotShareLock()
+    {
+        // Regression test: previously the lock was static, so two instances
+        // of AsyncExpiringLazy<string> serialized through one semaphore even
+        // though they cache independent values.
+        var gateA = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var gateB = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var sutA = CreateSut(async _ =>
+        {
+            await gateA.Task;
+            return new TemporaryValue<string>
+            {
+                Result = "A",
+                ValidUntil = DateTimeOffset.UtcNow.AddHours(1),
+            };
+        });
+        var sutB = CreateSut(async _ =>
+        {
+            await gateB.Task;
+            return new TemporaryValue<string>
+            {
+                Result = "B",
+                ValidUntil = DateTimeOffset.UtcNow.AddHours(1),
+            };
+        });
+
+        var taskA = Task.Run(() => sutA.Value());
+        var taskB = Task.Run(() => sutB.Value());
+
+        // Release B first. With a shared static lock, B would block until A
+        // finishes. With instance-scoped locks, B completes independently.
+        gateB.SetResult(true);
+        Assert.Equal("B", await taskB.WaitAsync(TimeSpan.FromSeconds(5)));
+
+        gateA.SetResult(true);
+        Assert.Equal("A", await taskA.WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
+    [Fact]
     public async Task Invalidate_ClearsCachedValue()
     {
         var calls = 0;

--- a/test/WopiHost.FileSystemProvider.Tests/WopiFileTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/WopiFileTests.cs
@@ -106,20 +106,23 @@ public class WopiFileTests : IDisposable
     }
 
     [Fact]
-    public void Owner_OnLinux_MissingFile_Throws()
+    public void Owner_OnLinux_FileDeleted_Throws()
     {
         if (!OperatingSystem.IsLinux())
         {
             return;
         }
 
-        // statx returns -1 with ENOENT when the file does not exist;
-        // LinuxFileOwner surfaces that as IOException.
-        var missing = Path.Combine(_tempDir.FullName, "no-such-file.docx");
-        var sut = new WopiFile(missing, "id-missing");
+        // Construct against a real file (FileVersionInfo.GetVersionInfo throws
+        // FileNotFoundException for missing paths on Unix), then remove it so
+        // statx fails with ENOENT and LinuxFileOwner surfaces that as IOException.
+        var transient = Path.Combine(_tempDir.FullName, "transient.docx");
+        File.WriteAllText(transient, "x");
+        var sut = new WopiFile(transient, "id-transient");
+        File.Delete(transient);
 
 #pragma warning disable CA1416 // Linux-only test path; analyzer can't follow the early-return guard through the lambda
-        Assert.Throws<IOException>(() => _ = sut.Owner);
+        Assert.ThrowsAny<IOException>(() => _ = sut.Owner);
 #pragma warning restore CA1416
     }
 }

--- a/test/WopiHost.FileSystemProvider.Tests/WopiFileTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/WopiFileTests.cs
@@ -73,12 +73,35 @@ public class WopiFileTests : IDisposable
     }
 
     [Fact]
-    public void Owner_ReturnsNonNull()
+    public void Owner_OnSupportedPlatform_ReturnsNonEmpty()
     {
-        // The Windows branch returns the NT account; the non-Windows branch
-        // returns the literal "UNSUPPORTED_PLATFORM". Both must be non-null.
-#pragma warning disable CA1416 // Owner is annotated for Windows/Linux only; the impl returns a fallback string elsewhere
-        Assert.NotNull(_sut.Owner);
+        if (OperatingSystem.IsWindows() || OperatingSystem.IsLinux())
+        {
+            Assert.False(string.IsNullOrEmpty(_sut.Owner));
+        }
+        else
+        {
+            // CA1416 suppressed: the surrounding else branch already guards
+            // for non-Windows/non-Linux, but the analyzer can't follow that
+            // through the lambda capture.
+#pragma warning disable CA1416
+            Assert.Throws<PlatformNotSupportedException>(() => _ = _sut.Owner);
 #pragma warning restore CA1416
+        }
+    }
+
+    [Fact]
+    public void Owner_OnLinux_MatchesProcessUserName()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        // Files created by the test process are owned by the current user;
+        // statx + getpwuid_r should resolve back to that name (or numeric uid
+        // if the user has been deleted from /etc/passwd, which we don't expect
+        // in a CI environment).
+        Assert.Equal(Environment.UserName, _sut.Owner);
     }
 }

--- a/test/WopiHost.FileSystemProvider.Tests/WopiFileTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/WopiFileTests.cs
@@ -104,4 +104,22 @@ public class WopiFileTests : IDisposable
         // in a CI environment).
         Assert.Equal(Environment.UserName, _sut.Owner);
     }
+
+    [Fact]
+    public void Owner_OnLinux_MissingFile_Throws()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        // statx returns -1 with ENOENT when the file does not exist;
+        // LinuxFileOwner surfaces that as IOException.
+        var missing = Path.Combine(_tempDir.FullName, "no-such-file.docx");
+        var sut = new WopiFile(missing, "id-missing");
+
+#pragma warning disable CA1416 // Linux-only test path; analyzer can't follow the early-return guard through the lambda
+        Assert.Throws<IOException>(() => _ = sut.Owner);
+#pragma warning restore CA1416
+    }
 }


### PR DESCRIPTION
Closes #303.

## Summary

- **`WopiFile.Owner` on Linux** — replaces the `"UNSUPPORTED_PLATFORM"` sentinel with a real implementation. New [`LinuxFileOwner`](src/WopiHost.FileSystemProvider/LinuxFileOwner.cs) P/Invokes libc's `statx` (kernel-stable struct, avoids per-arch `stat` ABI variance) to read the file UID, then `getpwuid_r` to resolve the user name; falls back to numeric UID if no passwd entry. Non-Windows/non-Linux now throws `PlatformNotSupportedException` instead of returning a sentinel string. `[SupportedOSPlatform("linux")]` is kept since the platform is now genuinely supported.
- **`AsyncExpiringLazy<T>.Value()` race** — collapsed two `try/finally` blocks into one so the lock is held across the cache-miss check and the provider invocation. Concurrent first-time callers no longer each fan out a network request.
- **`AsyncExpiringLazy<T>` static lock** — moved the `SemaphoreSlim` from `static` to instance scope. Previously every `AsyncExpiringLazy<XElement>` in the host shared one semaphore (closed-generic singleton), serializing unrelated discovery and proof-key fetches.

## Test plan

- [x] `dotnet build WOPI.slnx` — clean (0 warnings, 0 errors) across `net8.0;net9.0;net10.0`.
- [x] `dotnet test WOPI.slnx` — all suites pass on Windows.
- [x] `Owner_OnLinux_MatchesProcessUserName` — new Fact that runs only on Linux; asserts the resolved owner equals `Environment.UserName` for files created by the test process. CI runs on `ubuntu-latest`.
- [x] `Owner_OnSupportedPlatform_ReturnsNonEmpty` — replaces the old `Owner_ReturnsNonNull`; asserts non-empty on Windows/Linux and `PlatformNotSupportedException` elsewhere.
- [x] `Value_ConcurrentFirstTimeCallers_InvokeProviderExactlyOnce` — 16 concurrent callers race on a gated provider; asserts the provider runs exactly once.
- [x] `Value_TwoInstances_DoNotShareLock` — two instances with independent gated providers; releases B first and asserts B completes without waiting for A. Would fail (timeout) under the old static lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)