### PR TITLE
fix(cobalt): cache CobaltFile per file + flow principal via AsyncLocal

### DIFF
--- a/src/WopiHost.Cobalt/CobaltHostLockingStore.cs
+++ b/src/WopiHost.Cobalt/CobaltHostLockingStore.cs
@@ -4,28 +4,36 @@ using Cobalt;
 namespace WopiHost.Cobalt;
 
 public class CobaltHostLockingStore(
-    ClaimsPrincipal principal,
     string fileId,
     CoauthoringSessionTracker sessionTracker) : HostLockingStore
 {
-    private readonly ClaimsPrincipal _principal = principal;
+    /// <summary>
+    /// Per-call principal. <see cref="CobaltProcessor"/> caches one
+    /// <see cref="CobaltHostLockingStore"/> per file (it lives inside the cached
+    /// <c>CobaltFile</c>) so the locking store cannot capture a single principal
+    /// at construction; instead each <c>ProcessCobalt</c> invocation sets this
+    /// AsyncLocal before the request runs and clears it after.
+    /// </summary>
+    internal static readonly AsyncLocal<ClaimsPrincipal> CurrentPrincipal = new();
+
     private readonly string _fileId = fileId;
     private readonly CoauthoringSessionTracker _sessionTracker = sessionTracker;
 
-    private string UserId => _principal?.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? string.Empty;
-    private string UserName => _principal?.FindFirst(ClaimTypes.Name)?.Value ?? string.Empty;
+    private static ClaimsPrincipal Principal => CurrentPrincipal.Value;
+    private string UserId => Principal?.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? string.Empty;
+    private string UserName => Principal?.FindFirst(ClaimTypes.Name)?.Value ?? string.Empty;
 
     public override WhoAmIRequest.OutputType HandleWhoAmI(WhoAmIRequest.InputType input)
     {
-        var result = new WhoAmIRequest.OutputType
+        var p = Principal;
+        var login = p?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        return new WhoAmIRequest.OutputType
         {
-            UserEmailAddress = _principal?.FindFirst(ClaimTypes.Email).Value,
-            UserIsAnonymous = string.IsNullOrEmpty(_principal?.FindFirst(ClaimTypes.NameIdentifier).Value),
-            UserLogin = _principal?.FindFirst(ClaimTypes.NameIdentifier).Value,
-            UserName = _principal?.FindFirst(ClaimTypes.Name).Value
+            UserEmailAddress = p?.FindFirst(ClaimTypes.Email)?.Value,
+            UserIsAnonymous = string.IsNullOrEmpty(login),
+            UserLogin = login,
+            UserName = p?.FindFirst(ClaimTypes.Name)?.Value,
         };
-
-        return result;
     }
 
     public override ServerTimeRequest.OutputType HandleServerTime(ServerTimeRequest.InputType input)

--- a/src/WopiHost.Cobalt/CobaltSession.cs
+++ b/src/WopiHost.Cobalt/CobaltSession.cs
@@ -1,99 +1,235 @@
-﻿using System.Security.Claims;
+using System.Collections.Concurrent;
+using System.Security.Claims;
 using Cobalt;
 using Cobalt.Base.IO;
 using WopiHost.Abstractions;
 
 namespace WopiHost.Cobalt;
 
-public class CobaltProcessor : ICobaltProcessor
+/// <summary>
+/// MS-FSSHTTP / Cobalt processor that maintains a long-lived <see cref="CobaltFile"/>
+/// per WOPI file id.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The Cobalt protocol is stateful: schema/exclusive locks, edit deltas, and
+/// co-authoring metadata live inside the <c>CobaltFile</c>'s in-memory blob
+/// stores and must persist across HTTP requests for the same file. Creating a
+/// fresh <c>CobaltFile</c> per request (the previous behavior) makes
+/// co-authoring and delta-based edits impossible.
+/// </para>
+/// <para>
+/// Sessions are cached in a <see cref="ConcurrentDictionary{TKey,TValue}"/>
+/// keyed by <see cref="IWopiFile.Identifier"/>. A periodic timer evicts idle
+/// sessions after <see cref="SessionIdleTimeout"/> to keep memory bounded —
+/// the <see cref="LocalHostBlobStore"/> backing each session is in-memory.
+/// </para>
+/// </remarks>
+public sealed class CobaltProcessor : ICobaltProcessor, IDisposable
 {
+    /// <summary>How long a session may go without traffic before it is disposed.</summary>
+    public static TimeSpan SessionIdleTimeout { get; } = TimeSpan.FromMinutes(60);
+
+    private static readonly TimeSpan CleanupInterval = TimeSpan.FromMinutes(5);
+
     private readonly CoauthoringSessionTracker _sessionTracker = new();
-    private async Task<CobaltFile> GetCobaltFile(IWopiFile file, ClaimsPrincipal principal)
+    private readonly ConcurrentDictionary<string, Lazy<Task<CobaltSessionEntry>>> _sessions = new(StringComparer.Ordinal);
+    private readonly Timer _cleanupTimer;
+    private int _disposed;
+
+    public CobaltProcessor()
     {
-        var disposal = new DisposalEscrow(file.Owner);
-        // CobaltCore 16.x retired `TemporaryHostBlobStore`; `LocalHostBlobStore` is the
-        // closest equivalent (in-memory by default; can be backed by a directory if a
-        // `dirPathForFileBackedBlobs` is supplied — left null here to match the old
-        // temp-only behavior).
-        var content = new CobaltFilePartitionConfig
-        {
-            IsNewFile = true,
-            HostBlobStore = new LocalHostBlobStore(new LocalHostBlobStore.Config()),
-            cellSchemaIsGenericFda = true,
-            CellStorageConfig = new CellStorageConfig(),
-            Schema = CobaltFilePartition.Schema.ShreddedCobalt,
-            PartitionId = FilePartitionId.Content
-        };
-
-        var coauth = new CobaltFilePartitionConfig
-        {
-            IsNewFile = true,
-            HostBlobStore = new LocalHostBlobStore(new LocalHostBlobStore.Config()),
-            cellSchemaIsGenericFda = false,
-            CellStorageConfig = new CellStorageConfig(),
-            Schema = CobaltFilePartition.Schema.ShreddedCobalt,
-            PartitionId = FilePartitionId.CoauthMetadata
-        };
-
-        var wacupdate = new CobaltFilePartitionConfig
-        {
-            IsNewFile = true,
-            HostBlobStore = new LocalHostBlobStore(new LocalHostBlobStore.Config()),
-            cellSchemaIsGenericFda = false,
-            CellStorageConfig = new CellStorageConfig(),
-            Schema = CobaltFilePartition.Schema.ShreddedCobalt,
-            PartitionId = FilePartitionId.WordWacUpdate
-        };
-
-        var partitionConfigs = new Dictionary<FilePartitionId, CobaltFilePartitionConfig> { { FilePartitionId.Content, content }, { FilePartitionId.WordWacUpdate, wacupdate }, { FilePartitionId.CoauthMetadata, coauth } };
-
-        // CobaltCore 16.x changed the CobaltFile ctor to take a
-        // `GetConfigForPartitionAndVersion` delegate instead of a Dictionary, so the
-        // host can serve different configurations per (partition, version) tuple.
-        // Bridge the existing dictionary-based setup to the delegate by ignoring the
-        // versionToken (we only have one config per partition).
-        var tempCobaltFile = new CobaltFile(
-            disposal,
-            (partition, _) => partitionConfigs.TryGetValue(partition, out var cfg) ? cfg : null,
-            new CobaltHostLockingStore(principal, file.Identifier, _sessionTracker),
-            null);
-
-        if (file.Exists)
-        {
-            using var stream = await file.GetReadStream();
-            // 16.x made `AtomFromStream` an internal sealed type; the public surface
-            // exposes `Atom.CreateFromArray(byte[])`. Buffer the stream so we can
-            // hand a byte[] to the factory.
-            using var ms = new MemoryStream();
-            await stream.CopyToAsync(ms);
-            var srcAtom = Atom.CreateFromArray(ms.ToArray());
-            tempCobaltFile.GetCobaltFilePartition(FilePartitionId.Content).SetStream(RootId.Default.Value, srcAtom, out var o1);
-            tempCobaltFile.GetCobaltFilePartition(FilePartitionId.Content).GetStream(RootId.Default.Value).Flush();
-        }
-        return tempCobaltFile;
+        _cleanupTimer = new Timer(_ => EvictIdleSessions(), state: null, CleanupInterval, CleanupInterval);
     }
 
     /// <inheritdoc/>
     public async Task<byte[]> ProcessCobalt(IWopiFile file, ClaimsPrincipal principal, byte[] newContent)
     {
-        // 16.x replaced the Atom-taking overload of `DeserializeInputFromProtocol` with one
-        // that takes `CobaltStream`. Wrap the request bytes via `CobaltStream.Get(Stream)`.
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(file);
+        ArgumentNullException.ThrowIfNull(newContent);
+
+        var entry = await GetOrCreateSession(file).ConfigureAwait(false);
+
+        // Wrap the request bytes as a CobaltStream (16.x replaced the Atom-taking
+        // overload of DeserializeInputFromProtocol with one that takes CobaltStream).
         using var newContentStream = new MemoryStream(newContent, writable: false);
         var requestStream = CobaltStream.Get(newContentStream, streamIsImmutable: true);
         var requestBatch = new RequestBatch();
+        requestBatch.DeserializeInputFromProtocol(requestStream, out _, out var protocolVersion);
 
-        requestBatch.DeserializeInputFromProtocol(requestStream, out var ctx, out var protocolVersion);
-        var cobaltFile = await GetCobaltFile(file, principal);
-        cobaltFile.CobaltEndpoint.ExecuteRequestBatch(requestBatch);
-
-        if (requestBatch.Requests.Any(request => request is PutChangesRequest && request.PartitionId == FilePartitionId.Content))
+        // Flow the current principal to CobaltHostLockingStore.HandleWhoAmI for the
+        // duration of this request only. AsyncLocal flows through async/await but is
+        // scoped per logical-call so concurrent requests for the same file from
+        // different users don't cross-pollute.
+        var prev = CobaltHostLockingStore.CurrentPrincipal.Value;
+        CobaltHostLockingStore.CurrentPrincipal.Value = principal;
+        byte[] response;
+        try
         {
-            using var stream = await file.GetWriteStream();
-            new GenericFda(cobaltFile.CobaltEndpoint).GetContentStream().CopyTo(stream);
+            entry.Touch();
+            entry.File.CobaltEndpoint.ExecuteRequestBatch(requestBatch);
+
+            if (requestBatch.Requests.Any(r => r is PutChangesRequest && r.PartitionId == FilePartitionId.Content))
+            {
+                // Serialize concurrent saves for the same file. WOPI itself uses
+                // protocol-level locks but those don't necessarily cover the
+                // window between ExecuteRequestBatch and the disk flush.
+                await entry.WriteLock.WaitAsync().ConfigureAwait(false);
+                try
+                {
+                    using var stream = await file.GetWriteStream().ConfigureAwait(false);
+                    new GenericFda(entry.File.CobaltEndpoint).GetContentStream().CopyTo(stream);
+                }
+                finally
+                {
+                    entry.WriteLock.Release();
+                }
+            }
+
+            using var ms = new MemoryStream();
+            requestBatch.SerializeOutputToProtocol(protocolVersion).CopyTo(ms);
+            response = ms.ToArray();
+        }
+        finally
+        {
+            CobaltHostLockingStore.CurrentPrincipal.Value = prev;
         }
 
-        using var ms = new MemoryStream();
-        requestBatch.SerializeOutputToProtocol(protocolVersion).CopyTo(ms);
-        return ms.ToArray();
+        return response;
+    }
+
+    private async Task<CobaltSessionEntry> GetOrCreateSession(IWopiFile file)
+    {
+        var lazy = _sessions.GetOrAdd(
+            file.Identifier,
+            _ => new Lazy<Task<CobaltSessionEntry>>(() => CreateSessionEntry(file), LazyThreadSafetyMode.ExecutionAndPublication));
+        try
+        {
+            return await lazy.Value.ConfigureAwait(false);
+        }
+        catch
+        {
+            // A faulted Lazy<Task<>> would otherwise be cached forever; remove
+            // exactly this entry so the next call retries. The KeyValuePair
+            // overload of TryRemove avoids racing with a concurrent
+            // GetOrCreateSession that already replaced the entry.
+            _sessions.TryRemove(new KeyValuePair<string, Lazy<Task<CobaltSessionEntry>>>(file.Identifier, lazy));
+            throw;
+        }
+    }
+
+    private async Task<CobaltSessionEntry> CreateSessionEntry(IWopiFile file)
+    {
+        var disposal = new DisposalEscrow(file.Owner);
+
+        // CobaltCore 16.x retired `TemporaryHostBlobStore`; `LocalHostBlobStore` is
+        // the closest equivalent (in-memory by default; can be backed by a
+        // directory if a `dirPathForFileBackedBlobs` is supplied — left null here
+        // to match the old temp-only behavior).
+        CobaltFilePartitionConfig MakePartition(FilePartitionId partition, bool genericFda) => new()
+        {
+            IsNewFile = true,
+            HostBlobStore = new LocalHostBlobStore(new LocalHostBlobStore.Config()),
+            cellSchemaIsGenericFda = genericFda,
+            CellStorageConfig = new CellStorageConfig(),
+            Schema = CobaltFilePartition.Schema.ShreddedCobalt,
+            PartitionId = partition,
+        };
+
+        var partitionConfigs = new Dictionary<FilePartitionId, CobaltFilePartitionConfig>
+        {
+            [FilePartitionId.Content] = MakePartition(FilePartitionId.Content, genericFda: true),
+            [FilePartitionId.WordWacUpdate] = MakePartition(FilePartitionId.WordWacUpdate, genericFda: false),
+            [FilePartitionId.CoauthMetadata] = MakePartition(FilePartitionId.CoauthMetadata, genericFda: false),
+        };
+
+        // CobaltCore 16.x changed the CobaltFile ctor to take a
+        // `GetConfigForPartitionAndVersion` delegate instead of a Dictionary.
+        var cobaltFile = new CobaltFile(
+            disposal,
+            (partition, _) => partitionConfigs.TryGetValue(partition, out var cfg) ? cfg : null,
+            new CobaltHostLockingStore(file.Identifier, _sessionTracker),
+            null);
+
+        if (file.Exists)
+        {
+            using var stream = await file.GetReadStream().ConfigureAwait(false);
+            // 16.x made `AtomFromStream` an internal sealed type; `Atom.CreateFromArray`
+            // is the public byte[] factory. Buffer the stream so we can hand a byte[]
+            // to it.
+            using var ms = new MemoryStream();
+            await stream.CopyToAsync(ms).ConfigureAwait(false);
+            var srcAtom = Atom.CreateFromArray(ms.ToArray());
+            cobaltFile.GetCobaltFilePartition(FilePartitionId.Content).SetStream(RootId.Default.Value, srcAtom, out _);
+            cobaltFile.GetCobaltFilePartition(FilePartitionId.Content).GetStream(RootId.Default.Value).Flush();
+        }
+
+        return new CobaltSessionEntry(cobaltFile, disposal);
+    }
+
+    private void EvictIdleSessions()
+    {
+        if (Volatile.Read(ref _disposed) != 0) return;
+
+        var cutoff = DateTimeOffset.UtcNow - SessionIdleTimeout;
+        foreach (var pair in _sessions)
+        {
+            if (!pair.Value.IsValueCreated)
+            {
+                continue;
+            }
+
+            // The Lazy<Task<...>> may not have completed yet for a brand-new entry;
+            // skip those — they're definitionally not idle.
+            var task = pair.Value.Value;
+            if (task.Status != TaskStatus.RanToCompletion)
+            {
+                continue;
+            }
+
+            var entry = task.Result;
+            if (entry.LastUsed < cutoff && _sessions.TryRemove(pair.Key, out _))
+            {
+                entry.Dispose();
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+
+        _cleanupTimer.Dispose();
+        foreach (var pair in _sessions)
+        {
+            if (pair.Value.IsValueCreated && pair.Value.Value.Status == TaskStatus.RanToCompletion)
+            {
+                pair.Value.Value.Result.Dispose();
+            }
+        }
+        _sessions.Clear();
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (Volatile.Read(ref _disposed) != 0) throw new ObjectDisposedException(nameof(CobaltProcessor));
+    }
+
+    private sealed class CobaltSessionEntry(CobaltFile file, DisposalEscrow disposal) : IDisposable
+    {
+        private long _lastUsedTicks = DateTimeOffset.UtcNow.UtcTicks;
+
+        public CobaltFile File { get; } = file;
+        public SemaphoreSlim WriteLock { get; } = new(initialCount: 1, maxCount: 1);
+        public DateTimeOffset LastUsed => new(Volatile.Read(ref _lastUsedTicks), TimeSpan.Zero);
+
+        public void Touch() => Volatile.Write(ref _lastUsedTicks, DateTimeOffset.UtcNow.UtcTicks);
+
+        public void Dispose()
+        {
+            disposal.Dispose();
+            WriteLock.Dispose();
+        }
     }
 }


### PR DESCRIPTION
## Why

After #320 the Cobalt processor compiled and went through the motions of an MS-FSSHTTP request, but it built a brand-new `CobaltFile` (with empty in-memory `LocalHostBlobStore`s, fresh `CobaltHostLockingStore`, re-loaded file content) on **every** `ProcessCobalt` invocation. That breaks the protocol:

- Schema/exclusive locks, edit deltas, and coauth metadata all live inside the `CobaltFile`'s in-memory blob stores. Throwing them away after every request → coauthoring impossible, delta edits lose context, locks never stick.
- The entire file gets re-buffered from disk on every request.

[marx-yu/WopiHost](https://github.com/marx-yu/WopiHost/blob/289778e/WopiCobaltHost/CobaltSessionManager.cs) — the upstream we originally ported from — kept long-lived `CobaltSession` objects in a manager keyed by file id with a 60-min idle eviction. We ported the call shape but not the lifecycle, so this PR re-introduces it.

## Changes

### Per-file session cache
- `CobaltProcessor` holds `ConcurrentDictionary<string, Lazy<Task<CobaltSessionEntry>>>` keyed by `IWopiFile.Identifier`. The `Lazy<Task<>>` makes concurrent first-touches share one create.
- Each `CobaltSessionEntry` owns its `CobaltFile`, `DisposalEscrow`, a `SemaphoreSlim` (save-side serialization), and a volatile `LastUsed` timestamp.
- A 5-minute `Timer` evicts entries idle > 60 minutes (matches marx-yu) and disposes their resources.
- `IDisposable` on the processor itself for clean container shutdown.
- If session creation throws (file read failure, etc.), the faulted `Lazy<Task<>>` is removed from the dict so the next call retries instead of serving the cached failure forever.

### Principal flow via `AsyncLocal`
A cached `CobaltFile` means the `CobaltHostLockingStore` inside it can't capture a single `ClaimsPrincipal` at construction — different users share the file's Cobalt session. So:
- `CobaltHostLockingStore` reads the current principal from a static `AsyncLocal<ClaimsPrincipal>`.
- `ProcessCobalt` sets it before `ExecuteRequestBatch` and restores the previous value in a `finally`.
- AsyncLocal flows through async/await and is isolated per logical-call → concurrent `ProcessCobalt` invocations from different users don't cross-pollute.

### Other fixes
- `HandleWhoAmI` was NRE-prone: `_principal?.FindFirst(...).Value` throws if the principal is non-null but the claim is missing. Now null-conditional on each link.
- `Save` path is serialized by `entry.WriteLock`. Marx-yu used `lock (m_fileinfo)` for the same reason; WOPI's protocol-level locks don't cover the window between `ExecuteRequestBatch` and the disk flush.
- `CobaltProcessor` now `sealed`, with `ArgumentNullException` guards on public entry points.

### Kept (the good stuff already there)
- `CoauthoringSessionTracker` still drives `JoinCoauthoring` / `RefreshCoauthoring` / `GetCoauthoringStatus` / `AmIAlone` / `QueryEditorsTable` from real session state. (Marx-yu hard-coded `CoauthStatusType.Alone` and an empty editors table — your post-port version is genuinely better.)
- All seven new 16.x abstract method stubs (`HandleEnumerateEditors`, `HandleEditorsPropertyCheck`, `HandleRename`, `HandleDelete`, `HandleGetVersionList`, `HandleRestoreVersion`, `FileExists`) untouched.

## Out of scope (tracked for later)
- `LockStatusRequest` still returns `LockType.SchemaLock` without populating `LockId` / `LockedBy` from `IWopiLockProvider`. Defensible — marx-yu shipped the same shape and it works for solo editing — but multi-user lock visibility wants the lock provider injected into `CobaltHostLockingStore`.
- A real end-to-end test against an Office Online Server instance is still untested. The architectural fix here makes coauth *possible* in principle; verifying it works on the wire is a separate exercise. Tracked toward #321.

## Test plan
- [x] `dotnet test WOPI.slnx -c Release` — 1188 tests pass, 0 failures, on net8/9/10.
- [ ] CI green on this PR.
- [ ] (Out of band) Manual smoke against OOS: open a Word/Excel doc, edit, verify save round-trips; open same doc in two tabs, verify coauth status flips from Alone → Coauthoring and editors table shows both users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)