### PR TITLE
feat: Azure Blob storage + lock providers; async IWopiLockProvider

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
 		<EnablePackageValidation>true</EnablePackageValidation>
 		<!-- Baseline used to detect public-API breaks against the last released version.
 		     Bump this in lockstep with releases. -->
-		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>
+		<PackageValidationBaselineVersion>6.0.0</PackageValidationBaselineVersion>
 		<!-- Generate XML doc files alongside the assembly. Letting the SDK pick the
 		     path keeps it in sync with UseArtifactsOutput. -->
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,8 @@
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.13.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
     <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.7" />
@@ -33,6 +35,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.13" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.13" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.13" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.13" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.7" />
@@ -59,6 +62,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.3" />
@@ -70,6 +74,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.2.4" />
     <PackageVersion Include="Aspire.Hosting" Version="9.5.2" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="13.2.4" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
   </ItemGroup>
 </Project>

--- a/WOPI.slnx
+++ b/WOPI.slnx
@@ -1,5 +1,7 @@
 <Solution>
   <Project Path="src/WopiHost.Abstractions/WopiHost.Abstractions.csproj" />
+  <Project Path="src/WopiHost.AzureLockProvider/WopiHost.AzureLockProvider.csproj" />
+  <Project Path="src/WopiHost.AzureStorageProvider/WopiHost.AzureStorageProvider.csproj" />
   <Project Path="src/WopiHost.Cobalt/WopiHost.Cobalt.csproj" />
   <Project Path="src/WopiHost.Core/WopiHost.Core.csproj" />
   <Project Path="src/WopiHost.Discovery/WopiHost.Discovery.csproj" />
@@ -15,6 +17,8 @@
   <Project Path="sample/WopiHost.Web/WopiHost.Web.csproj" />
   <Project Path="sample/WopiHost.Web.Oidc/WopiHost.Web.Oidc.csproj" />
 
+  <Project Path="test/WopiHost.AzureLockProvider.Tests/WopiHost.AzureLockProvider.Tests.csproj" />
+  <Project Path="test/WopiHost.AzureStorageProvider.Tests/WopiHost.AzureStorageProvider.Tests.csproj" />
   <Project Path="test/WopiHost.Core.Tests/WopiHost.Core.Tests.csproj" />
   <Project Path="test/WopiHost.IntegrationTests/WopiHost.IntegrationTests.csproj" />
   <Project Path="test/WopiHost.Discovery.Tests/WopiHost.Discovery.Tests.csproj" />

--- a/infra/WopiHost.AppHost/Program.cs
+++ b/infra/WopiHost.AppHost/Program.cs
@@ -11,6 +11,18 @@ var wopiHost = builder.AddProject<Projects.WopiHost>("wopihost")
                           url.Url = "/scalar";
                       });
 
+// Optional: Azure Blob Storage backend via Azurite emulator. Opt-in via "AppHost:UseAzureStorage"=true
+// so the default flow keeps using the file-system provider out of the box. When enabled, the Azurite
+// resource is added and its connection string is forwarded to the WopiHost project as
+// "ConnectionStrings__BlobStorage", which sample/WopiHost reads when configured for the Azure provider.
+if (builder.Configuration.GetValue<bool>("AppHost:UseAzureStorage"))
+{
+    var storage = builder.AddAzureStorage("blob-storage")
+                         .RunAsEmulator(emu => emu.WithLifetime(ContainerLifetime.Persistent));
+    var blobs = storage.AddBlobs("BlobStorage");
+    wopiHost.WithReference(blobs);
+}
+
 // Add WopiHost.Web frontend that depends on WopiHost
 builder.AddProject<Projects.WopiHost_Web>("wopihost-web")
        .WithReference(wopiHost)

--- a/infra/WopiHost.AppHost/WopiHost.AppHost.csproj
+++ b/infra/WopiHost.AppHost/WopiHost.AppHost.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.AppHost" />
+    <PackageReference Include="Aspire.Hosting.Azure.Storage" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/WopiHost/Program.cs
+++ b/sample/WopiHost/Program.cs
@@ -5,7 +5,6 @@ using WopiHost.Core.Models;
 using WopiHost.Core.Extensions;
 using WopiHost.Core.Infrastructure;
 using WopiHost.Core.Security.Authentication;
-using WopiHost.FileSystemProvider;
 using WopiHost.Discovery;
 using Scalar.AspNetCore;
 
@@ -55,13 +54,10 @@ public partial class Program
 
             var wopiHostOptions = wopiHostOptionsSection.Get<WopiHostOptions>();
 
-            // Register InMemoryFileIds - needed by WopiFileSystemProvider
-            builder.Services.AddSingleton<InMemoryFileIds>();
-
-            // Add file provider
-            builder.Services.AddStorageProvider(wopiHostOptions.StorageProviderAssemblyName);
+            // Add file provider (registers required dependencies based on which assembly is configured)
+            builder.Services.AddStorageProvider(builder.Configuration, wopiHostOptions.StorageProviderAssemblyName);
             // Add lock provider
-            builder.Services.AddLockProvider(wopiHostOptions.LockProviderAssemblyName);
+            builder.Services.AddLockProvider(builder.Configuration, wopiHostOptions.LockProviderAssemblyName);
 
             // Add Discovery services
             builder.Services.AddWopiDiscovery<WopiHostOptions>(

--- a/sample/WopiHost/ServiceCollectionExtensions.cs
+++ b/sample/WopiHost/ServiceCollectionExtensions.cs
@@ -1,38 +1,68 @@
-﻿using System.Runtime.Loader;
+using System.Runtime.Loader;
+using Microsoft.Extensions.Configuration;
 using WopiHost.Abstractions;
+using WopiHost.AzureLockProvider;
+using WopiHost.AzureStorageProvider;
+using WopiHost.FileSystemProvider;
 
 namespace WopiHost;
 
 public static class ServiceCollectionExtensions
 {
-    public static void AddStorageProvider(this IServiceCollection services, string storageProviderAssemblyName)
+    /// <summary>
+    /// Registers the storage provider identified by <paramref name="storageProviderAssemblyName"/>.
+    /// </summary>
+    /// <remarks>
+    /// Recognises specific assembly names so each provider's required DI dependencies are wired up
+    /// correctly (Azure clients, options binding, ID maps). Falls back to a Scrutor scan for
+    /// arbitrary third-party assemblies whose providers can be constructed from already-registered
+    /// services.
+    /// </remarks>
+    public static void AddStorageProvider(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string storageProviderAssemblyName)
     {
-        var assemblyPath = Path.Combine(AppContext.BaseDirectory, $"{storageProviderAssemblyName}.dll");
-        if (!File.Exists(assemblyPath))
+        switch (storageProviderAssemblyName)
         {
-            throw new InvalidProgramException($"StorageProvider's Assembly {assemblyPath} not found.");
+            case "WopiHost.FileSystemProvider":
+                services.AddSingleton<InMemoryFileIds>();
+                services.AddScoped<IWopiStorageProvider, WopiFileSystemProvider>();
+                services.AddScoped<IWopiWritableStorageProvider, WopiFileSystemProvider>();
+                return;
+
+            case "WopiHost.AzureStorageProvider":
+                services.AddAzureStorageProvider(configuration);
+                return;
+
+            default:
+                ScanAssemblyAndRegister<IWopiStorageProvider>(services, storageProviderAssemblyName);
+                return;
         }
-        var assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
-        services
-            .Scan(scan => scan.FromAssemblies(assembly)
-            .AddClasses(classes => classes
-                .AssignableTo<IWopiStorageProvider>())
-            .AsImplementedInterfaces());
     }
 
-    public static void AddLockProvider(this IServiceCollection services, string lockProviderAssemblyName)
+    /// <summary>
+    /// Registers the lock provider identified by <paramref name="lockProviderAssemblyName"/>.
+    /// </summary>
+    public static void AddLockProvider(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string lockProviderAssemblyName)
     {
-        var assemblyPath = Path.Combine(AppContext.BaseDirectory, $"{lockProviderAssemblyName}.dll");
-        if (!File.Exists(assemblyPath))
+        switch (lockProviderAssemblyName)
         {
-            throw new InvalidProgramException($"LockProvider's Assembly {assemblyPath} not found.");
+            case "WopiHost.MemoryLockProvider":
+                services.AddSingleton<IWopiLockProvider, MemoryLockProvider.MemoryLockProvider>();
+                return;
+
+            case "WopiHost.AzureLockProvider":
+                services.AddAzureLockProvider(configuration);
+                return;
+
+            default:
+                ScanAssemblyAndRegister<IWopiLockProvider>(services, lockProviderAssemblyName);
+                return;
         }
-        var assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
-        services
-            .Scan(scan => scan.FromAssemblies(assembly)
-            .AddClasses(classes => classes
-                .AssignableTo<IWopiLockProvider>())
-            .AsImplementedInterfaces());
     }
 
     public static void AddCobalt(this IServiceCollection services)
@@ -47,6 +77,21 @@ public static class ServiceCollectionExtensions
             .Scan(scan => scan.FromAssemblies(cobaltAssembly)
             .AddClasses(classes => classes
                 .AssignableTo<ICobaltProcessor>())
+            .AsImplementedInterfaces());
+    }
+
+    private static void ScanAssemblyAndRegister<TInterface>(IServiceCollection services, string assemblyName)
+    {
+        var assemblyPath = Path.Combine(AppContext.BaseDirectory, $"{assemblyName}.dll");
+        if (!File.Exists(assemblyPath))
+        {
+            throw new InvalidProgramException($"Provider assembly {assemblyPath} not found.");
+        }
+        var assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
+        services
+            .Scan(scan => scan.FromAssemblies(assembly)
+            .AddClasses(classes => classes
+                .AssignableTo<TInterface>())
             .AsImplementedInterfaces());
     }
 }

--- a/sample/WopiHost/WopiHost.csproj
+++ b/sample/WopiHost/WopiHost.csproj
@@ -20,6 +20,8 @@
 		<!--ProjectReference Include="..\WopiHost.Cobalt\WopiHost.Cobalt.csproj" /-->
 		<ProjectReference Include="..\..\src\WopiHost.MemoryLockProvider\WopiHost.MemoryLockProvider.csproj" />
 		<ProjectReference Include="..\..\src\WopiHost.FileSystemProvider\WopiHost.FileSystemProvider.csproj" />
+		<ProjectReference Include="..\..\src\WopiHost.AzureStorageProvider\WopiHost.AzureStorageProvider.csproj" />
+		<ProjectReference Include="..\..\src\WopiHost.AzureLockProvider\WopiHost.AzureLockProvider.csproj" />
 		<ProjectReference Include="..\..\src\WopiHost.Core\WopiHost.Core.csproj" />
 		<ProjectReference Include="..\..\src\WopiHost.Discovery\WopiHost.Discovery.csproj" />
 		<ProjectReference Include="..\..\infra\WopiHost.ServiceDefaults\WopiHost.ServiceDefaults.csproj" />

--- a/src/WopiHost.Abstractions/IWopiLockProvider.cs
+++ b/src/WopiHost.Abstractions/IWopiLockProvider.cs
@@ -1,42 +1,48 @@
-﻿using System.Diagnostics.CodeAnalysis;
-
 namespace WopiHost.Abstractions;
 
 /// <summary>
 /// Represents an editing file lock provider.
 /// </summary>
+/// <remarks>
+/// All operations are asynchronous so implementations can talk to out-of-process
+/// stores (Azure Blob, Redis, SQL, etc.) without blocking. The in-process
+/// <c>MemoryLockProvider</c> simply wraps its synchronous logic in <see cref="Task.FromResult{T}"/>.
+/// </remarks>
 public interface IWopiLockProvider
 {
     /// <summary>
-    /// try to get an existing lock by it's identifier.
+    /// Try to get an existing lock by its identifier.
     /// </summary>
     /// <param name="fileId">the fileId to check for.</param>
-    /// <param name="lockInfo">the existing lockInfo if found.</param>
-    /// <returns>true if found, false otherwise</returns>
-    bool TryGetLock(string fileId, [NotNullWhen(true)] out WopiLockInfo? lockInfo);
+    /// <param name="cancellationToken">cancellation token</param>
+    /// <returns>the existing <see cref="WopiLockInfo"/> if present and not expired; <see langword="null"/> otherwise.</returns>
+    Task<WopiLockInfo?> GetLockAsync(string fileId, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// extend an existing lock on fileId expiration time.
+    /// Extend an existing lock's expiration time.
     /// </summary>
     /// <param name="fileId">the fileId to refresh the lock for.</param>
     /// <param name="lockId">include to also update the lockId.</param>
-    /// <returns>true if success</returns>
-    bool RefreshLock(string fileId, string? lockId = null);
+    /// <param name="cancellationToken">cancellation token</param>
+    /// <returns>true if the lock was successfully refreshed</returns>
+    Task<bool> RefreshLockAsync(string fileId, string? lockId = null, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// create a new lock.
+    /// Create a new lock.
     /// </summary>
     /// <param name="fileId">the fileId to lock.</param>
     /// <param name="lockId">the lock identifier to use.</param>
-    /// <returns></returns>
-    WopiLockInfo? AddLock(string fileId, string lockId);
+    /// <param name="cancellationToken">cancellation token</param>
+    /// <returns>the created <see cref="WopiLockInfo"/>, or <see langword="null"/> if a lock already exists for <paramref name="fileId"/>.</returns>
+    Task<WopiLockInfo?> AddLockAsync(string fileId, string lockId, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// remove an existing lock from a given fileId.
+    /// Remove an existing lock from a given fileId.
     /// </summary>
     /// <param name="fileId">the lock for fileId to remove.</param>
-    /// <returns>true for success</returns>
-    bool RemoveLock(string fileId);
+    /// <param name="cancellationToken">cancellation token</param>
+    /// <returns>true if a lock was removed</returns>
+    Task<bool> RemoveLockAsync(string fileId, CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/src/WopiHost.Abstractions/README.md
+++ b/src/WopiHost.Abstractions/README.md
@@ -13,16 +13,16 @@ dotnet add package WopiHost.Abstractions
 
 ## The interfaces
 
-| Interface | Purpose | Default | When to implement |
+| Interface | Purpose | Bundled implementations | When to implement |
 |---|---|---|---|
-| [`IWopiStorageProvider`](IWopiStorageProvider.cs) | Read access to files and containers (folders). | `WopiFileSystemProvider` | Always — there is no useful default beyond the file-system sample. |
-| [`IWopiWritableStorageProvider`](IWopiWritableStorageProvider.cs) | Create / delete / rename / suggest names. Optional. | — | If you want WOPI clients to be able to mutate the store. |
-| [`IWopiLockProvider`](IWopiLockProvider.cs) | Editing locks. Synchronous. | `MemoryLockProvider` (in-process) | Replace for multi-instance hosts. |
+| [`IWopiStorageProvider`](IWopiStorageProvider.cs) | Read access to files and containers (folders). | `WopiFileSystemProvider` (local disk), `WopiAzureStorageProvider` (Azure Blob) | When neither bundled provider fits. |
+| [`IWopiWritableStorageProvider`](IWopiWritableStorageProvider.cs) | Create / delete / rename / suggest names. Optional. | Same providers above also implement this. | If you want WOPI clients to be able to mutate the store. |
+| [`IWopiLockProvider`](IWopiLockProvider.cs) | Editing locks. Asynchronous so out-of-process stores (Azure Blob, Redis, SQL) can plug in without sync-over-async. | `MemoryLockProvider` (in-process), `WopiAzureLockProvider` (blob leases) | Replace for multi-instance hosts. |
 | [`IWopiPermissionProvider`](IWopiPermissionProvider.cs) | What a `ClaimsPrincipal` can do with a file/container. | `DefaultWopiPermissionProvider` (reads from token claims) | Almost always — this is where your ACL model plugs in. |
 | [`IWopiAccessTokenService`](IWopiAccessTokenService.cs) | Issue and validate access tokens. | `JwtAccessTokenService` (signed JWT) | Rarely — only if you need opaque/revocable tokens or external issuance. |
 | [`IWopiHostCapabilities`](IWopiHostCapabilities.cs) | Feature flags reported in `CheckFileInfo`. | `WopiHostCapabilities` | Override individual flags via `WopiHostOptions.OnCheckFileInfo`. |
 
-The defaults marked above ship in `WopiHost.Core`, `WopiHost.FileSystemProvider`, and `WopiHost.MemoryLockProvider` — wired up by `services.AddWopi()`.
+The defaults ship in `WopiHost.Core`, `WopiHost.FileSystemProvider`, `WopiHost.MemoryLockProvider`, `WopiHost.AzureStorageProvider`, and `WopiHost.AzureLockProvider` — selected via `WopiHostOptions.StorageProviderAssemblyName` / `LockProviderAssemblyName`.
 
 ## Resource model
 

--- a/src/WopiHost.Abstractions/WopiConfigurationSections.cs
+++ b/src/WopiHost.Abstractions/WopiConfigurationSections.cs
@@ -16,6 +16,11 @@ public class WopiConfigurationSections
     public const string STORAGE_OPTIONS = WOPI_ROOT + ":StorageProvider";
 
     /// <summary>
+    /// Name of the configuration section related to lock provider settings.
+    /// </summary>
+    public const string LOCK_OPTIONS = WOPI_ROOT + ":LockProvider";
+
+    /// <summary>
     /// Name of the configuration section related to WOPI discovery.
     /// </summary>
     public const string DISCOVERY_OPTIONS = WOPI_ROOT + ":Discovery";

--- a/src/WopiHost.AzureLockProvider/README.md
+++ b/src/WopiHost.AzureLockProvider/README.md
@@ -1,0 +1,81 @@
+# WopiHost.AzureLockProvider
+
+[![NuGet](https://img.shields.io/nuget/v/WopiHost.AzureLockProvider.svg)](https://www.nuget.org/packages/WopiHost.AzureLockProvider)
+[![NuGet](https://img.shields.io/nuget/dt/WopiHost.AzureLockProvider.svg)](https://www.nuget.org/packages/WopiHost.AzureLockProvider)
+
+Distributed [`IWopiLockProvider`](../WopiHost.Abstractions/IWopiLockProvider.cs) backed by **Azure Blob leases**. Use this in place of [WopiHost.MemoryLockProvider](../WopiHost.MemoryLockProvider/README.md) when you run more than one WopiHost instance and need them to agree on who is currently editing a file.
+
+## Install
+
+```bash
+dotnet add package WopiHost.AzureLockProvider
+```
+
+## Configure
+
+```jsonc
+"Wopi": {
+  "LockProviderAssemblyName": "WopiHost.AzureLockProvider",
+  "LockProvider": {
+    "ConnectionString": "UseDevelopmentStorage=true",
+    "ContainerName": "wopi-locks"
+  }
+}
+```
+
+```jsonc
+"Wopi": {
+  "LockProviderAssemblyName": "WopiHost.AzureLockProvider",
+  "LockProvider": {
+    "ServiceUri": "https://my-account.blob.core.windows.net",
+    "ContainerName": "wopi-locks"
+  }
+}
+```
+
+The lock container is dedicated and separate from your content blobs — that keeps lock churn out of the hot data path and lets you put locks in a different storage account if you want.
+
+## Register
+
+```csharp
+builder.Services.AddAzureLockProvider(builder.Configuration);
+builder.Services.AddWopi(o =>
+{
+    o.LockProviderAssemblyName = "WopiHost.AzureLockProvider";
+});
+```
+
+The sample's [`AddLockProvider`](../../sample/WopiHost/ServiceCollectionExtensions.cs) helper recognises `"WopiHost.AzureLockProvider"` and dispatches to the call above.
+
+## How it works
+
+For every `fileId`, the provider holds a **placeholder blob** named `SHA256(fileId)` in the configured container. Two pieces of state coexist:
+
+1. **An infinite-duration Azure blob lease** — provides true cross-instance mutual exclusion. Only one WopiHost instance can hold the lease at a time.
+2. **Blob metadata** — carries the WOPI-level state visible to any instance that can read the blob:
+
+| Metadata key | Meaning |
+|---|---|
+| `wopi_lock_id` | The client-supplied WOPI lock id (any string). |
+| `wopi_lease_id` | The Azure lease GUID — needed by remote instances to renew or release the lease. |
+| `wopi_created` | ISO-8601 timestamp; honours the WOPI 30-minute auto-expiry. |
+
+Why both? The lease provides "is this lock physically held right now"; the metadata provides "who claims it and when did the claim start". An instance handling a `RefreshLock` or `Unlock` reads the metadata to recover the lease GUID stored by whichever instance originally created the lock.
+
+### Crash recovery
+
+If the WopiHost instance that created a lock dies without releasing, the infinite lease persists. The next `GetLock` or `AddLock` call against that fileId notices the metadata indicates a >30-minute-old claim, breaks the lease, and either evicts (`GetLock`) or takes over (`AddLock`). This matches the WOPI specification's 30-minute lock auto-expiry without requiring a background sweeper.
+
+## Caveats
+
+- **Latency**: every WOPI lock op is one or two round-trips to Azure Blob. For high-volume editing scenarios, measure carefully.
+- **Costs**: each lock acquire/refresh/release is a billable Azure Storage operation.
+- **Storage cleanup**: `RemoveLock` deletes the placeholder blob; expired locks are also evicted on observation. There is no separate cleanup process.
+
+## Local development
+
+Works against [Azurite](https://learn.microsoft.com/azure/storage/common/storage-use-azurite). The repo's tests use Testcontainers to spin up Azurite per test run; production hosts will typically use Azurite via Aspire's `AddAzureStorage().RunAsEmulator()` integration (see [WopiHost.AppHost](../../infra/WopiHost.AppHost/Program.cs)).
+
+## License
+
+See the [repo README](../../README.md#license).

--- a/src/WopiHost.AzureLockProvider/ServiceCollectionExtensions.cs
+++ b/src/WopiHost.AzureLockProvider/ServiceCollectionExtensions.cs
@@ -1,0 +1,54 @@
+using Azure.Core;
+using Azure.Identity;
+using Azure.Storage.Blobs;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using WopiHost.Abstractions;
+
+namespace WopiHost.AzureLockProvider;
+
+/// <summary>
+/// DI extensions to register <see cref="WopiAzureLockProvider"/>.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="WopiAzureLockProvider"/> as the <see cref="IWopiLockProvider"/> in the
+    /// container. Reads <see cref="WopiAzureLockProviderOptions"/> from the <c>Wopi:LockProvider</c>
+    /// configuration section. The lock container is created on first use.
+    /// </summary>
+    public static IServiceCollection AddAzureLockProvider(this IServiceCollection services, IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services
+            .AddOptions<WopiAzureLockProviderOptions>()
+            .Bind(configuration.GetSection(WopiConfigurationSections.LOCK_OPTIONS))
+            .Validate(o => !string.IsNullOrWhiteSpace(o.ContainerName), "Wopi:LockProvider:ContainerName is required.")
+            .Validate(o => !string.IsNullOrWhiteSpace(o.ConnectionString) || !string.IsNullOrWhiteSpace(o.ServiceUri),
+                "Either Wopi:LockProvider:ConnectionString or Wopi:LockProvider:ServiceUri must be set.")
+            .ValidateOnStart();
+
+        services.AddSingleton<WopiAzureLockProvider>(sp =>
+        {
+            var opts = sp.GetRequiredService<IOptions<WopiAzureLockProviderOptions>>().Value;
+            BlobServiceClient serviceClient;
+            if (!string.IsNullOrWhiteSpace(opts.ConnectionString))
+            {
+                serviceClient = new BlobServiceClient(opts.ConnectionString);
+            }
+            else
+            {
+                var credential = sp.GetService<TokenCredential>() ?? new DefaultAzureCredential();
+                serviceClient = new BlobServiceClient(new Uri(opts.ServiceUri!), credential);
+            }
+            var container = serviceClient.GetBlobContainerClient(opts.ContainerName);
+            return new WopiAzureLockProvider(container, sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<WopiAzureLockProvider>>());
+        });
+        services.AddSingleton<IWopiLockProvider>(sp => sp.GetRequiredService<WopiAzureLockProvider>());
+
+        return services;
+    }
+}

--- a/src/WopiHost.AzureLockProvider/WopiAzureLockProvider.cs
+++ b/src/WopiHost.AzureLockProvider/WopiAzureLockProvider.cs
@@ -1,0 +1,273 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Specialized;
+using Microsoft.Extensions.Logging;
+using WopiHost.Abstractions;
+
+namespace WopiHost.AzureLockProvider;
+
+/// <summary>
+/// <see cref="IWopiLockProvider"/> backed by Azure Blob leases.
+/// </summary>
+/// <remarks>
+/// <para>
+/// For each <c>fileId</c>, the provider creates a placeholder blob in <see cref="WopiAzureLockProviderOptions.ContainerName"/>
+/// and acquires an <em>infinite</em> blob lease. The Azure lease provides true cross-instance
+/// exclusion (only one WopiHost instance can hold the lease at a time), while the blob's metadata
+/// carries the WOPI-level state (the client-supplied lock id, the Azure lease GUID, and the
+/// creation timestamp used to honour the WOPI 30-minute expiry).
+/// </para>
+/// <para>
+/// Cross-instance coordination on refresh / remove works because the lease GUID is stored in blob
+/// metadata: any instance that observes the lock can read it back and call renew/release. If the
+/// instance that created the lock dies, the infinite lease survives until another instance
+/// observes the WOPI-expiry has passed and explicitly breaks the lease in <see cref="GetLockAsync"/>.
+/// </para>
+/// </remarks>
+public class WopiAzureLockProvider : IWopiLockProvider
+{
+    internal const string LockIdKey = "wopi_lock_id";
+    internal const string LeaseIdKey = "wopi_lease_id";
+    internal const string CreatedKey = "wopi_created";
+
+    private readonly BlobContainerClient containerClient;
+    private readonly ILogger<WopiAzureLockProvider> logger;
+    private readonly SemaphoreSlim initLock = new(1, 1);
+    private bool initialized;
+
+    /// <summary>Create the provider from a configured <see cref="BlobContainerClient"/>.</summary>
+    public WopiAzureLockProvider(BlobContainerClient containerClient, ILogger<WopiAzureLockProvider> logger)
+    {
+        this.containerClient = containerClient ?? throw new ArgumentNullException(nameof(containerClient));
+        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<WopiLockInfo?> GetLockAsync(string fileId, CancellationToken cancellationToken = default)
+    {
+        await EnsureContainerAsync(cancellationToken).ConfigureAwait(false);
+        var blobClient = GetLockBlob(fileId);
+        var props = await TryGetPropertiesAsync(blobClient, cancellationToken).ConfigureAwait(false);
+        if (props is null || !TryReadLock(fileId, props, out var info))
+        {
+            return null;
+        }
+        if (!info.Expired)
+        {
+            return info;
+        }
+
+        // WOPI-expired. Break the lease so subsequent AddLock calls can take over, then evict.
+        await TryBreakLeaseAsync(blobClient, cancellationToken).ConfigureAwait(false);
+        await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        return null;
+    }
+
+    /// <inheritdoc />
+    public async Task<WopiLockInfo?> AddLockAsync(string fileId, string lockId, CancellationToken cancellationToken = default)
+    {
+        await EnsureContainerAsync(cancellationToken).ConfigureAwait(false);
+        var blobClient = GetLockBlob(fileId);
+
+        // Honour WOPI expiry: a stale (>30 min old) lock can be taken over.
+        var existing = await TryGetPropertiesAsync(blobClient, cancellationToken).ConfigureAwait(false);
+        if (existing is not null && TryReadLock(fileId, existing, out var existingInfo) && !existingInfo.Expired)
+        {
+            return null;
+        }
+        if (existing is not null)
+        {
+            // Either no valid metadata or expired. Break the lease and delete so we can start fresh.
+            await TryBreakLeaseAsync(blobClient, cancellationToken).ConfigureAwait(false);
+            await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        // Upload the placeholder. If two callers race here, exactly one wins (overwrite=false).
+        try
+        {
+            using var empty = new MemoryStream(Array.Empty<byte>(), writable: false);
+            await blobClient.UploadAsync(empty, overwrite: false, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (RequestFailedException ex) when (ex.Status == 409)
+        {
+            // Raced with another caller that just created the blob.
+            return null;
+        }
+
+        var leaseId = Guid.NewGuid().ToString();
+        var now = DateTimeOffset.UtcNow;
+        var leaseClient = blobClient.GetBlobLeaseClient(leaseId);
+
+        try
+        {
+            await leaseClient.AcquireAsync(TimeSpan.FromSeconds(-1), cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (RequestFailedException ex)
+        {
+            // Couldn't lease — clean up the placeholder so we don't leave a no-op blob behind.
+            logger.LogWarning(ex, "Failed to acquire lease for fileId {FileId}", fileId);
+            await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            return null;
+        }
+
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [LockIdKey] = lockId,
+            [LeaseIdKey] = leaseId,
+            [CreatedKey] = now.ToString("O", CultureInfo.InvariantCulture),
+        };
+        await blobClient.SetMetadataAsync(metadata,
+            conditions: new BlobRequestConditions { LeaseId = leaseId },
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return new WopiLockInfo { FileId = fileId, LockId = lockId, DateCreated = now };
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> RefreshLockAsync(string fileId, string? lockId = null, CancellationToken cancellationToken = default)
+    {
+        await EnsureContainerAsync(cancellationToken).ConfigureAwait(false);
+        var blobClient = GetLockBlob(fileId);
+        var props = await TryGetPropertiesAsync(blobClient, cancellationToken).ConfigureAwait(false);
+        if (props is null || !TryReadLock(fileId, props, out var info))
+        {
+            return false;
+        }
+        if (info.Expired)
+        {
+            return false;
+        }
+        if (!props.Metadata.TryGetValue(LeaseIdKey, out var leaseId) || string.IsNullOrEmpty(leaseId))
+        {
+            return false;
+        }
+
+        // Renew the lease so the holder semantic stays alive (no-op for infinite leases but still
+        // confirms the lease is still ours), then update timestamp + optional new lockId.
+        var leaseClient = blobClient.GetBlobLeaseClient(leaseId);
+        try
+        {
+            await leaseClient.RenewAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (RequestFailedException ex)
+        {
+            logger.LogWarning(ex, "Failed to renew lease for fileId {FileId}", fileId);
+            return false;
+        }
+
+        var updated = new Dictionary<string, string>(props.Metadata, StringComparer.Ordinal)
+        {
+            [LockIdKey] = lockId ?? info.LockId,
+            [CreatedKey] = DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture),
+        };
+        try
+        {
+            await blobClient.SetMetadataAsync(updated,
+                conditions: new BlobRequestConditions { LeaseId = leaseId },
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (RequestFailedException ex)
+        {
+            logger.LogWarning(ex, "Failed to update metadata while refreshing lock for fileId {FileId}", fileId);
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> RemoveLockAsync(string fileId, CancellationToken cancellationToken = default)
+    {
+        await EnsureContainerAsync(cancellationToken).ConfigureAwait(false);
+        var blobClient = GetLockBlob(fileId);
+        var props = await TryGetPropertiesAsync(blobClient, cancellationToken).ConfigureAwait(false);
+        if (props is null)
+        {
+            return false;
+        }
+        if (props.Metadata.TryGetValue(LeaseIdKey, out var leaseId) && !string.IsNullOrEmpty(leaseId))
+        {
+            try
+            {
+                await blobClient.GetBlobLeaseClient(leaseId).ReleaseAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+            catch (RequestFailedException ex) when (ex.Status == 409 || ex.Status == 412)
+            {
+                // Lease already gone or mismatch — fall back to break-lease so the delete can proceed.
+                await TryBreakLeaseAsync(blobClient, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        var deleted = await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        return deleted.Value;
+    }
+
+    private async Task EnsureContainerAsync(CancellationToken cancellationToken)
+    {
+        if (initialized)
+        {
+            return;
+        }
+        await initLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (initialized)
+            {
+                return;
+            }
+            await containerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            initialized = true;
+        }
+        finally
+        {
+            initLock.Release();
+        }
+    }
+
+    private BlobClient GetLockBlob(string fileId)
+    {
+        // Hash the fileId so any caller-supplied identifier is reduced to a safe blob name.
+        var name = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(fileId))).ToLowerInvariant();
+        return containerClient.GetBlobClient(name);
+    }
+
+    private static async Task<BlobProperties?> TryGetPropertiesAsync(BlobClient blobClient, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await blobClient.GetPropertiesAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            return null;
+        }
+    }
+
+    private static async Task TryBreakLeaseAsync(BlobClient blobClient, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await blobClient.GetBlobLeaseClient().BreakAsync(breakPeriod: TimeSpan.Zero, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (RequestFailedException)
+        {
+            // Best-effort — if the lease is already gone or the blob disappeared, we don't care.
+        }
+    }
+
+    private static bool TryReadLock(string fileId, BlobProperties props, out WopiLockInfo info)
+    {
+        info = default!;
+        if (props.Metadata is not { Count: > 0 } meta) return false;
+        if (!meta.TryGetValue(LockIdKey, out var lockId) || string.IsNullOrEmpty(lockId)) return false;
+        if (!meta.TryGetValue(CreatedKey, out var createdStr)
+            || !DateTimeOffset.TryParse(createdStr, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var created))
+        {
+            return false;
+        }
+        info = new WopiLockInfo { FileId = fileId, LockId = lockId, DateCreated = created };
+        return true;
+    }
+}

--- a/src/WopiHost.AzureLockProvider/WopiAzureLockProviderOptions.cs
+++ b/src/WopiHost.AzureLockProvider/WopiAzureLockProviderOptions.cs
@@ -1,0 +1,25 @@
+namespace WopiHost.AzureLockProvider;
+
+/// <summary>
+/// Configuration for <see cref="WopiAzureLockProvider"/>.
+/// </summary>
+/// <remarks>
+/// Bind to the <c>Wopi:LockProvider</c> configuration section. Authentication mirrors the storage
+/// provider: prefer <see cref="ConnectionString"/> if set, otherwise <see cref="ServiceUri"/> +
+/// <see cref="Azure.Core.TokenCredential"/> from DI (default: <see cref="Azure.Identity.DefaultAzureCredential"/>).
+/// </remarks>
+public class WopiAzureLockProviderOptions
+{
+    /// <summary>Storage account connection string. Use <c>UseDevelopmentStorage=true</c> for Azurite.</summary>
+    public string? ConnectionString { get; set; }
+
+    /// <summary>Blob service endpoint when using <see cref="Azure.Core.TokenCredential"/>.</summary>
+    public string? ServiceUri { get; set; }
+
+    /// <summary>
+    /// Name of the blob container that holds the per-fileId lock placeholder blobs. Will be created
+    /// on first use if missing. A dedicated container is recommended so locks are isolated from
+    /// content blobs (and so a different storage account can be used for lock state if desired).
+    /// </summary>
+    public string ContainerName { get; set; } = "wopi-locks";
+}

--- a/src/WopiHost.AzureLockProvider/WopiHost.AzureLockProvider.csproj
+++ b/src/WopiHost.AzureLockProvider/WopiHost.AzureLockProvider.csproj
@@ -1,0 +1,51 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<Nullable>enable</Nullable>
+		<Description>WopiHost.AzureLockProvider Class Library — distributed lock provider backed by Azure Blob leases.</Description>
+		<Authors>Petr Svihlik</Authors>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<AssemblyName>WopiHost.AzureLockProvider</AssemblyName>
+		<PackageId>WopiHost.AzureLockProvider</PackageId>
+		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+		<PackageIcon>logo.png</PackageIcon>
+		<PackageTags>WOPI;Azure;Blob;Lease;Lock;Office Online Server;Office Web Apps;Web Application Open Platform Interface</PackageTags>
+		<RepositoryType>git</RepositoryType>
+		<RepositoryUrl>https://github.com/petrsvihlik/WopiHost.git</RepositoryUrl>
+		<GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+		<GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+		<GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+		<EnablePackageValidation>false</EnablePackageValidation>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="..\..\LICENSE.txt" Pack="true" PackagePath="" />
+		<None Include="..\..\img\logo.png" Pack="true" PackagePath="" />
+		<None Include="README.md" Pack="true" PackagePath="" />
+	</ItemGroup>
+
+	<PropertyGroup>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+		<PackageReference Include="Azure.Storage.Blobs" />
+		<PackageReference Include="Azure.Identity" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+		<PackageReference Include="Microsoft.DotNet.PackageValidation" PrivateAssets="All" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\WopiHost.Abstractions\WopiHost.Abstractions.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/WopiHost.AzureStorageProvider/BlobIdMap.cs
+++ b/src/WopiHost.AzureStorageProvider/BlobIdMap.cs
@@ -1,0 +1,125 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace WopiHost.AzureStorageProvider;
+
+/// <summary>
+/// Maps WOPI identifiers to blob paths inside a single Azure Blob container.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Identifiers are deterministic hex-MD5 hashes of the lowercased blob path so the same blob always
+/// produces the same ID across process restarts and separate WopiHost instances. The mapping itself
+/// is held in memory and is rebuilt by <see cref="ScanAll"/> at startup; this matches the pattern used
+/// by <c>WopiHost.FileSystemProvider</c>'s <c>InMemoryFileIds</c>.
+/// </para>
+/// <para>
+/// Folders are virtual: a path with no extension and no marker blob still appears in the map if any
+/// child blob shares its prefix, plus the explicit folder-marker blob (<see cref="FolderMarker"/>) is
+/// recognised as creating an otherwise-empty folder.
+/// </para>
+/// </remarks>
+public sealed class BlobIdMap(ILogger<BlobIdMap> logger)
+{
+    /// <summary>
+    /// Zero-byte marker blob name used to materialize otherwise-empty folders.
+    /// </summary>
+    /// <remarks>
+    /// Plain Azure Blob Storage has no concept of an empty directory. To keep parity with
+    /// <c>WopiFileSystemProvider</c>'s ability to create an empty folder via
+    /// <c>CreateWopiChildResource&lt;IWopiFolder&gt;</c>, we drop a 0-byte blob with this name into the
+    /// folder. The provider hides marker blobs from listings so callers never see them.
+    /// </remarks>
+    public const string FolderMarker = ".wopi.folder";
+
+    private readonly Dictionary<string, string> idToPath = new(StringComparer.Ordinal);
+
+    /// <summary>Whether <see cref="ScanAll(IEnumerable{string})"/> has been called.</summary>
+    public bool WasScanned { get; private set; }
+
+    /// <summary>Looks up the blob path for an identifier.</summary>
+    public bool TryGetPath(string fileId, [NotNullWhen(true)] out string? path)
+        => idToPath.TryGetValue(fileId, out path);
+
+    /// <summary>Looks up the identifier for a blob path. Path comparison is case-sensitive.</summary>
+    public bool TryGetFileId(string path, [NotNullWhen(true)] out string? fileId)
+    {
+        foreach (var pair in idToPath)
+        {
+            if (pair.Value == path)
+            {
+                fileId = pair.Key;
+                return true;
+            }
+        }
+        fileId = null;
+        return false;
+    }
+
+    /// <summary>Adds (or replaces) a path-to-id mapping and returns the deterministic id.</summary>
+    public string Add(string path)
+    {
+        var id = IdFromPath(path);
+        idToPath[id] = path;
+        return id;
+    }
+
+    /// <summary>Removes a mapping by id.</summary>
+    public bool Remove(string fileId) => idToPath.Remove(fileId);
+
+    /// <summary>Updates the path for an existing id (used after a rename to keep the id stable).</summary>
+    public void Update(string fileId, string newPath) => idToPath[fileId] = newPath;
+
+    /// <summary>
+    /// Rebuilds the map from a flat enumeration of blob paths. The empty path is treated as the root
+    /// container. Every directory prefix encountered is also added so containers without an explicit
+    /// folder-marker blob are still addressable.
+    /// </summary>
+    public void ScanAll(IEnumerable<string> blobPaths)
+    {
+        idToPath.Clear();
+        // Root container is always identified by the empty string.
+        idToPath[IdFromPath(string.Empty)] = string.Empty;
+
+        var seenDirs = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var path in blobPaths)
+        {
+            // Hide folder markers from the file map but make sure the parent folder is registered.
+            var fileName = path[(path.LastIndexOf('/') + 1)..];
+            if (fileName == FolderMarker)
+            {
+                var parent = path[..^FolderMarker.Length].TrimEnd('/');
+                AddDirectoryAndAncestors(parent, seenDirs);
+                continue;
+            }
+
+            idToPath[IdFromPath(path)] = path;
+
+            var lastSlash = path.LastIndexOf('/');
+            if (lastSlash > 0)
+            {
+                AddDirectoryAndAncestors(path[..lastSlash], seenDirs);
+            }
+        }
+
+        WasScanned = true;
+        logger.LogInformation("Scanned {Count} blob entries", idToPath.Count);
+    }
+
+    private void AddDirectoryAndAncestors(string dirPath, HashSet<string> seen)
+    {
+        var current = dirPath;
+        while (!string.IsNullOrEmpty(current) && seen.Add(current))
+        {
+            idToPath[IdFromPath(current)] = current;
+            var slash = current.LastIndexOf('/');
+            current = slash > 0 ? current[..slash] : string.Empty;
+        }
+    }
+
+    /// <summary>Returns the deterministic id for a blob path.</summary>
+    public static string IdFromPath(string path)
+        => Convert.ToHexString(MD5.HashData(Encoding.UTF8.GetBytes(path.ToLowerInvariant()))).ToLowerInvariant();
+}

--- a/src/WopiHost.AzureStorageProvider/HashingBlobWriteStream.cs
+++ b/src/WopiHost.AzureStorageProvider/HashingBlobWriteStream.cs
@@ -1,0 +1,105 @@
+using System.Security.Cryptography;
+using Azure.Storage.Blobs;
+
+namespace WopiHost.AzureStorageProvider;
+
+/// <summary>
+/// Wraps the blob upload stream returned by <see cref="BlobClient.OpenWriteAsync(bool, Azure.Storage.Blobs.Models.BlobOpenWriteOptions, System.Threading.CancellationToken)"/>
+/// so callers can stream large content while we incrementally compute SHA-256 of the new payload.
+/// On dispose, the hash is finalized and written back as the <see cref="WopiBlobFile.Sha256MetadataKey"/>
+/// metadata key, preserving the metadata that existed before the write.
+/// </summary>
+internal sealed class HashingBlobWriteStream : Stream
+{
+    private readonly Stream inner;
+    private readonly BlobClient blobClient;
+    private readonly Dictionary<string, string> metadataToWrite;
+    private readonly IncrementalHash hasher = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+    private bool disposed;
+
+    public HashingBlobWriteStream(Stream inner, BlobClient blobClient, Dictionary<string, string> preservedMetadata)
+    {
+        this.inner = inner;
+        this.blobClient = blobClient;
+        this.metadataToWrite = preservedMetadata;
+    }
+
+    public override bool CanRead => false;
+    public override bool CanSeek => false;
+    public override bool CanWrite => true;
+    public override long Length => throw new NotSupportedException();
+
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override void Flush() => inner.Flush();
+    public override Task FlushAsync(CancellationToken cancellationToken) => inner.FlushAsync(cancellationToken);
+
+    public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        hasher.AppendData(buffer, offset, count);
+        inner.Write(buffer, offset, count);
+    }
+
+    public override void Write(ReadOnlySpan<byte> buffer)
+    {
+        hasher.AppendData(buffer);
+        inner.Write(buffer);
+    }
+
+    public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        hasher.AppendData(buffer, offset, count);
+        await inner.WriteAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
+    }
+
+    public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        hasher.AppendData(buffer.Span);
+        await inner.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        if (disposed)
+        {
+            return;
+        }
+        disposed = true;
+
+        // Closing/disposing the inner Azure write stream is what actually commits the blob.
+        await inner.DisposeAsync().ConfigureAwait(false);
+
+        var hash = hasher.GetCurrentHash();
+        hasher.Dispose();
+        metadataToWrite[WopiBlobFile.Sha256MetadataKey] = Convert.ToHexString(hash).ToLowerInvariant();
+
+        await blobClient.SetMetadataAsync(metadataToWrite).ConfigureAwait(false);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        // Synchronous dispose is unavoidable for callers that don't await DisposeAsync; do the
+        // expensive bits inline. Intentionally no GetAwaiter().GetResult() on user-facing async
+        // calls here — we already removed sync-over-async from the lock provider; this stream is the
+        // last necessary sync-over-async boundary because Stream.Dispose can't be async.
+        if (disposed || !disposing)
+        {
+            return;
+        }
+        disposed = true;
+
+        inner.Dispose();
+        var hash = hasher.GetCurrentHash();
+        hasher.Dispose();
+        metadataToWrite[WopiBlobFile.Sha256MetadataKey] = Convert.ToHexString(hash).ToLowerInvariant();
+        blobClient.SetMetadata(metadataToWrite);
+    }
+}

--- a/src/WopiHost.AzureStorageProvider/README.md
+++ b/src/WopiHost.AzureStorageProvider/README.md
@@ -1,0 +1,96 @@
+# WopiHost.AzureStorageProvider
+
+[![NuGet](https://img.shields.io/nuget/v/WopiHost.AzureStorageProvider.svg)](https://www.nuget.org/packages/WopiHost.AzureStorageProvider)
+[![NuGet](https://img.shields.io/nuget/dt/WopiHost.AzureStorageProvider.svg)](https://www.nuget.org/packages/WopiHost.AzureStorageProvider)
+
+[`IWopiStorageProvider`](../WopiHost.Abstractions/IWopiStorageProvider.cs) + [`IWopiWritableStorageProvider`](../WopiHost.Abstractions/IWopiWritableStorageProvider.cs) backed by **Azure Blob Storage**. WOPI files map directly to blobs; folders are virtual prefixes with a hidden zero-byte marker so empty folders remain addressable.
+
+Suitable for production multi-instance deployments. Use with [WopiHost.AzureLockProvider](../WopiHost.AzureLockProvider/README.md) for distributed locking.
+
+## Install
+
+```bash
+dotnet add package WopiHost.AzureStorageProvider
+```
+
+## Configure
+
+Two authentication modes — connection string (Azurite, dev) and `TokenCredential` (managed identity, service principal):
+
+```jsonc
+// appsettings.json — connection string
+"Wopi": {
+  "StorageProviderAssemblyName": "WopiHost.AzureStorageProvider",
+  "StorageProvider": {
+    "ConnectionString": "UseDevelopmentStorage=true",
+    "ContainerName": "wopi-files"
+  }
+}
+```
+
+```jsonc
+// appsettings.json — DefaultAzureCredential
+"Wopi": {
+  "StorageProviderAssemblyName": "WopiHost.AzureStorageProvider",
+  "StorageProvider": {
+    "ServiceUri": "https://my-account.blob.core.windows.net",
+    "ContainerName": "wopi-files"
+  }
+}
+```
+
+When `ServiceUri` is used the provider resolves a `TokenCredential` from DI; if none is registered, [`DefaultAzureCredential`](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) is created automatically. Register your own to override:
+
+```csharp
+builder.Services.AddSingleton<TokenCredential>(new ManagedIdentityCredential(clientId));
+```
+
+The container is created on first use if it doesn't exist.
+
+## Register
+
+```csharp
+builder.Services.AddAzureStorageProvider(builder.Configuration);
+builder.Services.AddWopi(o =>
+{
+    o.ClientUrl                   = new Uri("https://your-office-online-server.com");
+    o.StorageProviderAssemblyName = "WopiHost.AzureStorageProvider";
+});
+```
+
+The sample's [`AddStorageProvider`](../../sample/WopiHost/ServiceCollectionExtensions.cs) helper recognises `"WopiHost.AzureStorageProvider"` and dispatches to the call above, so a single config-driven registration works there too.
+
+## How it maps to Blob Storage
+
+| WOPI concept | Azure Blob equivalent |
+|---|---|
+| File content | Blob bytes |
+| `IWopiFile.Length`, `LastWriteTimeUtc` | Blob `ContentLength`, `LastModified` |
+| `IWopiFile.Version` | Blob `ETag` (changes on every byte-level update) |
+| `IWopiFile.Owner` | Blob metadata key `wopi_owner` (empty string when unset) |
+| `IWopiFile.Checksum` (SHA-256) | Blob metadata key `wopi_sha256` (lowercase hex), computed during upload |
+| Folder | Virtual blob-name prefix (`/` delimiter) + zero-byte marker `.wopi.folder` for materialising empty folders |
+| Identifier | Hex-MD5 of the lowercased blob path (matches `WopiHost.FileSystemProvider`) |
+
+The provider scans the container at first access to populate the in-memory id-to-path map. Identifiers are stable across process restarts (deterministic from path) but not across renames — a rename re-points the existing id to the new path so the WOPI URL doesn't break mid-edit.
+
+## Caveats
+
+- **Folder rename / delete-folder** are O(N) over the children — plain Blob has no atomic prefix rename. If you do this often, consider switching to ADLS Gen2 (not currently supported, see [issue #26](https://github.com/petrsvihlik/WopiHost/issues/26)) for atomic rename via the DFS endpoint.
+- **Empty folders** are materialised by writing a zero-byte `.wopi.folder` blob. Listings filter it out; deleting an empty folder removes the marker and drops the id.
+- **SHA-256** is computed streaming on upload via [`HashingBlobWriteStream`](HashingBlobWriteStream.cs) and stored as metadata. Pre-existing blobs that were not written through this provider will return `null` from `Checksum` until they are next written.
+- **Owner** is read from blob metadata; the provider doesn't *set* an owner on its own. Hosts that care about ownership should set `wopi_owner` themselves (e.g. via a custom write pipeline that enriches metadata after `GetWriteStream`).
+
+## Local development
+
+The provider works against [Azurite](https://learn.microsoft.com/azure/storage/common/storage-use-azurite). The repo's Aspire AppHost runs Azurite as a container resource when `AppHost:UseAzureStorage=true`:
+
+```bash
+AppHost__UseAzureStorage=true dotnet run --project infra/WopiHost.AppHost
+```
+
+The Aspire orchestrator forwards the emulator connection string into `WopiHost` as `ConnectionStrings:BlobStorage`, which you can map into `Wopi:StorageProvider:ConnectionString` via standard configuration substitution.
+
+## License
+
+See the [repo README](../../README.md#license).

--- a/src/WopiHost.AzureStorageProvider/ServiceCollectionExtensions.cs
+++ b/src/WopiHost.AzureStorageProvider/ServiceCollectionExtensions.cs
@@ -1,0 +1,74 @@
+using Azure.Core;
+using Azure.Identity;
+using Azure.Storage.Blobs;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using WopiHost.Abstractions;
+
+namespace WopiHost.AzureStorageProvider;
+
+/// <summary>
+/// DI extensions to register <see cref="WopiAzureStorageProvider"/>.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="WopiAzureStorageProvider"/> as both <see cref="IWopiStorageProvider"/> and
+    /// <see cref="IWopiWritableStorageProvider"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Reads <see cref="WopiAzureStorageProviderOptions"/> from the <c>Wopi:StorageProvider</c>
+    /// configuration section. If <c>ConnectionString</c> is set, that wins (typical for Azurite/dev).
+    /// Otherwise <c>ServiceUri</c> is required and is paired with whatever <see cref="TokenCredential"/>
+    /// the caller has registered in DI; if none is registered, <see cref="DefaultAzureCredential"/> is
+    /// used.
+    /// </para>
+    /// <para>
+    /// The host can call this directly for explicit registration, or rely on
+    /// <c>services.AddStorageProvider("WopiHost.AzureStorageProvider")</c> to discover and register it
+    /// via the assembly-name convention used by the rest of WopiHost.
+    /// </para>
+    /// </remarks>
+    public static IServiceCollection AddAzureStorageProvider(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services
+            .AddOptions<WopiAzureStorageProviderOptions>()
+            .Bind(configuration.GetSection(WopiConfigurationSections.STORAGE_OPTIONS))
+            .Validate(o => !string.IsNullOrWhiteSpace(o.ContainerName), "Wopi:StorageProvider:ContainerName is required.")
+            .Validate(o => !string.IsNullOrWhiteSpace(o.ConnectionString) || !string.IsNullOrWhiteSpace(o.ServiceUri),
+                "Either Wopi:StorageProvider:ConnectionString or Wopi:StorageProvider:ServiceUri must be set.")
+            .ValidateOnStart();
+
+        services.TryAddSingleton<BlobIdMap>();
+
+        services.AddSingleton(sp =>
+        {
+            var opts = sp.GetRequiredService<IOptions<WopiAzureStorageProviderOptions>>().Value;
+            BlobServiceClient serviceClient;
+            if (!string.IsNullOrWhiteSpace(opts.ConnectionString))
+            {
+                serviceClient = new BlobServiceClient(opts.ConnectionString);
+            }
+            else
+            {
+                var credential = sp.GetService<TokenCredential>() ?? new DefaultAzureCredential();
+                serviceClient = new BlobServiceClient(new Uri(opts.ServiceUri!), credential);
+            }
+            return serviceClient.GetBlobContainerClient(opts.ContainerName);
+        });
+
+        services.AddSingleton<WopiAzureStorageProvider>();
+        services.AddSingleton<IWopiStorageProvider>(sp => sp.GetRequiredService<WopiAzureStorageProvider>());
+        services.AddSingleton<IWopiWritableStorageProvider>(sp => sp.GetRequiredService<WopiAzureStorageProvider>());
+
+        return services;
+    }
+}

--- a/src/WopiHost.AzureStorageProvider/WopiAzureStorageProvider.cs
+++ b/src/WopiHost.AzureStorageProvider/WopiAzureStorageProvider.cs
@@ -1,0 +1,516 @@
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Microsoft.Extensions.Logging;
+using WopiHost.Abstractions;
+
+namespace WopiHost.AzureStorageProvider;
+
+/// <summary>
+/// <see cref="IWopiStorageProvider"/> + <see cref="IWopiWritableStorageProvider"/> backed by Azure Blob Storage.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Folders are virtual: they map to <c>/</c>-delimited blob-name prefixes. An "empty" folder is
+/// materialized via a zero-byte folder-marker blob (<see cref="BlobIdMap.FolderMarker"/>) so that
+/// freshly-created folders are addressable until something is written to them.
+/// </para>
+/// <para>
+/// Identifiers are deterministic hex-MD5 of the lowercased blob path (see <see cref="BlobIdMap"/>),
+/// matching the scheme used by <c>WopiHost.FileSystemProvider</c>. Identifiers are stable across
+/// process restarts as long as paths don't change. A rename preserves the identifier by re-pointing
+/// the in-memory map to the new path.
+/// </para>
+/// </remarks>
+public class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWritableStorageProvider
+{
+    private readonly BlobContainerClient containerClient;
+    private readonly BlobIdMap idMap;
+    private readonly ILogger<WopiAzureStorageProvider> logger;
+    private readonly SemaphoreSlim initLock = new(1, 1);
+    private bool initialized;
+
+    /// <inheritdoc/>
+    public IWopiFolder RootContainerPointer { get; }
+
+    /// <summary>Create the provider from a configured <see cref="BlobContainerClient"/>.</summary>
+    public WopiAzureStorageProvider(
+        BlobContainerClient containerClient,
+        BlobIdMap idMap,
+        ILogger<WopiAzureStorageProvider> logger)
+    {
+        this.containerClient = containerClient ?? throw new ArgumentNullException(nameof(containerClient));
+        this.idMap = idMap ?? throw new ArgumentNullException(nameof(idMap));
+        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        var rootId = BlobIdMap.IdFromPath(string.Empty);
+        RootContainerPointer = new WopiBlobFolder(string.Empty, rootId);
+    }
+
+    private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
+    {
+        if (initialized)
+        {
+            return;
+        }
+        await initLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (initialized)
+            {
+                return;
+            }
+            await containerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (!idMap.WasScanned)
+            {
+                var paths = new List<string>();
+                await foreach (var item in containerClient.GetBlobsAsync(traits: BlobTraits.None, states: BlobStates.None, prefix: null, cancellationToken: cancellationToken).ConfigureAwait(false))
+                {
+                    paths.Add(item.Name);
+                }
+                idMap.ScanAll(paths);
+            }
+            initialized = true;
+            logger.LogInformation("WopiAzureStorageProvider initialized for container {Container}", containerClient.Name);
+        }
+        finally
+        {
+            initLock.Release();
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<T?> GetWopiResource<T>(string identifier, CancellationToken cancellationToken = default)
+        where T : class, IWopiResource
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        if (!idMap.TryGetPath(identifier, out var path))
+        {
+            return null;
+        }
+
+        if (typeof(IWopiFile).IsAssignableFrom(typeof(T)))
+        {
+            var blobClient = containerClient.GetBlobClient(path);
+            return await WopiBlobFile.CreateAsync(blobClient, path, identifier, cancellationToken).ConfigureAwait(false) as T;
+        }
+        if (typeof(IWopiFolder).IsAssignableFrom(typeof(T)))
+        {
+            return new WopiBlobFolder(path, identifier) as T;
+        }
+        throw new NotSupportedException($"Unsupported resource type: {typeof(T).Name}");
+    }
+
+    /// <inheritdoc/>
+    public async IAsyncEnumerable<IWopiFile> GetWopiFiles(
+        string? identifier = null,
+        string? searchPattern = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        var folderPath = ResolveFolderPath(identifier ?? RootContainerPointer.Identifier);
+        var prefix = string.IsNullOrEmpty(folderPath) ? null : folderPath + "/";
+
+        var matcher = BuildSearchMatcher(searchPattern);
+
+        await foreach (var item in containerClient.GetBlobsByHierarchyAsync(traits: BlobTraits.None, states: BlobStates.None, delimiter: "/", prefix: prefix, cancellationToken: cancellationToken).ConfigureAwait(false))
+        {
+            if (item.IsBlob is false)
+            {
+                continue;
+            }
+            var name = item.Blob.Name;
+            // Skip the folder-marker blob — it represents the parent's existence, not a real file.
+            if (name.EndsWith("/" + BlobIdMap.FolderMarker, StringComparison.Ordinal)
+                || name == BlobIdMap.FolderMarker)
+            {
+                continue;
+            }
+            var fileName = name[(name.LastIndexOf('/') + 1)..];
+            if (matcher is not null && !matcher(fileName))
+            {
+                continue;
+            }
+            var id = idMap.TryGetFileId(name, out var existingId) ? existingId : idMap.Add(name);
+            var blobClient = containerClient.GetBlobClient(name);
+            yield return await WopiBlobFile.CreateAsync(blobClient, name, id, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async IAsyncEnumerable<IWopiFolder> GetWopiContainers(
+        string? identifier = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        var folderPath = ResolveFolderPath(identifier ?? RootContainerPointer.Identifier);
+        var prefix = string.IsNullOrEmpty(folderPath) ? null : folderPath + "/";
+
+        await foreach (var item in containerClient.GetBlobsByHierarchyAsync(traits: BlobTraits.None, states: BlobStates.None, delimiter: "/", prefix: prefix, cancellationToken: cancellationToken).ConfigureAwait(false))
+        {
+            if (item.IsPrefix is false)
+            {
+                continue;
+            }
+            var subPrefix = item.Prefix.TrimEnd('/');
+            var id = idMap.TryGetFileId(subPrefix, out var existingId) ? existingId : idMap.Add(subPrefix);
+            yield return new WopiBlobFolder(subPrefix, id);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<ReadOnlyCollection<IWopiFolder>> GetAncestors<T>(string identifier, CancellationToken cancellationToken = default)
+        where T : class, IWopiResource
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        if (!idMap.TryGetPath(identifier, out var path))
+        {
+            throw new DirectoryNotFoundException($"Resource '{identifier}' not found.");
+        }
+
+        var result = new List<IWopiFolder>();
+
+        if (typeof(IWopiFile).IsAssignableFrom(typeof(T)))
+        {
+            // Always include the immediate parent for files (matches WopiFileSystemProvider behavior).
+            var parentPath = GetParentPath(path);
+            var parentId = idMap.TryGetFileId(parentPath, out var existingId) ? existingId : idMap.Add(parentPath);
+            result.Add(new WopiBlobFolder(parentPath, parentId));
+            path = parentPath;
+        }
+
+        while (!string.IsNullOrEmpty(path))
+        {
+            path = GetParentPath(path);
+            var ancestorId = idMap.TryGetFileId(path, out var existingId) ? existingId : idMap.Add(path);
+            result.Add(new WopiBlobFolder(path, ancestorId));
+            if (string.IsNullOrEmpty(path))
+            {
+                break;
+            }
+        }
+        result.Reverse();
+        return result.AsReadOnly();
+    }
+
+    /// <inheritdoc/>
+    public async Task<T?> GetWopiResourceByName<T>(string containerId, string name, CancellationToken cancellationToken = default)
+        where T : class, IWopiResource
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        if (!idMap.TryGetPath(containerId, out var folderPath))
+        {
+            throw new DirectoryNotFoundException($"Container '{containerId}' not found.");
+        }
+        var combined = string.IsNullOrEmpty(folderPath) ? name : folderPath + "/" + name;
+
+        if (typeof(IWopiFile).IsAssignableFrom(typeof(T)))
+        {
+            var blobClient = containerClient.GetBlobClient(combined);
+            try
+            {
+                _ = await blobClient.GetPropertiesAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+            catch (RequestFailedException ex) when (ex.Status == 404)
+            {
+                return null;
+            }
+            var id = idMap.TryGetFileId(combined, out var existingId) ? existingId : idMap.Add(combined);
+            return await WopiBlobFile.CreateAsync(blobClient, combined, id, cancellationToken).ConfigureAwait(false) as T;
+        }
+        if (typeof(IWopiFolder).IsAssignableFrom(typeof(T)))
+        {
+            // Folder exists if any blob shares this prefix.
+            await foreach (var _ in containerClient.GetBlobsAsync(traits: BlobTraits.None, states: BlobStates.None, prefix: combined + "/", cancellationToken: cancellationToken).ConfigureAwait(false))
+            {
+                var id = idMap.TryGetFileId(combined, out var existingId) ? existingId : idMap.Add(combined);
+                return new WopiBlobFolder(combined, id) as T;
+            }
+            return null;
+        }
+        throw new NotSupportedException($"Unsupported resource type: {typeof(T).Name}");
+    }
+
+    #region IWopiWritableStorageProvider
+
+    /// <inheritdoc/>
+    public int FileNameMaxLength => 250;
+
+    /// <inheritdoc/>
+    public Task<bool> CheckValidName<T>(string name, CancellationToken cancellationToken = default)
+        where T : class, IWopiResource
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return Task.FromResult(false);
+        }
+        if (name.Length > FileNameMaxLength)
+        {
+            return Task.FromResult(false);
+        }
+        // Single segment — no slashes, no path nav.
+        if (name.Contains('/') || name.Contains('\\') || name == "." || name == "..")
+        {
+            return Task.FromResult(false);
+        }
+        // Azure blob naming spec disallows control characters.
+        foreach (var ch in name)
+        {
+            if (char.IsControl(ch))
+            {
+                return Task.FromResult(false);
+            }
+        }
+        // Folder-marker is reserved.
+        if (name == BlobIdMap.FolderMarker)
+        {
+            return Task.FromResult(false);
+        }
+        return Task.FromResult(true);
+    }
+
+    /// <inheritdoc/>
+    public async Task<string> GetSuggestedName<T>(string containerId, string name, CancellationToken cancellationToken = default)
+        where T : class, IWopiResource
+    {
+        if (!await CheckValidName<T>(name, cancellationToken).ConfigureAwait(false))
+        {
+            throw new ArgumentException("Invalid characters in the name.", nameof(name));
+        }
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        if (!idMap.TryGetPath(containerId, out var folderPath))
+        {
+            throw new DirectoryNotFoundException($"Container '{containerId}' not found.");
+        }
+
+        var existing = await GetWopiResourceByName<T>(containerId, name, cancellationToken).ConfigureAwait(false);
+        if (existing is null)
+        {
+            return name;
+        }
+
+        var candidate = name;
+        var counter = 1;
+        while (await GetWopiResourceByName<T>(containerId, candidate, cancellationToken).ConfigureAwait(false) is not null)
+        {
+            candidate = typeof(IWopiFile).IsAssignableFrom(typeof(T))
+                ? FormatSuggestedFileName(name, counter++)
+                : $"{name} ({counter++})";
+        }
+        return candidate;
+    }
+
+    /// <inheritdoc/>
+    public async Task<T?> CreateWopiChildResource<T>(string? containerId, string name, CancellationToken cancellationToken = default)
+        where T : class, IWopiResource
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        var parentId = containerId ?? RootContainerPointer.Identifier;
+        if (!idMap.TryGetPath(parentId, out var parentPath))
+        {
+            throw new DirectoryNotFoundException($"Container '{parentId}' not found.");
+        }
+
+        if (typeof(IWopiFile).IsAssignableFrom(typeof(T)))
+        {
+            var path = string.IsNullOrEmpty(parentPath) ? name : parentPath + "/" + name;
+            var blobClient = containerClient.GetBlobClient(path);
+            try
+            {
+                using var empty = new MemoryStream(Array.Empty<byte>(), writable: false);
+                await blobClient.UploadAsync(empty, overwrite: false, cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+            catch (RequestFailedException ex) when (ex.Status == 409)
+            {
+                throw new ArgumentException($"File '{path}' already exists.", nameof(name));
+            }
+            var id = idMap.Add(path);
+            return await WopiBlobFile.CreateAsync(blobClient, path, id, cancellationToken).ConfigureAwait(false) as T;
+        }
+        if (typeof(IWopiFolder).IsAssignableFrom(typeof(T)))
+        {
+            var path = string.IsNullOrEmpty(parentPath) ? name : parentPath + "/" + name;
+            var markerPath = path + "/" + BlobIdMap.FolderMarker;
+            var markerClient = containerClient.GetBlobClient(markerPath);
+            try
+            {
+                using var empty = new MemoryStream(Array.Empty<byte>(), writable: false);
+                await markerClient.UploadAsync(empty, overwrite: false, cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+            catch (RequestFailedException ex) when (ex.Status == 409)
+            {
+                throw new ArgumentException($"Folder '{path}' already exists.", nameof(name));
+            }
+            var id = idMap.Add(path);
+            return new WopiBlobFolder(path, id) as T;
+        }
+        throw new NotSupportedException($"Unsupported resource type: {typeof(T).Name}");
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> DeleteWopiResource<T>(string identifier, CancellationToken cancellationToken = default)
+        where T : class, IWopiResource
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        if (!idMap.TryGetPath(identifier, out var path))
+        {
+            return false;
+        }
+
+        if (typeof(IWopiFile).IsAssignableFrom(typeof(T)))
+        {
+            var blobClient = containerClient.GetBlobClient(path);
+            var deleted = await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (deleted.Value)
+            {
+                idMap.Remove(identifier);
+            }
+            return deleted.Value;
+        }
+        if (typeof(IWopiFolder).IsAssignableFrom(typeof(T)))
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                throw new InvalidOperationException("Cannot delete the root container.");
+            }
+            var prefix = path + "/";
+
+            // Check the folder is empty (other than possibly the marker blob).
+            await foreach (var item in containerClient.GetBlobsAsync(traits: BlobTraits.None, states: BlobStates.None, prefix: prefix, cancellationToken: cancellationToken).ConfigureAwait(false))
+            {
+                if (item.Name != prefix + BlobIdMap.FolderMarker)
+                {
+                    throw new InvalidOperationException($"Folder '{path}' is not empty.");
+                }
+            }
+
+            // Delete the marker if present, then drop the id.
+            var markerClient = containerClient.GetBlobClient(prefix + BlobIdMap.FolderMarker);
+            await markerClient.DeleteIfExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            idMap.Remove(identifier);
+            return true;
+        }
+        throw new NotSupportedException($"Unsupported resource type: {typeof(T).Name}");
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> RenameWopiResource<T>(string identifier, string requestedName, CancellationToken cancellationToken = default)
+        where T : class, IWopiResource
+    {
+        if (!await CheckValidName<T>(requestedName, cancellationToken).ConfigureAwait(false))
+        {
+            throw new ArgumentException("Invalid characters in the name.", nameof(requestedName));
+        }
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        if (!idMap.TryGetPath(identifier, out var oldPath))
+        {
+            return false;
+        }
+        var parent = GetParentPath(oldPath);
+
+        if (typeof(IWopiFile).IsAssignableFrom(typeof(T)))
+        {
+            var newPath = string.IsNullOrEmpty(parent) ? requestedName : parent + "/" + requestedName;
+            await CopyAndDeleteBlobAsync(oldPath, newPath, cancellationToken).ConfigureAwait(false);
+            idMap.Update(identifier, newPath);
+            return true;
+        }
+        if (typeof(IWopiFolder).IsAssignableFrom(typeof(T)))
+        {
+            if (string.IsNullOrEmpty(oldPath))
+            {
+                throw new InvalidOperationException("Cannot rename the root container.");
+            }
+            var oldPrefix = oldPath + "/";
+            var newPath = string.IsNullOrEmpty(parent) ? requestedName : parent + "/" + requestedName;
+            var newPrefix = newPath + "/";
+
+            // Plain blob storage has no atomic rename — copy each blob then delete the original.
+            // Order matters for crash safety: copy first, only delete after the copy succeeded.
+            var renamed = new List<(string oldName, string newName, string? oldId)>();
+            await foreach (var item in containerClient.GetBlobsAsync(traits: BlobTraits.None, states: BlobStates.None, prefix: oldPrefix, cancellationToken: cancellationToken).ConfigureAwait(false))
+            {
+                var rel = item.Name[oldPrefix.Length..];
+                var dest = newPrefix + rel;
+                await CopyAndDeleteBlobAsync(item.Name, dest, cancellationToken).ConfigureAwait(false);
+                idMap.TryGetFileId(item.Name, out var blobId);
+                renamed.Add((item.Name, dest, blobId));
+            }
+
+            // Update the id map: keep the folder identifier stable, re-point children to new paths.
+            idMap.Update(identifier, newPath);
+            foreach (var (_, newName, oldId) in renamed)
+            {
+                if (oldId is not null)
+                {
+                    idMap.Update(oldId, newName);
+                }
+            }
+            return true;
+        }
+        throw new NotSupportedException($"Unsupported resource type: {typeof(T).Name}");
+    }
+
+    #endregion
+
+    private string ResolveFolderPath(string identifier)
+    {
+        if (idMap.TryGetPath(identifier, out var path))
+        {
+            return path;
+        }
+        throw new DirectoryNotFoundException($"Container '{identifier}' not found.");
+    }
+
+    private static string GetParentPath(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return string.Empty;
+        }
+        var slash = path.LastIndexOf('/');
+        return slash < 0 ? string.Empty : path[..slash];
+    }
+
+    private async Task CopyAndDeleteBlobAsync(string sourcePath, string destPath, CancellationToken cancellationToken)
+    {
+        var source = containerClient.GetBlobClient(sourcePath);
+        var dest = containerClient.GetBlobClient(destPath);
+
+        if (await dest.ExistsAsync(cancellationToken).ConfigureAwait(false))
+        {
+            throw new InvalidOperationException($"Target blob '{destPath}' already exists.");
+        }
+
+        var copyOp = await dest.StartCopyFromUriAsync(source.Uri, cancellationToken: cancellationToken).ConfigureAwait(false);
+        await copyOp.WaitForCompletionAsync(cancellationToken).ConfigureAwait(false);
+        await source.DeleteAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    private static string FormatSuggestedFileName(string name, int counter)
+    {
+        var dot = name.LastIndexOf('.');
+        if (dot <= 0)
+        {
+            return $"{name} ({counter.ToString(CultureInfo.InvariantCulture)})";
+        }
+        var stem = name[..dot];
+        var ext = name[dot..];
+        return $"{stem} ({counter.ToString(CultureInfo.InvariantCulture)}){ext}";
+    }
+
+    private static Func<string, bool>? BuildSearchMatcher(string? searchPattern)
+    {
+        if (string.IsNullOrEmpty(searchPattern) || searchPattern == "*" || searchPattern == "*.*")
+        {
+            return null;
+        }
+        // Translate the simple glob (FileSystemProvider semantics) into a regex anchored to full names.
+        var escaped = Regex.Escape(searchPattern).Replace("\\*", ".*").Replace("\\?", ".");
+        var regex = new Regex("^" + escaped + "$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        return name => regex.IsMatch(name);
+    }
+}

--- a/src/WopiHost.AzureStorageProvider/WopiAzureStorageProvider.cs
+++ b/src/WopiHost.AzureStorageProvider/WopiAzureStorageProvider.cs
@@ -243,33 +243,16 @@ public class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWritableStora
     public Task<bool> CheckValidName<T>(string name, CancellationToken cancellationToken = default)
         where T : class, IWopiResource
     {
-        if (string.IsNullOrWhiteSpace(name))
-        {
-            return Task.FromResult(false);
-        }
-        if (name.Length > FileNameMaxLength)
-        {
-            return Task.FromResult(false);
-        }
-        // Single segment — no slashes, no path nav.
-        if (name.Contains('/') || name.Contains('\\') || name == "." || name == "..")
-        {
-            return Task.FromResult(false);
-        }
-        // Azure blob naming spec disallows control characters.
-        foreach (var ch in name)
-        {
-            if (char.IsControl(ch))
-            {
-                return Task.FromResult(false);
-            }
-        }
-        // Folder-marker is reserved.
-        if (name == BlobIdMap.FolderMarker)
-        {
-            return Task.FromResult(false);
-        }
-        return Task.FromResult(true);
+        var valid =
+            !string.IsNullOrWhiteSpace(name)
+            && name.Length <= FileNameMaxLength
+            // Single segment — no slashes, no path nav.
+            && !name.Contains('/') && !name.Contains('\\') && name != "." && name != ".."
+            // Folder-marker is reserved.
+            && name != BlobIdMap.FolderMarker
+            // Azure blob naming spec disallows control characters.
+            && !name.Any(char.IsControl);
+        return Task.FromResult(valid);
     }
 
     /// <inheritdoc/>

--- a/src/WopiHost.AzureStorageProvider/WopiAzureStorageProviderOptions.cs
+++ b/src/WopiHost.AzureStorageProvider/WopiAzureStorageProviderOptions.cs
@@ -1,0 +1,35 @@
+namespace WopiHost.AzureStorageProvider;
+
+/// <summary>
+/// Configuration for <see cref="WopiAzureStorageProvider"/>.
+/// </summary>
+/// <remarks>
+/// Bind to the <c>Wopi:StorageProvider</c> configuration section. Authentication is determined by which
+/// fields are populated, in order of precedence:
+/// <list type="number">
+///   <item><description><see cref="ConnectionString"/> set → use it (typical for Azurite/dev or shared-key prod).</description></item>
+///   <item><description><see cref="ServiceUri"/> set → use the <c>TokenCredential</c> registered in DI; fall back to
+///   <see cref="Azure.Identity.DefaultAzureCredential"/> if none was supplied.</description></item>
+/// </list>
+/// </remarks>
+public class WopiAzureStorageProviderOptions
+{
+    /// <summary>
+    /// Storage account connection string. Use <c>UseDevelopmentStorage=true</c> for Azurite, or a full
+    /// shared-key connection string for production.
+    /// Mutually exclusive with <see cref="ServiceUri"/>; takes precedence if both are set.
+    /// </summary>
+    public string? ConnectionString { get; set; }
+
+    /// <summary>
+    /// Blob service endpoint (e.g. <c>https://my-account.blob.core.windows.net</c>) used together with a
+    /// <see cref="Azure.Core.TokenCredential"/> from DI (typically <see cref="Azure.Identity.DefaultAzureCredential"/>)
+    /// for managed-identity / service-principal auth.
+    /// </summary>
+    public string? ServiceUri { get; set; }
+
+    /// <summary>
+    /// Name of the blob container that holds WOPI files. Will be created on startup if missing.
+    /// </summary>
+    public required string ContainerName { get; set; }
+}

--- a/src/WopiHost.AzureStorageProvider/WopiBlobFile.cs
+++ b/src/WopiHost.AzureStorageProvider/WopiBlobFile.cs
@@ -1,0 +1,150 @@
+using System.Security.Cryptography;
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using WopiHost.Abstractions;
+
+namespace WopiHost.AzureStorageProvider;
+
+/// <summary>
+/// <see cref="IWopiFile"/> backed by an Azure Blob.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Properties (<see cref="Length"/>, <see cref="LastWriteTimeUtc"/>, <see cref="Version"/>, <see cref="Owner"/>,
+/// <see cref="Checksum"/>) are eagerly fetched once via <see cref="CreateAsync"/> and cached on the instance,
+/// so subsequent property reads are local. The <see cref="IWopiStorageProvider"/> creates a fresh
+/// <see cref="WopiBlobFile"/> per request, which keeps cached state implicitly fresh.
+/// </para>
+/// <para>
+/// Identifiers are hex-MD5 of the lowercased blob path (see <see cref="BlobIdMap"/>). The blob's ETag is
+/// surfaced as <see cref="Version"/>; this is more meaningful than a timestamp because every byte-level
+/// change produces a new ETag.
+/// </para>
+/// </remarks>
+public class WopiBlobFile : IWopiFile
+{
+    /// <summary>Blob metadata key that holds the file's owner identifier (free-form).</summary>
+    public const string OwnerMetadataKey = "wopi_owner";
+
+    /// <summary>Blob metadata key that holds the SHA-256 of the blob content as a lowercase hex string.</summary>
+    public const string Sha256MetadataKey = "wopi_sha256";
+
+    private readonly BlobClient blobClient;
+    private readonly BlobProperties? properties;
+
+    private WopiBlobFile(BlobClient blobClient, string blobPath, string identifier, BlobProperties? properties)
+    {
+        this.blobClient = blobClient;
+        this.properties = properties;
+        BlobPath = blobPath;
+        Identifier = identifier;
+    }
+
+    /// <summary>Full blob path within the container (no leading slash).</summary>
+    public string BlobPath { get; }
+
+    /// <inheritdoc/>
+    public string Identifier { get; }
+
+    /// <inheritdoc/>
+    public string Name
+    {
+        get
+        {
+            var fileName = BlobPath[(BlobPath.LastIndexOf('/') + 1)..];
+            var dot = fileName.LastIndexOf('.');
+            return dot < 0 ? fileName : fileName[..dot];
+        }
+    }
+
+    /// <inheritdoc/>
+    public string Extension
+    {
+        get
+        {
+            var fileName = BlobPath[(BlobPath.LastIndexOf('/') + 1)..];
+            var dot = fileName.LastIndexOf('.');
+            return dot < 0 ? string.Empty : fileName[(dot + 1)..];
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool Exists => properties is not null;
+
+    /// <inheritdoc/>
+    public long Length => properties?.ContentLength ?? 0;
+
+    /// <inheritdoc/>
+    public long Size => Length;
+
+    /// <inheritdoc/>
+    public DateTime LastWriteTimeUtc => properties?.LastModified.UtcDateTime ?? DateTime.MinValue;
+
+    /// <inheritdoc/>
+    public string? Version => properties?.ETag.ToString();
+
+    /// <inheritdoc/>
+    public string Owner
+    {
+        get
+        {
+            if (properties is { Metadata: { } meta } && meta.TryGetValue(OwnerMetadataKey, out var owner))
+            {
+                return owner;
+            }
+            return string.Empty;
+        }
+    }
+
+    /// <inheritdoc/>
+#pragma warning disable CA1819 // Properties should not return arrays — interface contract
+    public byte[]? Checksum
+#pragma warning restore CA1819
+    {
+        get
+        {
+            if (properties is { Metadata: { } meta } && meta.TryGetValue(Sha256MetadataKey, out var hex) && !string.IsNullOrEmpty(hex))
+            {
+                return Convert.FromHexString(hex);
+            }
+            return null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<Stream> GetReadStream(CancellationToken cancellationToken = default)
+        => await blobClient.OpenReadAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Returns a stream that wraps the blob's upload stream and incrementally computes the SHA-256
+    /// of the new content. On dispose the hash is finalized and written back as the
+    /// <see cref="Sha256MetadataKey"/> metadata key, preserving any pre-existing metadata (owner,
+    /// custom keys) so they survive the rewrite.
+    /// </remarks>
+    public async Task<Stream> GetWriteStream(CancellationToken cancellationToken = default)
+    {
+        var preserved = properties?.Metadata is { } existing
+            ? new Dictionary<string, string>(existing, StringComparer.Ordinal)
+            : new Dictionary<string, string>(StringComparer.Ordinal);
+
+        var inner = await blobClient.OpenWriteAsync(overwrite: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return new HashingBlobWriteStream(inner, blobClient, preserved);
+    }
+
+    /// <summary>Fetches blob properties (or returns null on 404) and produces a fully-populated <see cref="WopiBlobFile"/>.</summary>
+    public static async Task<WopiBlobFile> CreateAsync(BlobClient blobClient, string blobPath, string identifier, CancellationToken cancellationToken)
+    {
+        BlobProperties? props = null;
+        try
+        {
+            props = await blobClient.GetPropertiesAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            // Blob does not exist — Exists will be false, all other properties default.
+        }
+        return new WopiBlobFile(blobClient, blobPath, identifier, props);
+    }
+}

--- a/src/WopiHost.AzureStorageProvider/WopiBlobFolder.cs
+++ b/src/WopiHost.AzureStorageProvider/WopiBlobFolder.cs
@@ -1,0 +1,21 @@
+using WopiHost.Abstractions;
+
+namespace WopiHost.AzureStorageProvider;
+
+/// <summary>
+/// Virtual folder backed by a blob-name prefix. Plain Blob Storage has no folder objects, so a folder
+/// is just a logical grouping of blobs that share a <c>/</c>-delimited prefix.
+/// </summary>
+public class WopiBlobFolder(string prefix, string identifier) : IWopiFolder
+{
+    /// <summary>Blob-name prefix this folder represents (no leading or trailing slash).</summary>
+    public string Prefix { get; } = prefix;
+
+    /// <inheritdoc/>
+    public string Identifier { get; } = identifier;
+
+    /// <inheritdoc/>
+    public string Name => string.IsNullOrEmpty(Prefix)
+        ? string.Empty
+        : Prefix[(Prefix.LastIndexOf('/') + 1)..];
+}

--- a/src/WopiHost.AzureStorageProvider/WopiHost.AzureStorageProvider.csproj
+++ b/src/WopiHost.AzureStorageProvider/WopiHost.AzureStorageProvider.csproj
@@ -1,0 +1,52 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<Nullable>enable</Nullable>
+		<Description>WopiHost.AzureStorageProvider Class Library — Azure Blob Storage backend.</Description>
+		<Authors>Petr Svihlik</Authors>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<AssemblyName>WopiHost.AzureStorageProvider</AssemblyName>
+		<PackageId>WopiHost.AzureStorageProvider</PackageId>
+		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+		<PackageIcon>logo.png</PackageIcon>
+		<PackageTags>WOPI;Azure;Blob;Storage;Office Online Server;Office Web Apps;Web Application Open Platform Interface</PackageTags>
+		<RepositoryType>git</RepositoryType>
+		<RepositoryUrl>https://github.com/petrsvihlik/WopiHost.git</RepositoryUrl>
+		<GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+		<GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+		<GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+		<!-- This is a brand new package; no prior released version to validate against. -->
+		<EnablePackageValidation>false</EnablePackageValidation>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="..\..\LICENSE.txt" Pack="true" PackagePath="" />
+		<None Include="..\..\img\logo.png" Pack="true" PackagePath="" />
+		<None Include="README.md" Pack="true" PackagePath="" />
+	</ItemGroup>
+
+	<PropertyGroup>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+		<PackageReference Include="Azure.Storage.Blobs" />
+		<PackageReference Include="Azure.Identity" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+		<PackageReference Include="Microsoft.DotNet.PackageValidation" PrivateAssets="All" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\WopiHost.Abstractions\WopiHost.Abstractions.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/WopiHost.Core/Controllers/ContainersController.cs
+++ b/src/WopiHost.Core/Controllers/ContainersController.cs
@@ -207,10 +207,14 @@ public class ContainersController(
                 else
                 {
                     // a file matching the target name might be locked
-                    if (lockProvider?.TryGetLock(newFile.Identifier, out var existingLock) == true)
+                    if (lockProvider is not null)
                     {
-                        // the host must respond with a 409 Conflict and include a X-WOPI-Lock response header
-                        return new LockMismatchResult(Response, existingLock.LockId, reason: "File already exists and is currently locked");
+                        var existingLock = await lockProvider.GetLockAsync(newFile.Identifier, cancellationToken);
+                        if (existingLock is not null)
+                        {
+                            // the host must respond with a 409 Conflict and include a X-WOPI-Lock response header
+                            return new LockMismatchResult(Response, existingLock.LockId, reason: "File already exists and is currently locked");
+                        }
                     }
                 }
             }

--- a/src/WopiHost.Core/Controllers/ContainersController.cs
+++ b/src/WopiHost.Core/Controllers/ContainersController.cs
@@ -207,14 +207,13 @@ public class ContainersController(
                 else
                 {
                     // a file matching the target name might be locked
-                    if (lockProvider is not null)
+                    var existingLock = lockProvider is null
+                        ? null
+                        : await lockProvider.GetLockAsync(newFile.Identifier, cancellationToken);
+                    if (existingLock is not null)
                     {
-                        var existingLock = await lockProvider.GetLockAsync(newFile.Identifier, cancellationToken);
-                        if (existingLock is not null)
-                        {
-                            // the host must respond with a 409 Conflict and include a X-WOPI-Lock response header
-                            return new LockMismatchResult(Response, existingLock.LockId, reason: "File already exists and is currently locked");
-                        }
+                        // the host must respond with a 409 Conflict and include a X-WOPI-Lock response header
+                        return new LockMismatchResult(Response, existingLock.LockId, reason: "File already exists and is currently locked");
                     }
                 }
             }

--- a/src/WopiHost.Core/Controllers/FilesController.cs
+++ b/src/WopiHost.Core/Controllers/FilesController.cs
@@ -158,10 +158,13 @@ public class FilesController(
 
         // If the file is currently locked, the host should return a 409 Conflict
         // and include an X-WOPI-Lock response header containing the value of the current lock on the file
-        if (lockProvider?.TryGetLock(id, out var existingLock) == true && 
-            existingLock.LockId != lockIdentifier)
+        if (lockProvider is not null)
         {
-            return new LockMismatchResult(Response, existingLock.LockId);
+            var existingLock = await lockProvider.GetLockAsync(id, cancellationToken);
+            if (existingLock is not null && existingLock.LockId != lockIdentifier)
+            {
+                return new LockMismatchResult(Response, existingLock.LockId);
+            }
         }
 
         // If the host can't rename the file because the name requested is invalid ... it should return an HTTP status code 400 Bad Request.
@@ -417,10 +420,14 @@ public class FilesController(
                 else
                 {
                     // a file matching the target name might be locked
-                    if (lockProvider?.TryGetLock(newFile.Identifier, out var existingLock) == true)
+                    if (lockProvider is not null)
                     {
-                        // the host must respond with a 409 Conflict and include a X-WOPI-Lock response header
-                        return new LockMismatchResult(Response, existingLock.LockId, reason: "File already exists and is currently locked");
+                        var existingLock = await lockProvider.GetLockAsync(newFile.Identifier, cancellationToken);
+                        if (existingLock is not null)
+                        {
+                            // the host must respond with a 409 Conflict and include a X-WOPI-Lock response header
+                            return new LockMismatchResult(Response, existingLock.LockId, reason: "File already exists and is currently locked");
+                        }
                     }
                 }
             }
@@ -541,9 +548,13 @@ public class FilesController(
 
         // If the file is currently locked, the host should return a 409 Conflict
         // and include an X-WOPI-Lock response header containing the value of the current lock on the file
-        if (lockProvider?.TryGetLock(id, out var existingLock) == true)
+        if (lockProvider is not null)
         {
-            return new LockMismatchResult(Response, existingLock.LockId);
+            var existingLock = await lockProvider.GetLockAsync(id, cancellationToken);
+            if (existingLock is not null)
+            {
+                return new LockMismatchResult(Response, existingLock.LockId);
+            }
         }
 
         if (await writableStorageProvider.CheckValidName<IWopiFile>(id, cancellationToken))
@@ -624,32 +635,23 @@ public class FilesController(
         var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken)
                    ?? throw new InvalidOperationException("File not found");
         Response.Headers[WopiHeaders.ITEM_VERSION] = file.Version;
-        
-        var lockAcquired = lockProvider.TryGetLock(id, out var existingLock);
+
+        var existingLock = await lockProvider.GetLockAsync(id, cancellationToken);
         return wopiOverrideHeader switch
         {
-            WopiFileOperations.GetLock => HandleGetLock(lockAcquired, existingLock),
-            WopiFileOperations.Lock or WopiFileOperations.Put => HandleLockOrPut(id, oldLockIdentifier, newLockIdentifier, lockAcquired, existingLock),
-            WopiFileOperations.Unlock => HandleUnlock(id, newLockIdentifier, lockAcquired, existingLock),
-            WopiFileOperations.RefreshLock => HandleRefreshLock(newLockIdentifier, lockAcquired, existingLock),
+            WopiFileOperations.GetLock => HandleGetLock(existingLock),
+            WopiFileOperations.Lock or WopiFileOperations.Put => await HandleLockOrPut(id, oldLockIdentifier, newLockIdentifier, existingLock, cancellationToken),
+            WopiFileOperations.Unlock => await HandleUnlock(id, newLockIdentifier, existingLock, cancellationToken),
+            WopiFileOperations.RefreshLock => await HandleRefreshLock(newLockIdentifier, existingLock, cancellationToken),
             _ => new NotImplementedResult(),
         };
     }
 
-    private IActionResult HandleGetLock(bool lockAcquired, WopiLockInfo? existingLock)
+    private IActionResult HandleGetLock(WopiLockInfo? existingLock)
     {
-        if (lockAcquired)
-        {
-            if (existingLock is null)
-            {
-                return new LockMismatchResult(Response, reason: "Missing existing lock");
-            }
-            Response.Headers[WopiHeaders.LOCK] = existingLock.LockId;
-        }
-        else
-        {
-            Response.Headers[WopiHeaders.LOCK] = WopiHeaders.EMPTY_LOCK_VALUE;
-        }
+        Response.Headers[WopiHeaders.LOCK] = existingLock is not null
+            ? existingLock.LockId
+            : WopiHeaders.EMPTY_LOCK_VALUE;
         return Ok();
     }
 
@@ -660,7 +662,7 @@ public class FilesController(
     /// the existing lock matching oldLockIdentifier is atomically replaced with a new lock using newLockIdentifier.
     /// Specification: https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/unlockandrelock
     /// </summary>
-    private IActionResult HandleLockOrPut(string id, string? oldLockIdentifier, string? newLockIdentifier, bool lockAcquired, WopiLockInfo? existingLock)
+    private async Task<IActionResult> HandleLockOrPut(string id, string? oldLockIdentifier, string? newLockIdentifier, WopiLockInfo? existingLock, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(lockProvider);
         if (oldLockIdentifier is null)
@@ -670,135 +672,77 @@ public class FilesController(
                 return new LockMismatchResult(Response, reason: "Missing new lock identifier");
             }
 
-            if (lockAcquired)
+            if (existingLock is not null)
             {
-                if (existingLock is null)
-                {
-                    return new LockMismatchResult(Response, reason: "Missing existing lock");
-                }
-                return LockOrRefresh(newLockIdentifier, existingLock);
+                return await LockOrRefresh(newLockIdentifier, existingLock, cancellationToken);
             }
-            else
-            {
-                if (lockProvider.AddLock(id, newLockIdentifier) != null)
-                {
-                    return Ok();
-                }
-                else
-                {
-                    return new LockMismatchResult(Response, "Could not create lock");
-                }
-            }
-        }
-        else
-        {
-            if (lockAcquired)
-            {
-                if (existingLock is null)
-                {
-                    return new LockMismatchResult(Response, reason: "Missing existing lock");
-                }
-                if (existingLock.LockId == oldLockIdentifier)
-                {
-                    if (string.IsNullOrWhiteSpace(newLockIdentifier))
-                    {
-                        return new LockMismatchResult(Response, reason: "Missing new lock identifier");
-                    }
 
-                    if (lockProvider.RefreshLock(id, newLockIdentifier))
-                    {
-                        return Ok();
-                    }
-                    else
-                    {
-                        return new LockMismatchResult(Response, "Could not create lock");
-                    }
-                }
-                else
-                {
-                    return new LockMismatchResult(Response, existingLock.LockId);
-                }
-            }
-            else
-            {
-                return new LockMismatchResult(Response, reason: "File not locked");
-            }
+            return await lockProvider.AddLockAsync(id, newLockIdentifier, cancellationToken) is not null
+                ? Ok()
+                : new LockMismatchResult(Response, "Could not create lock");
         }
-    }
 
-    private IActionResult HandleUnlock(string id, string? newLockIdentifier, bool lockAcquired, WopiLockInfo? existingLock)
-    {
-        ArgumentNullException.ThrowIfNull(lockProvider);
-
-        if (lockAcquired)
-        {
-            if (existingLock is null)
-            {
-                return new LockMismatchResult(Response, reason: "Missing existing lock");
-            }
-            if (existingLock.LockId == newLockIdentifier)
-            {
-                if (lockProvider.RemoveLock(id))
-                {
-                    return Ok();
-                }
-                else
-                {
-                    return new LockMismatchResult(Response, "Could not remove lock");
-                }
-            }
-            else
-            {
-                return new LockMismatchResult(Response, existingLock.LockId);
-            }
-        }
-        else
+        if (existingLock is null)
         {
             return new LockMismatchResult(Response, reason: "File not locked");
         }
+        if (existingLock.LockId != oldLockIdentifier)
+        {
+            return new LockMismatchResult(Response, existingLock.LockId);
+        }
+        if (string.IsNullOrWhiteSpace(newLockIdentifier))
+        {
+            return new LockMismatchResult(Response, reason: "Missing new lock identifier");
+        }
+
+        return await lockProvider.RefreshLockAsync(id, newLockIdentifier, cancellationToken)
+            ? Ok()
+            : new LockMismatchResult(Response, "Could not create lock");
     }
 
-    private IActionResult HandleRefreshLock(string? newLockIdentifier, bool lockAcquired, WopiLockInfo? existingLock)
+    private async Task<IActionResult> HandleUnlock(string id, string? newLockIdentifier, WopiLockInfo? existingLock, CancellationToken cancellationToken)
     {
-        if (lockAcquired)
-        {
-            if (existingLock is null)
-            {
-                return new LockMismatchResult(Response, reason: "Missing existing lock");
-            }
-            if (string.IsNullOrWhiteSpace(newLockIdentifier))
-            {
-                return new LockMismatchResult(Response, reason: "Missing new lock identifier");
-            }
-            return LockOrRefresh(newLockIdentifier, existingLock);
-        }
-        else
+        ArgumentNullException.ThrowIfNull(lockProvider);
+
+        if (existingLock is null)
         {
             return new LockMismatchResult(Response, reason: "File not locked");
         }
+        if (existingLock.LockId != newLockIdentifier)
+        {
+            return new LockMismatchResult(Response, existingLock.LockId);
+        }
+
+        return await lockProvider.RemoveLockAsync(id, cancellationToken)
+            ? Ok()
+            : new LockMismatchResult(Response, "Could not remove lock");
     }
 
-    private IActionResult LockOrRefresh(string newLock, WopiLockInfo existingLock)
+    private async Task<IActionResult> HandleRefreshLock(string? newLockIdentifier, WopiLockInfo? existingLock, CancellationToken cancellationToken)
+    {
+        if (existingLock is null)
+        {
+            return new LockMismatchResult(Response, reason: "File not locked");
+        }
+        if (string.IsNullOrWhiteSpace(newLockIdentifier))
+        {
+            return new LockMismatchResult(Response, reason: "Missing new lock identifier");
+        }
+        return await LockOrRefresh(newLockIdentifier, existingLock, cancellationToken);
+    }
+
+    private async Task<IActionResult> LockOrRefresh(string newLock, WopiLockInfo existingLock, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(lockProvider);
-        if (existingLock.LockId == newLock)
-        {
-            // File is currently locked and the lock ids match, refresh lock (extend the lock timeout)
-            if (lockProvider.RefreshLock(existingLock.FileId))
-            {
-                return Ok();
-            }
-            else
-            {
-                // The lock has expired
-                return new LockMismatchResult(Response, reason: "Could not refresh lock");
-            }
-        }
-        else
+        if (existingLock.LockId != newLock)
         {
             // The existing lock doesn't match the requested one (someone else might have locked the file). Return a lock mismatch error along with the current lock
             return new LockMismatchResult(Response, existingLock.LockId);
         }
+        // File is currently locked and the lock ids match, refresh lock (extend the lock timeout)
+        return await lockProvider.RefreshLockAsync(existingLock.FileId, cancellationToken: cancellationToken)
+            ? Ok()
+            : new LockMismatchResult(Response, reason: "Could not refresh lock");
     }
     #endregion
 }

--- a/src/WopiHost.Core/Controllers/FilesController.cs
+++ b/src/WopiHost.Core/Controllers/FilesController.cs
@@ -420,14 +420,13 @@ public class FilesController(
                 else
                 {
                     // a file matching the target name might be locked
-                    if (lockProvider is not null)
+                    var existingLock = lockProvider is null
+                        ? null
+                        : await lockProvider.GetLockAsync(newFile.Identifier, cancellationToken);
+                    if (existingLock is not null)
                     {
-                        var existingLock = await lockProvider.GetLockAsync(newFile.Identifier, cancellationToken);
-                        if (existingLock is not null)
-                        {
-                            // the host must respond with a 409 Conflict and include a X-WOPI-Lock response header
-                            return new LockMismatchResult(Response, existingLock.LockId, reason: "File already exists and is currently locked");
-                        }
+                        // the host must respond with a 409 Conflict and include a X-WOPI-Lock response header
+                        return new LockMismatchResult(Response, existingLock.LockId, reason: "File already exists and is currently locked");
                     }
                 }
             }
@@ -637,10 +636,14 @@ public class FilesController(
         Response.Headers[WopiHeaders.ITEM_VERSION] = file.Version;
 
         var existingLock = await lockProvider.GetLockAsync(id, cancellationToken);
+        // The Lock override doubles as UnlockAndRelock when X-WOPI-OldLock is present, so dispatch
+        // by header presence rather than baking a third branch into the switch.
         return wopiOverrideHeader switch
         {
             WopiFileOperations.GetLock => HandleGetLock(existingLock),
-            WopiFileOperations.Lock or WopiFileOperations.Put => await HandleLockOrPut(id, oldLockIdentifier, newLockIdentifier, existingLock, cancellationToken),
+            WopiFileOperations.Lock or WopiFileOperations.Put => oldLockIdentifier is null
+                ? await HandleLock(id, newLockIdentifier, existingLock, cancellationToken)
+                : await HandleUnlockAndRelock(id, oldLockIdentifier, newLockIdentifier, existingLock, cancellationToken),
             WopiFileOperations.Unlock => await HandleUnlock(id, newLockIdentifier, existingLock, cancellationToken),
             WopiFileOperations.RefreshLock => await HandleRefreshLock(newLockIdentifier, existingLock, cancellationToken),
             _ => new NotImplementedResult(),
@@ -656,32 +659,35 @@ public class FilesController(
     }
 
     /// <summary>
-    /// Handles Lock and UnlockAndRelock operations.
-    /// When <paramref name="oldLockIdentifier"/> is null, this is a Lock request.
-    /// When <paramref name="oldLockIdentifier"/> is present, this is an UnlockAndRelock request:
-    /// the existing lock matching oldLockIdentifier is atomically replaced with a new lock using newLockIdentifier.
-    /// Specification: https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/unlockandrelock
+    /// Handles a Lock request (X-WOPI-OldLock absent). Acquires a new lock when the file is unlocked,
+    /// or refreshes the existing one if the lock IDs match. Spec:
+    /// https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/lock
     /// </summary>
-    private async Task<IActionResult> HandleLockOrPut(string id, string? oldLockIdentifier, string? newLockIdentifier, WopiLockInfo? existingLock, CancellationToken cancellationToken)
+    private async Task<IActionResult> HandleLock(string id, string? newLockIdentifier, WopiLockInfo? existingLock, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(lockProvider);
-        if (oldLockIdentifier is null)
+        if (string.IsNullOrWhiteSpace(newLockIdentifier))
         {
-            if (string.IsNullOrWhiteSpace(newLockIdentifier))
-            {
-                return new LockMismatchResult(Response, reason: "Missing new lock identifier");
-            }
-
-            if (existingLock is not null)
-            {
-                return await LockOrRefresh(newLockIdentifier, existingLock, cancellationToken);
-            }
-
-            return await lockProvider.AddLockAsync(id, newLockIdentifier, cancellationToken) is not null
-                ? Ok()
-                : new LockMismatchResult(Response, "Could not create lock");
+            return new LockMismatchResult(Response, reason: "Missing new lock identifier");
         }
+        if (existingLock is not null)
+        {
+            return await LockOrRefresh(newLockIdentifier, existingLock, cancellationToken);
+        }
+        return await lockProvider.AddLockAsync(id, newLockIdentifier, cancellationToken) is not null
+            ? Ok()
+            : new LockMismatchResult(Response, "Could not create lock");
+    }
 
+    /// <summary>
+    /// Handles an UnlockAndRelock request (X-WOPI-OldLock present). Atomically replaces the existing
+    /// lock matching <paramref name="oldLockIdentifier"/> with a new lock using
+    /// <paramref name="newLockIdentifier"/>. Spec:
+    /// https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/unlockandrelock
+    /// </summary>
+    private async Task<IActionResult> HandleUnlockAndRelock(string id, string oldLockIdentifier, string? newLockIdentifier, WopiLockInfo? existingLock, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(lockProvider);
         if (existingLock is null)
         {
             return new LockMismatchResult(Response, reason: "File not locked");
@@ -694,7 +700,6 @@ public class FilesController(
         {
             return new LockMismatchResult(Response, reason: "Missing new lock identifier");
         }
-
         return await lockProvider.RefreshLockAsync(id, newLockIdentifier, cancellationToken)
             ? Ok()
             : new LockMismatchResult(Response, "Could not create lock");

--- a/src/WopiHost.MemoryLockProvider/MemoryLockProvider.cs
+++ b/src/WopiHost.MemoryLockProvider/MemoryLockProvider.cs
@@ -1,12 +1,16 @@
 using System.Collections.Concurrent;
-using System.Diagnostics.CodeAnalysis;
 using WopiHost.Abstractions;
 
 namespace WopiHost.MemoryLockProvider;
 
 /// <summary>
-/// In-memory implementation of a <see cref="IWopiLockProvider"/>
+/// In-memory implementation of <see cref="IWopiLockProvider"/>.
 /// </summary>
+/// <remarks>
+/// State lives in a static <see cref="ConcurrentDictionary{TKey,TValue}"/>; locks survive
+/// the lifetime of the process but not multi-instance deployments or restarts. Operations are
+/// inherently synchronous and are wrapped in <see cref="Task.FromResult{T}"/> to satisfy the async contract.
+/// </remarks>
 public class MemoryLockProvider : IWopiLockProvider
 {
     /// <summary>
@@ -15,25 +19,22 @@ public class MemoryLockProvider : IWopiLockProvider
     private static readonly ConcurrentDictionary<string, WopiLockInfo> locks = [];
 
     /// <inheritdoc />
-    public bool TryGetLock(string fileId, [NotNullWhen(true)] out WopiLockInfo? lockInfo)
+    public Task<WopiLockInfo?> GetLockAsync(string fileId, CancellationToken cancellationToken = default)
     {
-        if (locks.TryGetValue(fileId, out lockInfo))
+        if (locks.TryGetValue(fileId, out var lockInfo))
         {
             if (lockInfo.Expired)
             {
-                _ = RemoveLock(fileId);
-                return false;
+                _ = locks.TryRemove(fileId, out _);
+                return Task.FromResult<WopiLockInfo?>(null);
             }
-            return true;
+            return Task.FromResult<WopiLockInfo?>(lockInfo);
         }
-        else
-        {
-            return false;
-        }
+        return Task.FromResult<WopiLockInfo?>(null);
     }
 
     /// <inheritdoc />
-    public WopiLockInfo? AddLock(string fileId, string lockId)
+    public Task<WopiLockInfo?> AddLockAsync(string fileId, string lockId, CancellationToken cancellationToken = default)
     {
         var lockInfo = new WopiLockInfo
         {
@@ -41,35 +42,26 @@ public class MemoryLockProvider : IWopiLockProvider
             LockId = lockId,
             DateCreated = DateTimeOffset.UtcNow,
         };
-        if (locks.TryAdd(fileId, lockInfo))
-        {
-            return lockInfo;
-        }
-        else
-        {
-            return null;
-        }
+        return Task.FromResult<WopiLockInfo?>(locks.TryAdd(fileId, lockInfo) ? lockInfo : null);
     }
 
     /// <inheritdoc />
-    public bool RefreshLock(string fileId, string? lockId = null)
+    public async Task<bool> RefreshLockAsync(string fileId, string? lockId = null, CancellationToken cancellationToken = default)
     {
-        if (TryGetLock(fileId, out var existingLock))
+        var existing = await GetLockAsync(fileId, cancellationToken).ConfigureAwait(false);
+        if (existing is null)
         {
-            var lockInfo = existingLock with
-            {
-                DateCreated = DateTimeOffset.UtcNow,
-                LockId = lockId ?? existingLock.LockId,
-            };
-            return locks.TryUpdate(fileId, lockInfo, existingLock);
+            return false;
         }
-        return false;
+        var updated = existing with
+        {
+            DateCreated = DateTimeOffset.UtcNow,
+            LockId = lockId ?? existing.LockId,
+        };
+        return locks.TryUpdate(fileId, updated, existing);
     }
-
 
     /// <inheritdoc />
-    public bool RemoveLock(string fileId)
-    {
-        return locks.TryRemove(fileId, out _);
-    }
+    public Task<bool> RemoveLockAsync(string fileId, CancellationToken cancellationToken = default)
+        => Task.FromResult(locks.TryRemove(fileId, out _));
 }

--- a/src/WopiHost.MemoryLockProvider/README.md
+++ b/src/WopiHost.MemoryLockProvider/README.md
@@ -35,16 +35,16 @@ services.AddSingleton<IWopiLockProvider, MemoryLockProvider>();
 
 ## API
 
-The interface is **synchronous** (lock state is in-process; there's nothing to await):
+The interface is **asynchronous** so out-of-process implementations (Azure Blob, Redis, SQL) can plug in without sync-over-async. This in-memory provider just wraps its synchronous logic in `Task.FromResult`:
 
 ```csharp
-bool          TryGetLock(string fileId, out WopiLockInfo? lockInfo);
-WopiLockInfo? AddLock(string fileId, string lockId);
-bool          RefreshLock(string fileId, string? lockId = null);
-bool          RemoveLock(string fileId);
+Task<WopiLockInfo?> GetLockAsync(string fileId, CancellationToken ct = default);
+Task<WopiLockInfo?> AddLockAsync(string fileId, string lockId, CancellationToken ct = default);
+Task<bool>          RefreshLockAsync(string fileId, string? lockId = null, CancellationToken ct = default);
+Task<bool>          RemoveLockAsync(string fileId, CancellationToken ct = default);
 ```
 
-`WopiLockInfo` carries `LockId`, `FileId`, `DateCreated`, and a computed `Expired` flag.
+`GetLockAsync` returns `null` when the lock isn't present (or has expired and was evicted). `WopiLockInfo` carries `LockId`, `FileId`, `DateCreated`, and a computed `Expired` flag.
 
 See [WopiHost.Abstractions](../WopiHost.Abstractions/IWopiLockProvider.cs) for the full contract.
 

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -14,10 +14,12 @@
     <PackageVersion Include="FakeItEasy" Version="9.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
     <PackageVersion Include="Testcontainers" Version="4.7.0" />
+    <PackageVersion Include="Testcontainers.Azurite" Version="4.7.0" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.5.23" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.console" Version="2.9.3">

--- a/test/WopiHost.AzureLockProvider.Tests/AzuriteFixture.cs
+++ b/test/WopiHost.AzureLockProvider.Tests/AzuriteFixture.cs
@@ -1,0 +1,35 @@
+using Azure.Storage.Blobs;
+using Testcontainers.Azurite;
+using Xunit;
+
+namespace WopiHost.AzureLockProvider.Tests;
+
+public sealed class AzuriteFixture : IAsyncLifetime
+{
+    /// <summary>Latest stable Azurite at the time of writing.</summary>
+    public const string AzuriteImage = "mcr.microsoft.com/azure-storage/azurite:3.35.0";
+
+    /// <summary>
+    /// Latest blob service version Azurite 3.35.0 understands. Bump alongside <see cref="AzuriteImage"/>.
+    /// </summary>
+    public const BlobClientOptions.ServiceVersion AzuriteSupportedVersion = BlobClientOptions.ServiceVersion.V2025_11_05;
+
+    private readonly AzuriteContainer container = new AzuriteBuilder()
+        .WithImage(AzuriteImage)
+        .Build();
+
+    public string ConnectionString => container.GetConnectionString();
+
+    public BlobServiceClient CreateBlobServiceClient()
+        => new(ConnectionString, new BlobClientOptions(AzuriteSupportedVersion));
+
+    public Task InitializeAsync() => container.StartAsync();
+
+    public Task DisposeAsync() => container.DisposeAsync().AsTask();
+}
+
+[CollectionDefinition(Name)]
+public sealed class AzuriteCollection : ICollectionFixture<AzuriteFixture>
+{
+    public const string Name = "Azurite collection";
+}

--- a/test/WopiHost.AzureLockProvider.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/WopiHost.AzureLockProvider.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,132 @@
+using Azure.Core;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using WopiHost.Abstractions;
+using Xunit;
+
+namespace WopiHost.AzureLockProvider.Tests;
+
+public class ServiceCollectionExtensionsTests
+{
+    private static IConfiguration BuildConfig(Dictionary<string, string?> values)
+        => new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+
+    private static void AddNullLogging(IServiceCollection services)
+    {
+        services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+    }
+
+    [Fact]
+    public void AddAzureLockProvider_WithConnectionString_RegistersLockProvider()
+    {
+        var services = new ServiceCollection();
+        AddNullLogging(services);
+        var config = BuildConfig(new()
+        {
+            ["Wopi:LockProvider:ConnectionString"] = "UseDevelopmentStorage=true",
+            ["Wopi:LockProvider:ContainerName"] = "wopi-locks",
+        });
+
+        services.AddAzureLockProvider(config);
+
+        using var sp = services.BuildServiceProvider();
+        var lockProvider = sp.GetRequiredService<IWopiLockProvider>();
+        Assert.IsType<WopiAzureLockProvider>(lockProvider);
+    }
+
+    [Fact]
+    public void AddAzureLockProvider_WithServiceUriAndCredential_RegistersLockProvider()
+    {
+        var services = new ServiceCollection();
+        AddNullLogging(services);
+        services.AddSingleton<TokenCredential>(new FakeTokenCredential());
+        var config = BuildConfig(new()
+        {
+            ["Wopi:LockProvider:ServiceUri"] = "https://acct.blob.core.windows.net",
+            ["Wopi:LockProvider:ContainerName"] = "wopi-locks",
+        });
+
+        services.AddAzureLockProvider(config);
+
+        using var sp = services.BuildServiceProvider();
+        Assert.NotNull(sp.GetRequiredService<IWopiLockProvider>());
+    }
+
+    [Fact]
+    public void AddAzureLockProvider_WithServiceUriAndNoCredential_FallsBackToDefaultCredential()
+    {
+        var services = new ServiceCollection();
+        AddNullLogging(services);
+        var config = BuildConfig(new()
+        {
+            ["Wopi:LockProvider:ServiceUri"] = "https://acct.blob.core.windows.net",
+            ["Wopi:LockProvider:ContainerName"] = "wopi-locks",
+        });
+
+        services.AddAzureLockProvider(config);
+
+        using var sp = services.BuildServiceProvider();
+        Assert.NotNull(sp.GetRequiredService<IWopiLockProvider>());
+    }
+
+    [Fact]
+    public void AddAzureLockProvider_MissingContainerName_FailsValidation()
+    {
+        var services = new ServiceCollection();
+        AddNullLogging(services);
+        var config = BuildConfig(new()
+        {
+            ["Wopi:LockProvider:ConnectionString"] = "UseDevelopmentStorage=true",
+            ["Wopi:LockProvider:ContainerName"] = "",
+        });
+
+        services.AddAzureLockProvider(config);
+
+        using var sp = services.BuildServiceProvider();
+        var ex = Assert.Throws<OptionsValidationException>(
+            () => sp.GetRequiredService<IOptions<WopiAzureLockProviderOptions>>().Value);
+        Assert.Contains("ContainerName", ex.Message);
+    }
+
+    [Fact]
+    public void AddAzureLockProvider_MissingConnectionStringAndServiceUri_FailsValidation()
+    {
+        var services = new ServiceCollection();
+        AddNullLogging(services);
+        var config = BuildConfig(new()
+        {
+            ["Wopi:LockProvider:ContainerName"] = "wopi-locks",
+        });
+
+        services.AddAzureLockProvider(config);
+
+        using var sp = services.BuildServiceProvider();
+        var ex = Assert.Throws<OptionsValidationException>(
+            () => sp.GetRequiredService<IOptions<WopiAzureLockProviderOptions>>().Value);
+        Assert.Contains("ConnectionString", ex.Message);
+    }
+
+    [Fact]
+    public void AddAzureLockProvider_NullArgs_Throw()
+    {
+        var services = new ServiceCollection();
+        var config = BuildConfig(new());
+
+        Assert.Throws<ArgumentNullException>(
+            () => ServiceCollectionExtensions.AddAzureLockProvider(null!, config));
+        Assert.Throws<ArgumentNullException>(
+            () => services.AddAzureLockProvider(null!));
+    }
+
+    private sealed class FakeTokenCredential : TokenCredential
+    {
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            => new("fake", DateTimeOffset.UtcNow.AddHours(1));
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            => new(new AccessToken("fake", DateTimeOffset.UtcNow.AddHours(1)));
+    }
+}

--- a/test/WopiHost.AzureLockProvider.Tests/WopiAzureLockProviderEdgeCaseTests.cs
+++ b/test/WopiHost.AzureLockProvider.Tests/WopiAzureLockProviderEdgeCaseTests.cs
@@ -1,0 +1,214 @@
+using System.Reflection;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Specialized;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace WopiHost.AzureLockProvider.Tests;
+
+/// <summary>
+/// Targeted tests for error and edge paths in <see cref="WopiAzureLockProvider"/> that the happy-path
+/// tests don't reach: malformed metadata, expired locks, broken leases, etc.
+/// </summary>
+[Collection(AzuriteCollection.Name)]
+public class WopiAzureLockProviderEdgeCaseTests(AzuriteFixture azurite)
+{
+    private async Task<(WopiAzureLockProvider provider, BlobContainerClient container)> CreateProviderAsync()
+    {
+        var serviceClient = azurite.CreateBlobServiceClient();
+        var container = serviceClient.GetBlobContainerClient($"wopi-locks-edge-{Guid.NewGuid():N}");
+        await container.CreateIfNotExistsAsync();
+        var provider = new WopiAzureLockProvider(container, NullLogger<WopiAzureLockProvider>.Instance);
+        return (provider, container);
+    }
+
+    private static BlobClient GetLockBlob(WopiAzureLockProvider provider, string fileId)
+    {
+        var method = typeof(WopiAzureLockProvider)
+            .GetMethod("GetLockBlob", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("GetLockBlob not found");
+        return (BlobClient)method.Invoke(provider, [fileId])!;
+    }
+
+    [Fact]
+    public async Task RefreshLockAsync_ExpiredLock_ReturnsFalse()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var lockBlob = GetLockBlob(provider, "file-expired-refresh");
+        using (var empty = new MemoryStream(Array.Empty<byte>()))
+        {
+            await lockBlob.UploadAsync(empty);
+        }
+        await lockBlob.SetMetadataAsync(new Dictionary<string, string>
+        {
+            [WopiAzureLockProvider.LockIdKey] = "ancient",
+            [WopiAzureLockProvider.LeaseIdKey] = Guid.NewGuid().ToString(),
+            [WopiAzureLockProvider.CreatedKey] = DateTimeOffset.UtcNow.AddHours(-2).ToString("O"),
+        });
+
+        var refreshed = await provider.RefreshLockAsync("file-expired-refresh");
+
+        Assert.False(refreshed);
+    }
+
+    [Fact]
+    public async Task RefreshLockAsync_MissingLeaseIdInMetadata_ReturnsFalse()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var lockBlob = GetLockBlob(provider, "file-no-leaseid");
+        using (var empty = new MemoryStream(Array.Empty<byte>()))
+        {
+            await lockBlob.UploadAsync(empty);
+        }
+        await lockBlob.SetMetadataAsync(new Dictionary<string, string>
+        {
+            [WopiAzureLockProvider.LockIdKey] = "lock-A",
+            [WopiAzureLockProvider.CreatedKey] = DateTimeOffset.UtcNow.ToString("O"),
+            // No LeaseIdKey
+        });
+
+        var refreshed = await provider.RefreshLockAsync("file-no-leaseid");
+
+        Assert.False(refreshed);
+    }
+
+    [Fact]
+    public async Task RefreshLockAsync_LeaseGoneOrMismatched_ReturnsFalse()
+    {
+        // RefreshLockAsync recovers the leaseId from metadata. If the actual lease has been broken
+        // since AddLock (crash, manual intervention, lease GC), RenewAsync throws 412/409 and refresh returns false.
+        var (provider, _) = await CreateProviderAsync();
+        var info = await provider.AddLockAsync("file-broken-lease", "lock-A");
+        Assert.NotNull(info);
+
+        // Externally break the lease so the renew fails.
+        var lockBlob = GetLockBlob(provider, "file-broken-lease");
+        await lockBlob.GetBlobLeaseClient().BreakAsync(breakPeriod: TimeSpan.Zero);
+
+        var refreshed = await provider.RefreshLockAsync("file-broken-lease");
+
+        Assert.False(refreshed);
+    }
+
+    [Fact]
+    public async Task RemoveLockAsync_NoLeaseInMetadata_DeletesBlob()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var lockBlob = GetLockBlob(provider, "file-no-lease-remove");
+        using (var empty = new MemoryStream(Array.Empty<byte>()))
+        {
+            await lockBlob.UploadAsync(empty);
+        }
+        await lockBlob.SetMetadataAsync(new Dictionary<string, string>
+        {
+            [WopiAzureLockProvider.LockIdKey] = "lock-A",
+            [WopiAzureLockProvider.CreatedKey] = DateTimeOffset.UtcNow.ToString("O"),
+            // No LeaseIdKey — the metadata-only branch in RemoveLock.
+        });
+
+        var removed = await provider.RemoveLockAsync("file-no-lease-remove");
+
+        Assert.True(removed);
+        Assert.False(await lockBlob.ExistsAsync());
+    }
+
+    [Fact]
+    public async Task RemoveLockAsync_StaleLeaseIdInMetadata_FallsBackToBreak()
+    {
+        // The metadata's lease GUID doesn't match any actual active lease — Release will fail with
+        // a 409/412 LeaseIdMismatch. The fallback path break-leases and proceeds to delete.
+        var (provider, _) = await CreateProviderAsync();
+        var lockBlob = GetLockBlob(provider, "file-stale-lease-remove");
+        using (var empty = new MemoryStream(Array.Empty<byte>()))
+        {
+            await lockBlob.UploadAsync(empty);
+        }
+        await lockBlob.SetMetadataAsync(new Dictionary<string, string>
+        {
+            [WopiAzureLockProvider.LockIdKey] = "lock-A",
+            [WopiAzureLockProvider.LeaseIdKey] = Guid.NewGuid().ToString(), // never acquired
+            [WopiAzureLockProvider.CreatedKey] = DateTimeOffset.UtcNow.ToString("O"),
+        });
+
+        var removed = await provider.RemoveLockAsync("file-stale-lease-remove");
+
+        Assert.True(removed);
+        Assert.False(await lockBlob.ExistsAsync());
+    }
+
+    [Fact]
+    public async Task GetLockAsync_MalformedCreatedTimestamp_ReturnsNull()
+    {
+        // Hits the TryReadLock parse-failure branch (returns false → outer GetLockAsync returns null).
+        var (provider, _) = await CreateProviderAsync();
+        var lockBlob = GetLockBlob(provider, "file-malformed-created");
+        using (var empty = new MemoryStream(Array.Empty<byte>()))
+        {
+            await lockBlob.UploadAsync(empty);
+        }
+        await lockBlob.SetMetadataAsync(new Dictionary<string, string>
+        {
+            [WopiAzureLockProvider.LockIdKey] = "lock-A",
+            [WopiAzureLockProvider.LeaseIdKey] = Guid.NewGuid().ToString(),
+            [WopiAzureLockProvider.CreatedKey] = "not-a-real-iso-timestamp",
+        });
+
+        var info = await provider.GetLockAsync("file-malformed-created");
+
+        Assert.Null(info);
+    }
+
+    [Fact]
+    public async Task GetLockAsync_EmptyLockIdInMetadata_ReturnsNull()
+    {
+        // TryReadLock requires non-empty lock id; otherwise returns false.
+        var (provider, _) = await CreateProviderAsync();
+        var lockBlob = GetLockBlob(provider, "file-empty-lockid");
+        using (var empty = new MemoryStream(Array.Empty<byte>()))
+        {
+            await lockBlob.UploadAsync(empty);
+        }
+        await lockBlob.SetMetadataAsync(new Dictionary<string, string>
+        {
+            [WopiAzureLockProvider.LockIdKey] = "",
+            [WopiAzureLockProvider.LeaseIdKey] = Guid.NewGuid().ToString(),
+            [WopiAzureLockProvider.CreatedKey] = DateTimeOffset.UtcNow.ToString("O"),
+        });
+
+        var info = await provider.GetLockAsync("file-empty-lockid");
+
+        Assert.Null(info);
+    }
+
+    [Fact]
+    public async Task AddLockAsync_BlobExistsButNoMetadata_TakesOver()
+    {
+        // Hits the "existing blob with no readable lock metadata" → break-lease + delete path,
+        // then proceeds to upload + acquire.
+        var (provider, _) = await CreateProviderAsync();
+        var lockBlob = GetLockBlob(provider, "file-stale-blob");
+        using (var empty = new MemoryStream(Array.Empty<byte>()))
+        {
+            await lockBlob.UploadAsync(empty);
+        }
+        // No metadata at all on the blob — bare zero-byte placeholder.
+
+        var info = await provider.AddLockAsync("file-stale-blob", "fresh");
+
+        Assert.NotNull(info);
+        Assert.Equal("fresh", info.LockId);
+    }
+
+    [Fact]
+    public async Task Constructor_NullArgs_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => new WopiAzureLockProvider(null!, NullLogger<WopiAzureLockProvider>.Instance));
+
+        var serviceClient = azurite.CreateBlobServiceClient();
+        var container = serviceClient.GetBlobContainerClient("ctor-test");
+        Assert.Throws<ArgumentNullException>(
+            () => new WopiAzureLockProvider(container, null!));
+    }
+}

--- a/test/WopiHost.AzureLockProvider.Tests/WopiAzureLockProviderOptionsTests.cs
+++ b/test/WopiHost.AzureLockProvider.Tests/WopiAzureLockProviderOptionsTests.cs
@@ -1,0 +1,31 @@
+using Xunit;
+
+namespace WopiHost.AzureLockProvider.Tests;
+
+public class WopiAzureLockProviderOptionsTests
+{
+    [Fact]
+    public void Defaults_PopulateContainerName_LeaveAuthEmpty()
+    {
+        var options = new WopiAzureLockProviderOptions();
+
+        Assert.Null(options.ConnectionString);
+        Assert.Null(options.ServiceUri);
+        Assert.Equal("wopi-locks", options.ContainerName);
+    }
+
+    [Fact]
+    public void Setters_RoundTripValues()
+    {
+        var options = new WopiAzureLockProviderOptions
+        {
+            ConnectionString = "UseDevelopmentStorage=true",
+            ServiceUri = "https://acct.blob.core.windows.net",
+            ContainerName = "custom-locks",
+        };
+
+        Assert.Equal("UseDevelopmentStorage=true", options.ConnectionString);
+        Assert.Equal("https://acct.blob.core.windows.net", options.ServiceUri);
+        Assert.Equal("custom-locks", options.ContainerName);
+    }
+}

--- a/test/WopiHost.AzureLockProvider.Tests/WopiAzureLockProviderTests.cs
+++ b/test/WopiHost.AzureLockProvider.Tests/WopiAzureLockProviderTests.cs
@@ -1,0 +1,192 @@
+using System.Reflection;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Specialized;
+using Microsoft.Extensions.Logging.Abstractions;
+using WopiHost.Abstractions;
+using Xunit;
+
+namespace WopiHost.AzureLockProvider.Tests;
+
+[Collection(AzuriteCollection.Name)]
+public class WopiAzureLockProviderTests(AzuriteFixture azurite)
+{
+    private async Task<(WopiAzureLockProvider provider, BlobContainerClient container)> CreateProviderAsync()
+    {
+        var serviceClient = azurite.CreateBlobServiceClient();
+        var container = serviceClient.GetBlobContainerClient($"wopi-locks-test-{Guid.NewGuid():N}");
+        await container.CreateIfNotExistsAsync();
+        var provider = new WopiAzureLockProvider(container, NullLogger<WopiAzureLockProvider>.Instance);
+        return (provider, container);
+    }
+
+    [Fact]
+    public async Task AddLockAsync_NoExistingLock_Succeeds()
+    {
+        var (provider, _) = await CreateProviderAsync();
+
+        var info = await provider.AddLockAsync("file-1", "lock-A");
+
+        Assert.NotNull(info);
+        Assert.Equal("file-1", info.FileId);
+        Assert.Equal("lock-A", info.LockId);
+        Assert.False(info.Expired);
+    }
+
+    [Fact]
+    public async Task AddLockAsync_WhenAlreadyLocked_ReturnsNull()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        await provider.AddLockAsync("file-2", "lock-A");
+
+        var second = await provider.AddLockAsync("file-2", "lock-B");
+
+        Assert.Null(second);
+    }
+
+    [Fact]
+    public async Task GetLockAsync_ReturnsLock_WhenPresent()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        await provider.AddLockAsync("file-3", "lock-A");
+
+        var info = await provider.GetLockAsync("file-3");
+
+        Assert.NotNull(info);
+        Assert.Equal("lock-A", info.LockId);
+    }
+
+    [Fact]
+    public async Task GetLockAsync_ReturnsNull_WhenAbsent()
+    {
+        var (provider, _) = await CreateProviderAsync();
+
+        var info = await provider.GetLockAsync("file-never-locked");
+
+        Assert.Null(info);
+    }
+
+    [Fact]
+    public async Task RefreshLockAsync_UpdatesTimestamp_AndOptionallyChangesLockId()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var original = await provider.AddLockAsync("file-4", "lock-A");
+        Assert.NotNull(original);
+
+        await Task.Delay(50);
+        var refreshed = await provider.RefreshLockAsync("file-4", lockId: "lock-B");
+
+        Assert.True(refreshed);
+        var info = await provider.GetLockAsync("file-4");
+        Assert.NotNull(info);
+        Assert.Equal("lock-B", info.LockId);
+        Assert.True(info.DateCreated > original.DateCreated);
+    }
+
+    [Fact]
+    public async Task RefreshLockAsync_NoExistingLock_ReturnsFalse()
+    {
+        var (provider, _) = await CreateProviderAsync();
+
+        var result = await provider.RefreshLockAsync("file-no-lock");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task RemoveLockAsync_ClearsLock()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        await provider.AddLockAsync("file-5", "lock-A");
+
+        var removed = await provider.RemoveLockAsync("file-5");
+
+        Assert.True(removed);
+        Assert.Null(await provider.GetLockAsync("file-5"));
+    }
+
+    [Fact]
+    public async Task RemoveLockAsync_NoLock_ReturnsFalse()
+    {
+        var (provider, _) = await CreateProviderAsync();
+
+        var result = await provider.RemoveLockAsync("file-no-lock");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task AddLockAsync_AfterPreviousLockRemoved_Succeeds()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        await provider.AddLockAsync("file-6", "lock-A");
+        await provider.RemoveLockAsync("file-6");
+
+        var second = await provider.AddLockAsync("file-6", "lock-B");
+
+        Assert.NotNull(second);
+        Assert.Equal("lock-B", second.LockId);
+    }
+
+    [Fact]
+    public async Task GetLockAsync_ExpiredLock_ReturnsNull_AndEvicts()
+    {
+        // Seed an expired entry directly so we don't have to wait 30 minutes.
+        var (provider, container) = await CreateProviderAsync();
+        var lockBlob = GetLockBlob(provider, "file-stale");
+
+        // Stage: create the blob, set metadata with an old timestamp.
+        using (var empty = new MemoryStream(Array.Empty<byte>()))
+        {
+            await lockBlob.UploadAsync(empty);
+        }
+        await lockBlob.SetMetadataAsync(new Dictionary<string, string>
+        {
+            [WopiAzureLockProvider.LockIdKey] = "ancient",
+            [WopiAzureLockProvider.LeaseIdKey] = Guid.NewGuid().ToString(),
+            [WopiAzureLockProvider.CreatedKey] = DateTimeOffset.UtcNow.AddHours(-2).ToString("O"),
+        });
+
+        var info = await provider.GetLockAsync("file-stale");
+
+        Assert.Null(info);
+        Assert.False(await lockBlob.ExistsAsync());
+    }
+
+    [Fact]
+    public async Task AddLockAsync_TakesOverExpiredLock()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var lockBlob = GetLockBlob(provider, "file-takeover");
+
+        using (var empty = new MemoryStream(Array.Empty<byte>()))
+        {
+            await lockBlob.UploadAsync(empty);
+        }
+        // Acquire an infinite lease so the stale lock has a real Azure lease (mirroring a real "crashed holder" scenario).
+        var leaseId = Guid.NewGuid().ToString();
+        await lockBlob.GetBlobLeaseClient(leaseId).AcquireAsync(TimeSpan.FromSeconds(-1));
+        await lockBlob.SetMetadataAsync(
+            new Dictionary<string, string>
+            {
+                [WopiAzureLockProvider.LockIdKey] = "ancient",
+                [WopiAzureLockProvider.LeaseIdKey] = leaseId,
+                [WopiAzureLockProvider.CreatedKey] = DateTimeOffset.UtcNow.AddHours(-2).ToString("O"),
+            },
+            conditions: new BlobRequestConditions { LeaseId = leaseId });
+
+        var info = await provider.AddLockAsync("file-takeover", "fresh-lock");
+
+        Assert.NotNull(info);
+        Assert.Equal("fresh-lock", info.LockId);
+    }
+
+    private static BlobClient GetLockBlob(WopiAzureLockProvider provider, string fileId)
+    {
+        // Reach into the private GetLockBlob to address the same blob in setup helpers.
+        var method = typeof(WopiAzureLockProvider)
+            .GetMethod("GetLockBlob", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("GetLockBlob not found");
+        return (BlobClient)method.Invoke(provider, [fileId])!;
+    }
+}

--- a/test/WopiHost.AzureLockProvider.Tests/WopiHost.AzureLockProvider.Tests.csproj
+++ b/test/WopiHost.AzureLockProvider.Tests/WopiHost.AzureLockProvider.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+	</PropertyGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\WopiHost.AzureLockProvider\WopiHost.AzureLockProvider.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Testcontainers.Azurite" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+	</ItemGroup>
+	<ItemGroup>
+	  <PackageReference Update="coverlet.collector">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
+	  <PackageReference Update="coverlet.msbuild">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
+	  <PackageReference Update="xunit.runner.console">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
+	  <PackageReference Update="xunit.runner.visualstudio">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
+	</ItemGroup>
+</Project>

--- a/test/WopiHost.AzureStorageProvider.Tests/AzuriteFixture.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/AzuriteFixture.cs
@@ -1,0 +1,43 @@
+using Azure.Storage.Blobs;
+using Testcontainers.Azurite;
+using Xunit;
+
+namespace WopiHost.AzureStorageProvider.Tests;
+
+/// <summary>
+/// xUnit class fixture that boots an Azurite container once per test class. Tests build clients via
+/// <see cref="CreateBlobServiceClient"/>. The image tag is pinned to a recent Azurite that supports
+/// the API version the bundled <c>Azure.Storage.Blobs</c> sends — Testcontainers.Azurite's default
+/// image (3.28) lags behind the SDK and is rejected by version-check.
+/// </summary>
+public sealed class AzuriteFixture : IAsyncLifetime
+{
+    /// <summary>Latest stable Azurite at the time of writing.</summary>
+    public const string AzuriteImage = "mcr.microsoft.com/azure-storage/azurite:3.35.0";
+
+    /// <summary>
+    /// Latest blob service version Azurite 3.35.0 understands. The SDK ships a newer default
+    /// (currently 2026-02-06) which Azurite rejects with InvalidHeaderValue, so tests pin one
+    /// version older. Bump alongside <see cref="AzuriteImage"/>.
+    /// </summary>
+    public const BlobClientOptions.ServiceVersion AzuriteSupportedVersion = BlobClientOptions.ServiceVersion.V2025_11_05;
+
+    private readonly AzuriteContainer container = new AzuriteBuilder()
+        .WithImage(AzuriteImage)
+        .Build();
+
+    public string ConnectionString => container.GetConnectionString();
+
+    public BlobServiceClient CreateBlobServiceClient()
+        => new(ConnectionString, new BlobClientOptions(AzuriteSupportedVersion));
+
+    public Task InitializeAsync() => container.StartAsync();
+
+    public Task DisposeAsync() => container.DisposeAsync().AsTask();
+}
+
+[CollectionDefinition(Name)]
+public sealed class AzuriteCollection : ICollectionFixture<AzuriteFixture>
+{
+    public const string Name = "Azurite collection";
+}

--- a/test/WopiHost.AzureStorageProvider.Tests/BlobIdMapTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/BlobIdMapTests.cs
@@ -163,5 +163,4 @@ public class BlobIdMapTests
         Assert.False(map.TryGetFileId("orphan.txt", out _));
         Assert.True(map.TryGetFileId("fresh.txt", out _));
     }
-
 }

--- a/test/WopiHost.AzureStorageProvider.Tests/BlobIdMapTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/BlobIdMapTests.cs
@@ -1,0 +1,167 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace WopiHost.AzureStorageProvider.Tests;
+
+public class BlobIdMapTests
+{
+    private static BlobIdMap NewMap() => new(NullLogger<BlobIdMap>.Instance);
+
+    [Fact]
+    public void IdFromPath_DeterministicAndCaseInsensitive()
+    {
+        var lower = BlobIdMap.IdFromPath("a/b/file.txt");
+        var upper = BlobIdMap.IdFromPath("A/B/FILE.TXT");
+
+        Assert.Equal(lower, upper);
+        // Hex MD5 — 32 lowercase hex chars.
+        Assert.Equal(32, lower.Length);
+        Assert.All(lower, c => Assert.True(char.IsAsciiHexDigitLower(c)));
+    }
+
+    [Fact]
+    public void Add_RegistersPath_AndReturnsDeterministicId()
+    {
+        var map = NewMap();
+        var id = map.Add("docs/report.docx");
+
+        Assert.Equal(BlobIdMap.IdFromPath("docs/report.docx"), id);
+        Assert.True(map.TryGetPath(id, out var path));
+        Assert.Equal("docs/report.docx", path);
+    }
+
+    [Fact]
+    public void TryGetPath_UnknownId_ReturnsFalse()
+    {
+        var map = NewMap();
+        Assert.False(map.TryGetPath("does-not-exist", out var path));
+        Assert.Null(path);
+    }
+
+    [Fact]
+    public void TryGetFileId_UnknownPath_ReturnsFalse()
+    {
+        var map = NewMap();
+        map.Add("present.txt");
+
+        Assert.False(map.TryGetFileId("absent.txt", out var id));
+        Assert.Null(id);
+    }
+
+    [Fact]
+    public void TryGetFileId_KnownPath_ReturnsId()
+    {
+        var map = NewMap();
+        var addedId = map.Add("present.txt");
+
+        Assert.True(map.TryGetFileId("present.txt", out var id));
+        Assert.Equal(addedId, id);
+    }
+
+    [Fact]
+    public void Remove_DropsMapping()
+    {
+        var map = NewMap();
+        var id = map.Add("doomed.txt");
+
+        Assert.True(map.Remove(id));
+        Assert.False(map.TryGetPath(id, out _));
+        Assert.False(map.Remove(id)); // second call returns false
+    }
+
+    [Fact]
+    public void Update_RetainsIdentifier_PointsAtNewPath()
+    {
+        var map = NewMap();
+        var id = map.Add("before.txt");
+
+        map.Update(id, "after.txt");
+
+        Assert.True(map.TryGetPath(id, out var path));
+        Assert.Equal("after.txt", path);
+    }
+
+    [Fact]
+    public void ScanAll_EmptyEnumeration_RegistersOnlyRoot()
+    {
+        var map = NewMap();
+        map.ScanAll(Array.Empty<string>());
+
+        Assert.True(map.WasScanned);
+        var rootId = BlobIdMap.IdFromPath(string.Empty);
+        Assert.True(map.TryGetPath(rootId, out var rootPath));
+        Assert.Equal(string.Empty, rootPath);
+    }
+
+    [Fact]
+    public void ScanAll_FlatBlobs_RegistersEachBlob()
+    {
+        var map = NewMap();
+        map.ScanAll(["a.txt", "b.docx", "c.pdf"]);
+
+        Assert.True(map.TryGetFileId("a.txt", out _));
+        Assert.True(map.TryGetFileId("b.docx", out _));
+        Assert.True(map.TryGetFileId("c.pdf", out _));
+    }
+
+    [Fact]
+    public void ScanAll_NestedBlobs_RegistersAllAncestorFolders()
+    {
+        var map = NewMap();
+        map.ScanAll(["a/b/c/leaf.txt"]);
+
+        // Leaf
+        Assert.True(map.TryGetFileId("a/b/c/leaf.txt", out _));
+        // Each intermediate folder is registered
+        Assert.True(map.TryGetFileId("a/b/c", out _));
+        Assert.True(map.TryGetFileId("a/b", out _));
+        Assert.True(map.TryGetFileId("a", out _));
+    }
+
+    [Fact]
+    public void ScanAll_FolderMarker_RegistersFolder_HidesMarker()
+    {
+        var map = NewMap();
+        map.ScanAll(["empty/" + BlobIdMap.FolderMarker]);
+
+        Assert.True(map.TryGetFileId("empty", out _));
+        Assert.False(map.TryGetFileId("empty/" + BlobIdMap.FolderMarker, out _));
+    }
+
+    [Fact]
+    public void ScanAll_FolderMarkerOnRoot_RegistersOnlyRoot()
+    {
+        var map = NewMap();
+        // A bare folder-marker at root level (not nested under any prefix).
+        map.ScanAll([BlobIdMap.FolderMarker]);
+
+        Assert.False(map.TryGetFileId(BlobIdMap.FolderMarker, out _));
+        // Root is always registered.
+        Assert.True(map.TryGetPath(BlobIdMap.IdFromPath(string.Empty), out _));
+    }
+
+    [Fact]
+    public void ScanAll_DedupesAncestorRegistrations()
+    {
+        var map = NewMap();
+        map.ScanAll(["a/file1.txt", "a/file2.txt", "a/sub/file3.txt"]);
+
+        Assert.True(map.TryGetFileId("a", out var firstAId));
+        Assert.True(map.TryGetFileId("a", out var secondAId));
+        Assert.Equal(firstAId, secondAId);
+        Assert.True(map.TryGetFileId("a/sub", out _));
+    }
+
+    [Fact]
+    public void ScanAll_ResetsExistingMap()
+    {
+        var map = NewMap();
+        map.Add("orphan.txt");
+
+        map.ScanAll(["fresh.txt"]);
+
+        Assert.False(map.TryGetFileId("orphan.txt", out _));
+        Assert.True(map.TryGetFileId("fresh.txt", out _));
+    }
+
+}

--- a/test/WopiHost.AzureStorageProvider.Tests/HashingBlobWriteStreamTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/HashingBlobWriteStreamTests.cs
@@ -1,0 +1,190 @@
+using System.Security.Cryptography;
+using System.Text;
+using Azure.Storage.Blobs;
+using Xunit;
+
+namespace WopiHost.AzureStorageProvider.Tests;
+
+[Collection(AzuriteCollection.Name)]
+public class HashingBlobWriteStreamTests(AzuriteFixture azurite)
+{
+    private async Task<(BlobClient blobClient, BlobContainerClient container)> CreateBlobAsync()
+    {
+        var serviceClient = azurite.CreateBlobServiceClient();
+        var container = serviceClient.GetBlobContainerClient($"hash-test-{Guid.NewGuid():N}");
+        await container.CreateIfNotExistsAsync();
+        var blob = container.GetBlobClient("subject.bin");
+        // Pre-create the blob so OpenWriteAsync(overwrite:true) works.
+        using var empty = new MemoryStream(Array.Empty<byte>(), writable: false);
+        await blob.UploadAsync(empty, overwrite: false);
+        return (blob, container);
+    }
+
+    private async Task<HashingBlobWriteStream> OpenWrapperAsync(BlobClient blobClient)
+    {
+        var inner = await blobClient.OpenWriteAsync(overwrite: true);
+        return new HashingBlobWriteStream(inner, blobClient, new Dictionary<string, string>(StringComparer.Ordinal));
+    }
+
+    private static string ExpectedSha256(string s)
+        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(s))).ToLowerInvariant();
+
+    [Fact]
+    public async Task Write_ByteArrayOffsetCount_PersistsContentAndHash()
+    {
+        var (blob, _) = await CreateBlobAsync();
+        const string payload = "hello-byte-array";
+        var bytes = Encoding.UTF8.GetBytes(payload);
+
+        await using (var s = await OpenWrapperAsync(blob))
+        {
+            // Sync byte[]/offset/count overload
+            s.Write(bytes, 0, bytes.Length);
+        }
+
+        var props = await blob.GetPropertiesAsync();
+        Assert.Equal(payload.Length, props.Value.ContentLength);
+        Assert.Equal(ExpectedSha256(payload), props.Value.Metadata[WopiBlobFile.Sha256MetadataKey]);
+    }
+
+    [Fact]
+    public async Task Write_ReadOnlySpan_PersistsContentAndHash()
+    {
+        var (blob, _) = await CreateBlobAsync();
+        const string payload = "span-payload";
+        var bytes = Encoding.UTF8.GetBytes(payload);
+
+        await using (var s = await OpenWrapperAsync(blob))
+        {
+            s.Write(bytes.AsSpan());
+        }
+
+        var props = await blob.GetPropertiesAsync();
+        Assert.Equal(payload.Length, props.Value.ContentLength);
+        Assert.Equal(ExpectedSha256(payload), props.Value.Metadata[WopiBlobFile.Sha256MetadataKey]);
+    }
+
+    [Fact]
+    public async Task WriteAsync_ByteArrayOffsetCount_PersistsContentAndHash()
+    {
+        var (blob, _) = await CreateBlobAsync();
+        const string payload = "async-byte-array";
+        var bytes = Encoding.UTF8.GetBytes(payload);
+
+        await using (var s = await OpenWrapperAsync(blob))
+        {
+            await s.WriteAsync(bytes, 0, bytes.Length, CancellationToken.None);
+        }
+
+        var props = await blob.GetPropertiesAsync();
+        Assert.Equal(payload.Length, props.Value.ContentLength);
+        Assert.Equal(ExpectedSha256(payload), props.Value.Metadata[WopiBlobFile.Sha256MetadataKey]);
+    }
+
+    [Fact]
+    public async Task Flush_AndFlushAsync_DoNotThrow()
+    {
+        var (blob, _) = await CreateBlobAsync();
+
+        await using var s = await OpenWrapperAsync(blob);
+        s.Flush();
+        await s.FlushAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task CapabilityFlags_Match_WriteOnlyStream()
+    {
+        var (blob, _) = await CreateBlobAsync();
+        await using var s = await OpenWrapperAsync(blob);
+
+        Assert.False(s.CanRead);
+        Assert.False(s.CanSeek);
+        Assert.True(s.CanWrite);
+    }
+
+    [Fact]
+    public async Task LengthAndPosition_Throw_NotSupported()
+    {
+        var (blob, _) = await CreateBlobAsync();
+        await using var s = await OpenWrapperAsync(blob);
+
+        Assert.Throws<NotSupportedException>(() => s.Length);
+        Assert.Throws<NotSupportedException>(() => s.Position);
+        Assert.Throws<NotSupportedException>(() => s.Position = 0);
+    }
+
+    [Fact]
+    public async Task Read_Seek_SetLength_Throw_NotSupported()
+    {
+        var (blob, _) = await CreateBlobAsync();
+        await using var s = await OpenWrapperAsync(blob);
+
+        Assert.Throws<NotSupportedException>(() => s.Read(new byte[1], 0, 1));
+        Assert.Throws<NotSupportedException>(() => s.Seek(0, SeekOrigin.Begin));
+        Assert.Throws<NotSupportedException>(() => s.SetLength(0));
+    }
+
+    [Fact]
+    public async Task DisposeAsync_Idempotent()
+    {
+        var (blob, _) = await CreateBlobAsync();
+        var s = await OpenWrapperAsync(blob);
+        await s.WriteAsync(Encoding.UTF8.GetBytes("once"));
+
+        await s.DisposeAsync();
+        // Second dispose must be a no-op (does not re-call SetMetadata, doesn't throw).
+        await s.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task SyncDispose_PersistsContentAndHash()
+    {
+        var (blob, _) = await CreateBlobAsync();
+        const string payload = "sync-dispose-path";
+        var bytes = Encoding.UTF8.GetBytes(payload);
+
+        // Use plain `using` (sync dispose) instead of `await using` to exercise Dispose(true).
+        using (var s = await OpenWrapperAsync(blob))
+        {
+            s.Write(bytes, 0, bytes.Length);
+        }
+
+        var props = await blob.GetPropertiesAsync();
+        Assert.Equal(payload.Length, props.Value.ContentLength);
+        Assert.Equal(ExpectedSha256(payload), props.Value.Metadata[WopiBlobFile.Sha256MetadataKey]);
+    }
+
+    [Fact]
+    public async Task SyncDispose_Idempotent()
+    {
+        var (blob, _) = await CreateBlobAsync();
+        var s = await OpenWrapperAsync(blob);
+        s.Write([1, 2, 3], 0, 3);
+
+        s.Dispose();
+        s.Dispose(); // no-op on second call
+    }
+
+    [Fact]
+    public async Task PreservedMetadata_RoundTrips_AlongsideHash()
+    {
+        // Caller-provided metadata (e.g. the previous wopi_owner) should survive the write.
+        var (blob, _) = await CreateBlobAsync();
+        const string payload = "preserve-metadata";
+        var bytes = Encoding.UTF8.GetBytes(payload);
+
+        var preserved = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["wopi_owner"] = "alice",
+        };
+        var inner = await blob.OpenWriteAsync(overwrite: true);
+        await using (var s = new HashingBlobWriteStream(inner, blob, preserved))
+        {
+            await s.WriteAsync(bytes);
+        }
+
+        var props = await blob.GetPropertiesAsync();
+        Assert.Equal("alice", props.Value.Metadata["wopi_owner"]);
+        Assert.Equal(ExpectedSha256(payload), props.Value.Metadata[WopiBlobFile.Sha256MetadataKey]);
+    }
+}

--- a/test/WopiHost.AzureStorageProvider.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,140 @@
+using Azure.Core;
+using Azure.Storage.Blobs;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using WopiHost.Abstractions;
+using Xunit;
+
+namespace WopiHost.AzureStorageProvider.Tests;
+
+public class ServiceCollectionExtensionsTests
+{
+    private static IConfiguration BuildConfig(Dictionary<string, string?> values)
+        => new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+
+    private static void AddNullLogging(IServiceCollection services)
+    {
+        services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+    }
+
+    [Fact]
+    public void AddAzureStorageProvider_WithConnectionString_RegistersBothInterfaces()
+    {
+        var services = new ServiceCollection();
+        AddNullLogging(services);
+        var config = BuildConfig(new()
+        {
+            ["Wopi:StorageProvider:ConnectionString"] = "UseDevelopmentStorage=true",
+            ["Wopi:StorageProvider:ContainerName"] = "wopi-files",
+        });
+
+        services.AddAzureStorageProvider(config);
+
+        using var sp = services.BuildServiceProvider();
+        var storage = sp.GetRequiredService<IWopiStorageProvider>();
+        var writable = sp.GetRequiredService<IWopiWritableStorageProvider>();
+        Assert.Same(storage, writable);
+        Assert.IsType<WopiAzureStorageProvider>(storage);
+        // Container client and id map should be resolvable singletons.
+        Assert.NotNull(sp.GetRequiredService<BlobContainerClient>());
+        Assert.NotNull(sp.GetRequiredService<BlobIdMap>());
+    }
+
+    [Fact]
+    public void AddAzureStorageProvider_WithServiceUriAndCredential_RegistersProvider()
+    {
+        var services = new ServiceCollection();
+        AddNullLogging(services);
+        services.AddSingleton<TokenCredential>(new FakeTokenCredential());
+        var config = BuildConfig(new()
+        {
+            ["Wopi:StorageProvider:ServiceUri"] = "https://acct.blob.core.windows.net",
+            ["Wopi:StorageProvider:ContainerName"] = "wopi-files",
+        });
+
+        services.AddAzureStorageProvider(config);
+
+        using var sp = services.BuildServiceProvider();
+        Assert.NotNull(sp.GetRequiredService<IWopiStorageProvider>());
+    }
+
+    [Fact]
+    public void AddAzureStorageProvider_WithServiceUriAndNoCredential_FallsBackToDefaultCredential()
+    {
+        // No TokenCredential registered → ServiceCollectionExtensions must build a DefaultAzureCredential.
+        // We can't easily assert "is DefaultAzureCredential" since it's encapsulated in the BlobServiceClient,
+        // but resolution must not throw.
+        var services = new ServiceCollection();
+        AddNullLogging(services);
+        var config = BuildConfig(new()
+        {
+            ["Wopi:StorageProvider:ServiceUri"] = "https://acct.blob.core.windows.net",
+            ["Wopi:StorageProvider:ContainerName"] = "wopi-files",
+        });
+
+        services.AddAzureStorageProvider(config);
+
+        using var sp = services.BuildServiceProvider();
+        Assert.NotNull(sp.GetRequiredService<BlobContainerClient>());
+    }
+
+    [Fact]
+    public void AddAzureStorageProvider_MissingContainerName_FailsValidation()
+    {
+        var services = new ServiceCollection();
+        AddNullLogging(services);
+        var config = BuildConfig(new()
+        {
+            ["Wopi:StorageProvider:ConnectionString"] = "UseDevelopmentStorage=true",
+        });
+
+        services.AddAzureStorageProvider(config);
+
+        using var sp = services.BuildServiceProvider();
+        var ex = Assert.Throws<OptionsValidationException>(
+            () => sp.GetRequiredService<IOptions<WopiAzureStorageProviderOptions>>().Value);
+        Assert.Contains("ContainerName", ex.Message);
+    }
+
+    [Fact]
+    public void AddAzureStorageProvider_MissingConnectionStringAndServiceUri_FailsValidation()
+    {
+        var services = new ServiceCollection();
+        AddNullLogging(services);
+        var config = BuildConfig(new()
+        {
+            ["Wopi:StorageProvider:ContainerName"] = "wopi-files",
+        });
+
+        services.AddAzureStorageProvider(config);
+
+        using var sp = services.BuildServiceProvider();
+        var ex = Assert.Throws<OptionsValidationException>(
+            () => sp.GetRequiredService<IOptions<WopiAzureStorageProviderOptions>>().Value);
+        Assert.Contains("ConnectionString", ex.Message);
+    }
+
+    [Fact]
+    public void AddAzureStorageProvider_NullArgs_Throw()
+    {
+        var services = new ServiceCollection();
+        var config = BuildConfig(new());
+
+        Assert.Throws<ArgumentNullException>(
+            () => ServiceCollectionExtensions.AddAzureStorageProvider(null!, config));
+        Assert.Throws<ArgumentNullException>(
+            () => services.AddAzureStorageProvider(null!));
+    }
+
+    private sealed class FakeTokenCredential : TokenCredential
+    {
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            => new("fake", DateTimeOffset.UtcNow.AddHours(1));
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            => new(new AccessToken("fake", DateTimeOffset.UtcNow.AddHours(1)));
+    }
+}

--- a/test/WopiHost.AzureStorageProvider.Tests/WopiAzureStorageProviderEdgeCaseTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/WopiAzureStorageProviderEdgeCaseTests.cs
@@ -1,0 +1,371 @@
+using Azure.Storage.Blobs;
+using Microsoft.Extensions.Logging.Abstractions;
+using WopiHost.Abstractions;
+using Xunit;
+
+namespace WopiHost.AzureStorageProvider.Tests;
+
+/// <summary>
+/// Targeted tests for branches the happy-path tests don't cover: error returns, unsupported types,
+/// duplicate creation, root-folder operations, search-pattern matching, etc.
+/// </summary>
+[Collection(AzuriteCollection.Name)]
+public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
+{
+    private async Task<(WopiAzureStorageProvider provider, BlobContainerClient container)> CreateProviderAsync()
+    {
+        var serviceClient = azurite.CreateBlobServiceClient();
+        var container = serviceClient.GetBlobContainerClient($"wopi-edge-{Guid.NewGuid():N}");
+        var idMap = new BlobIdMap(NullLogger<BlobIdMap>.Instance);
+        var provider = new WopiAzureStorageProvider(container, idMap, NullLogger<WopiAzureStorageProvider>.Instance);
+        // Force init.
+        _ = await provider.GetWopiResource<IWopiFolder>(provider.RootContainerPointer.Identifier);
+        return (provider, container);
+    }
+
+    private static async Task UploadAsync(BlobContainerClient container, string path, string content = "")
+    {
+        var blob = container.GetBlobClient(path);
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(content));
+        await blob.UploadAsync(stream, overwrite: true);
+    }
+
+    [Fact]
+    public void Constructor_NullArgs_Throw()
+    {
+        var serviceClient = azurite.CreateBlobServiceClient();
+        var container = serviceClient.GetBlobContainerClient("ctor-test");
+        var idMap = new BlobIdMap(NullLogger<BlobIdMap>.Instance);
+
+        Assert.Throws<ArgumentNullException>(
+            () => new WopiAzureStorageProvider(null!, idMap, NullLogger<WopiAzureStorageProvider>.Instance));
+        Assert.Throws<ArgumentNullException>(
+            () => new WopiAzureStorageProvider(container, null!, NullLogger<WopiAzureStorageProvider>.Instance));
+        Assert.Throws<ArgumentNullException>(
+            () => new WopiAzureStorageProvider(container, idMap, null!));
+    }
+
+    [Fact]
+    public async Task GetWopiResource_UnsupportedType_Throws()
+    {
+        var (provider, container) = await CreateProviderAsync();
+        await UploadAsync(container, "x.txt");
+        // Drain GetWopiFiles to populate the id map for the blob.
+        await foreach (var _ in provider.GetWopiFiles(provider.RootContainerPointer.Identifier)) { }
+        var anyId = BlobIdMap.IdFromPath("x.txt");
+
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => provider.GetWopiResource<UnsupportedResource>(anyId));
+    }
+
+    [Fact]
+    public async Task GetWopiResource_Folder_RoundTripsViaIdentifier()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(null, "folder1"))!;
+
+        var fetched = await provider.GetWopiResource<IWopiFolder>(folder.Identifier);
+
+        Assert.NotNull(fetched);
+        Assert.Equal("folder1", fetched.Name);
+    }
+
+    [Fact]
+    public async Task GetWopiResourceByName_UnknownContainer_Throws()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        await Assert.ThrowsAsync<DirectoryNotFoundException>(
+            () => provider.GetWopiResourceByName<IWopiFile>("does-not-exist", "anything.txt"));
+    }
+
+    [Fact]
+    public async Task GetWopiResourceByName_Folder_FoundAndMissing()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(null, "subA"))!;
+        // The folder marker blob makes the folder discoverable.
+
+        var found = await provider.GetWopiResourceByName<IWopiFolder>(provider.RootContainerPointer.Identifier, "subA");
+        Assert.NotNull(found);
+        Assert.Equal(folder.Identifier, found.Identifier);
+
+        var missing = await provider.GetWopiResourceByName<IWopiFolder>(provider.RootContainerPointer.Identifier, "nope");
+        Assert.Null(missing);
+    }
+
+    [Fact]
+    public async Task GetWopiResourceByName_UnsupportedType_Throws()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => provider.GetWopiResourceByName<UnsupportedResource>(provider.RootContainerPointer.Identifier, "x"));
+    }
+
+    [Fact]
+    public async Task GetAncestors_UnknownIdentifier_Throws()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        await Assert.ThrowsAsync<DirectoryNotFoundException>(
+            () => provider.GetAncestors<IWopiFile>("not-real"));
+    }
+
+    [Fact]
+    public async Task GetAncestors_Folder_TopLevel_ReturnsRootOnly()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(null, "topfolder"))!;
+
+        var ancestors = await provider.GetAncestors<IWopiFolder>(folder.Identifier);
+
+        Assert.Single(ancestors);
+        Assert.Equal(provider.RootContainerPointer.Identifier, ancestors[0].Identifier);
+    }
+
+    [Fact]
+    public async Task GetWopiFiles_SearchPattern_FiltersByExtension()
+    {
+        var (provider, container) = await CreateProviderAsync();
+        await UploadAsync(container, "doc.docx");
+        await UploadAsync(container, "sheet.xlsx");
+        await UploadAsync(container, "notes.txt");
+
+        var matched = new List<string>();
+        await foreach (var f in provider.GetWopiFiles(provider.RootContainerPointer.Identifier, searchPattern: "*.docx"))
+        {
+            matched.Add(f.Name + "." + f.Extension);
+        }
+
+        Assert.Single(matched);
+        Assert.Equal("doc.docx", matched[0]);
+    }
+
+    [Fact]
+    public async Task GetWopiFiles_SearchPattern_QuestionMarkWildcard()
+    {
+        var (provider, container) = await CreateProviderAsync();
+        await UploadAsync(container, "a.txt");
+        await UploadAsync(container, "ab.txt");
+
+        var matched = new List<string>();
+        // "?.txt" → exactly one char before .txt
+        await foreach (var f in provider.GetWopiFiles(provider.RootContainerPointer.Identifier, searchPattern: "?.txt"))
+        {
+            matched.Add(f.Name + "." + f.Extension);
+        }
+
+        Assert.Single(matched);
+        Assert.Equal("a.txt", matched[0]);
+    }
+
+    [Theory]
+    [InlineData("*")]
+    [InlineData("*.*")]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task GetWopiFiles_NoPatternOrWildcard_ReturnsEverything(string? pattern)
+    {
+        var (provider, container) = await CreateProviderAsync();
+        await UploadAsync(container, "a.txt");
+        await UploadAsync(container, "b.docx");
+
+        var count = 0;
+        await foreach (var _ in provider.GetWopiFiles(provider.RootContainerPointer.Identifier, pattern))
+        {
+            count++;
+        }
+
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public async Task CreateWopiChildResource_Folder_DuplicateName_Throws()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        _ = await provider.CreateWopiChildResource<IWopiFolder>(null, "dup-folder");
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.CreateWopiChildResource<IWopiFolder>(null, "dup-folder"));
+    }
+
+    [Fact]
+    public async Task CreateWopiChildResource_UnsupportedType_Throws()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => provider.CreateWopiChildResource<UnsupportedResource>(null, "x"));
+    }
+
+    [Fact]
+    public async Task DeleteWopiResource_UnknownIdentifier_ReturnsFalse()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var deleted = await provider.DeleteWopiResource<IWopiFile>("not-mapped");
+        Assert.False(deleted);
+    }
+
+    [Fact]
+    public async Task DeleteWopiResource_RootFolder_Throws()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => provider.DeleteWopiResource<IWopiFolder>(provider.RootContainerPointer.Identifier));
+    }
+
+    [Fact]
+    public async Task DeleteWopiResource_UnsupportedType_Throws()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(null, "for-delete-unsupported"))!;
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => provider.DeleteWopiResource<UnsupportedResource>(folder.Identifier));
+    }
+
+    [Fact]
+    public async Task RenameWopiResource_InvalidName_Throws()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var file = (await provider.CreateWopiChildResource<IWopiFile>(null, "rn-invalid.txt"))!;
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.RenameWopiResource<IWopiFile>(file.Identifier, "bad/name.txt"));
+    }
+
+    [Fact]
+    public async Task RenameWopiResource_UnknownIdentifier_ReturnsFalse()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var renamed = await provider.RenameWopiResource<IWopiFile>("not-mapped", "ok.txt");
+        Assert.False(renamed);
+    }
+
+    [Fact]
+    public async Task RenameWopiResource_RootFolder_Throws()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => provider.RenameWopiResource<IWopiFolder>(provider.RootContainerPointer.Identifier, "newroot"));
+    }
+
+    [Fact]
+    public async Task RenameWopiResource_UnsupportedType_Throws()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var file = (await provider.CreateWopiChildResource<IWopiFile>(null, "rn-unsupported.txt"))!;
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => provider.RenameWopiResource<UnsupportedResource>(file.Identifier, "x"));
+    }
+
+    [Fact]
+    public async Task RenameWopiResource_Folder_PreservesId_AndMovesChildren()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(null, "rn-folder"))!;
+        var originalId = folder.Identifier;
+        var child = (await provider.CreateWopiChildResource<IWopiFile>(folder.Identifier, "child.txt"))!;
+
+        var renamed = await provider.RenameWopiResource<IWopiFolder>(originalId, "renamed-folder");
+        Assert.True(renamed);
+
+        var refreshed = await provider.GetWopiResource<IWopiFolder>(originalId);
+        Assert.NotNull(refreshed);
+        Assert.Equal("renamed-folder", refreshed.Name);
+
+        // The child file's identifier should still resolve, now under the new prefix.
+        var movedChild = await provider.GetWopiResource<IWopiFile>(child.Identifier);
+        Assert.NotNull(movedChild);
+        Assert.Equal("child", movedChild.Name);
+    }
+
+    [Fact]
+    public async Task GetSuggestedName_InvalidName_Throws()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.GetSuggestedName<IWopiFile>(provider.RootContainerPointer.Identifier, "bad/name"));
+    }
+
+    [Fact]
+    public async Task GetSuggestedName_UnknownContainer_Throws()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        await Assert.ThrowsAsync<DirectoryNotFoundException>(
+            () => provider.GetSuggestedName<IWopiFile>("not-real", "fresh.txt"));
+    }
+
+    [Fact]
+    public async Task GetSuggestedName_Folder_AppendsCounter_WhenExists()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        _ = await provider.CreateWopiChildResource<IWopiFolder>(null, "dup");
+
+        var suggested = await provider.GetSuggestedName<IWopiFolder>(
+            provider.RootContainerPointer.Identifier, "dup");
+
+        Assert.Equal("dup (1)", suggested);
+    }
+
+    [Fact]
+    public async Task GetSuggestedName_File_NoExtension_AppendsCounter()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        _ = await provider.CreateWopiChildResource<IWopiFile>(null, "noext");
+
+        var suggested = await provider.GetSuggestedName<IWopiFile>(
+            provider.RootContainerPointer.Identifier, "noext");
+
+        Assert.Equal("noext (1)", suggested);
+    }
+
+    [Fact]
+    public async Task FileNameMaxLength_Default_Is250()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        Assert.Equal(250, provider.FileNameMaxLength);
+    }
+
+    [Fact]
+    public async Task CheckValidName_RejectsControlCharsAndOverlongNames()
+    {
+        var (provider, _) = await CreateProviderAsync();
+
+        Assert.False(await provider.CheckValidName<IWopiFile>("foobar"));
+        Assert.False(await provider.CheckValidName<IWopiFile>(new string('x', 251)));
+    }
+
+    [Fact]
+    public async Task GetWopiContainers_FromRoot_ListsTopLevelFoldersOnly()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        _ = await provider.CreateWopiChildResource<IWopiFolder>(null, "alpha");
+        _ = await provider.CreateWopiChildResource<IWopiFolder>(null, "beta");
+        // A nested folder shouldn't appear in the top-level listing.
+        var alphaId = (await provider.GetWopiResourceByName<IWopiFolder>(provider.RootContainerPointer.Identifier, "alpha"))!.Identifier;
+        _ = await provider.CreateWopiChildResource<IWopiFolder>(alphaId, "alpha-inner");
+
+        var names = new List<string>();
+        await foreach (var f in provider.GetWopiContainers(provider.RootContainerPointer.Identifier))
+        {
+            names.Add(f.Name);
+        }
+
+        Assert.Equal(2, names.Count);
+        Assert.Contains("alpha", names);
+        Assert.Contains("beta", names);
+    }
+
+    [Fact]
+    public async Task RootContainerPointer_IsAddressableViaItsIdentifier()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var root = await provider.GetWopiResource<IWopiFolder>(provider.RootContainerPointer.Identifier);
+        Assert.NotNull(root);
+        Assert.Equal(string.Empty, root.Name);
+    }
+
+    /// <summary>An <see cref="IWopiResource"/> that is neither a file nor a folder.</summary>
+    public sealed class UnsupportedResource : IWopiResource
+    {
+        public string Name => string.Empty;
+        public string Identifier => string.Empty;
+    }
+}

--- a/test/WopiHost.AzureStorageProvider.Tests/WopiAzureStorageProviderOptionsTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/WopiAzureStorageProviderOptionsTests.cs
@@ -1,0 +1,31 @@
+using Xunit;
+
+namespace WopiHost.AzureStorageProvider.Tests;
+
+public class WopiAzureStorageProviderOptionsTests
+{
+    [Fact]
+    public void Defaults_AreNullExceptRequired()
+    {
+        var options = new WopiAzureStorageProviderOptions { ContainerName = "x" };
+
+        Assert.Null(options.ConnectionString);
+        Assert.Null(options.ServiceUri);
+        Assert.Equal("x", options.ContainerName);
+    }
+
+    [Fact]
+    public void Setters_RoundTripValues()
+    {
+        var options = new WopiAzureStorageProviderOptions
+        {
+            ConnectionString = "UseDevelopmentStorage=true",
+            ServiceUri = "https://acct.blob.core.windows.net",
+            ContainerName = "wopi-files",
+        };
+
+        Assert.Equal("UseDevelopmentStorage=true", options.ConnectionString);
+        Assert.Equal("https://acct.blob.core.windows.net", options.ServiceUri);
+        Assert.Equal("wopi-files", options.ContainerName);
+    }
+}

--- a/test/WopiHost.AzureStorageProvider.Tests/WopiAzureStorageProviderTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/WopiAzureStorageProviderTests.cs
@@ -1,0 +1,276 @@
+using Azure.Storage.Blobs;
+using Microsoft.Extensions.Logging.Abstractions;
+using WopiHost.Abstractions;
+using Xunit;
+
+namespace WopiHost.AzureStorageProvider.Tests;
+
+[Collection(AzuriteCollection.Name)]
+public class WopiAzureStorageProviderTests(AzuriteFixture azurite)
+{
+    private async Task<(WopiAzureStorageProvider provider, BlobContainerClient container)> CreateProviderAsync()
+    {
+        // Per-test container so tests don't interfere with each other.
+        var serviceClient = azurite.CreateBlobServiceClient();
+        var container = serviceClient.GetBlobContainerClient($"wopi-test-{Guid.NewGuid():N}");
+        var idMap = new BlobIdMap(NullLogger<BlobIdMap>.Instance);
+        var provider = new WopiAzureStorageProvider(container, idMap, NullLogger<WopiAzureStorageProvider>.Instance);
+
+        // Force initialization (creates the container, scans the empty space).
+        _ = await provider.GetWopiResource<IWopiFolder>(provider.RootContainerPointer.Identifier);
+        return (provider, container);
+    }
+
+    private static async Task UploadAsync(BlobContainerClient container, string path, string content)
+    {
+        var blob = container.GetBlobClient(path);
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(content));
+        await blob.UploadAsync(stream, overwrite: true);
+    }
+
+    [Fact]
+    public async Task GetWopiResource_File_ReturnsFile_WhenBlobExists()
+    {
+        var (provider, container) = await CreateProviderAsync();
+        await UploadAsync(container, "hello.txt", "world");
+
+        // Re-list so the id map picks up the seeded blob.
+        var files = new List<IWopiFile>();
+        await foreach (var f in provider.GetWopiFiles(provider.RootContainerPointer.Identifier))
+        {
+            files.Add(f);
+        }
+        Assert.Single(files);
+
+        var fetched = await provider.GetWopiResource<IWopiFile>(files[0].Identifier);
+        Assert.NotNull(fetched);
+        Assert.True(fetched.Exists);
+        Assert.Equal("hello", fetched.Name);
+        Assert.Equal("txt", fetched.Extension);
+        Assert.Equal(5, fetched.Length);
+        Assert.NotNull(fetched.Version);
+    }
+
+    [Fact]
+    public async Task GetWopiResource_UnknownIdentifier_ReturnsNull()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var fetched = await provider.GetWopiResource<IWopiFile>("nonexistent");
+        Assert.Null(fetched);
+    }
+
+    [Fact]
+    public async Task GetReadStream_ReturnsBlobContent()
+    {
+        var (provider, container) = await CreateProviderAsync();
+        await UploadAsync(container, "doc.txt", "stream-me");
+        await foreach (var f in provider.GetWopiFiles(provider.RootContainerPointer.Identifier)) { _ = f; }
+        var file = await provider.GetWopiResourceByName<IWopiFile>(provider.RootContainerPointer.Identifier, "doc.txt");
+
+        Assert.NotNull(file);
+        await using var s = await file.GetReadStream();
+        using var reader = new StreamReader(s);
+        Assert.Equal("stream-me", await reader.ReadToEndAsync());
+    }
+
+    [Fact]
+    public async Task GetWriteStream_StoresContent_AndComputesSha256()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var created = await provider.CreateWopiChildResource<IWopiFile>(null, "writeable.txt");
+        Assert.NotNull(created);
+        Assert.True(created.Exists);
+
+        const string payload = "the quick brown fox";
+        var expectedHash = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(payload))).ToLowerInvariant();
+
+        var writable = (await provider.GetWopiResource<IWopiFile>(created.Identifier))!;
+        await using (var s = await writable.GetWriteStream())
+        {
+            await s.WriteAsync(System.Text.Encoding.UTF8.GetBytes(payload));
+        }
+
+        // Re-fetch so cached metadata reflects the new state.
+        var refreshed = (await provider.GetWopiResource<IWopiFile>(created.Identifier))!;
+        Assert.Equal(payload.Length, refreshed.Length);
+        Assert.NotNull(refreshed.Checksum);
+        Assert.Equal(expectedHash, Convert.ToHexString(refreshed.Checksum!).ToLowerInvariant());
+    }
+
+    [Fact]
+    public async Task CreateWopiChildResource_File_AddsZeroByteBlob()
+    {
+        var (provider, _) = await CreateProviderAsync();
+
+        var created = await provider.CreateWopiChildResource<IWopiFile>(null, "fresh.docx");
+
+        Assert.NotNull(created);
+        Assert.True(created.Exists);
+        Assert.Equal(0, created.Length);
+        Assert.Equal("fresh", created.Name);
+        Assert.Equal("docx", created.Extension);
+    }
+
+    [Fact]
+    public async Task CreateWopiChildResource_File_DuplicateName_Throws()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        _ = await provider.CreateWopiChildResource<IWopiFile>(null, "dup.txt");
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.CreateWopiChildResource<IWopiFile>(null, "dup.txt"));
+    }
+
+    [Fact]
+    public async Task CreateWopiChildResource_Folder_MaterializesMarkerBlob_AndIsListable()
+    {
+        var (provider, _) = await CreateProviderAsync();
+
+        var folder = await provider.CreateWopiChildResource<IWopiFolder>(null, "subfolder");
+
+        Assert.NotNull(folder);
+        Assert.Equal("subfolder", folder.Name);
+
+        var folders = new List<IWopiFolder>();
+        await foreach (var f in provider.GetWopiContainers(provider.RootContainerPointer.Identifier))
+        {
+            folders.Add(f);
+        }
+        Assert.Contains(folders, f => f.Name == "subfolder");
+    }
+
+    [Fact]
+    public async Task GetWopiFiles_HidesFolderMarker()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var folder = await provider.CreateWopiChildResource<IWopiFolder>(null, "with-marker");
+
+        var files = new List<IWopiFile>();
+        await foreach (var f in provider.GetWopiFiles(folder!.Identifier))
+        {
+            files.Add(f);
+        }
+        Assert.Empty(files);
+    }
+
+    [Fact]
+    public async Task DeleteWopiResource_File_RemovesBlob_AndDropsId()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var created = (await provider.CreateWopiChildResource<IWopiFile>(null, "doomed.txt"))!;
+
+        var deleted = await provider.DeleteWopiResource<IWopiFile>(created.Identifier);
+
+        Assert.True(deleted);
+        Assert.Null(await provider.GetWopiResource<IWopiFile>(created.Identifier));
+    }
+
+    [Fact]
+    public async Task DeleteWopiResource_Folder_NonEmpty_Throws()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(null, "with-content"))!;
+        _ = await provider.CreateWopiChildResource<IWopiFile>(folder.Identifier, "child.txt");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => provider.DeleteWopiResource<IWopiFolder>(folder.Identifier));
+    }
+
+    [Fact]
+    public async Task DeleteWopiResource_Folder_Empty_Succeeds()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(null, "ephemeral"))!;
+
+        var deleted = await provider.DeleteWopiResource<IWopiFolder>(folder.Identifier);
+
+        Assert.True(deleted);
+    }
+
+    [Fact]
+    public async Task RenameWopiResource_File_PreservesIdentifier()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var created = (await provider.CreateWopiChildResource<IWopiFile>(null, "before.txt"))!;
+        var originalId = created.Identifier;
+
+        var renamed = await provider.RenameWopiResource<IWopiFile>(originalId, "after.txt");
+
+        Assert.True(renamed);
+        var fetched = await provider.GetWopiResource<IWopiFile>(originalId);
+        Assert.NotNull(fetched);
+        Assert.Equal("after", fetched.Name);
+    }
+
+    [Fact]
+    public async Task RenameWopiResource_File_TargetExists_Throws()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var src = (await provider.CreateWopiChildResource<IWopiFile>(null, "source.txt"))!;
+        _ = await provider.CreateWopiChildResource<IWopiFile>(null, "target.txt");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => provider.RenameWopiResource<IWopiFile>(src.Identifier, "target.txt"));
+    }
+
+    [Fact]
+    public async Task GetSuggestedName_File_ReturnsCounterSuffix_WhenNameExists()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        _ = await provider.CreateWopiChildResource<IWopiFile>(null, "report.docx");
+
+        var suggested = await provider.GetSuggestedName<IWopiFile>(
+            provider.RootContainerPointer.Identifier, "report.docx");
+
+        Assert.Equal("report (1).docx", suggested);
+    }
+
+    [Fact]
+    public async Task GetSuggestedName_File_ReturnsName_WhenNameAvailable()
+    {
+        var (provider, _) = await CreateProviderAsync();
+
+        var suggested = await provider.GetSuggestedName<IWopiFile>(
+            provider.RootContainerPointer.Identifier, "fresh.docx");
+
+        Assert.Equal("fresh.docx", suggested);
+    }
+
+    [Theory]
+    [InlineData("a/b")]
+    [InlineData("a\\b")]
+    [InlineData("")]
+    [InlineData(".wopi.folder")]
+    [InlineData("..")]
+    public async Task CheckValidName_RejectsIllegalNames(string name)
+    {
+        var (provider, _) = await CreateProviderAsync();
+
+        Assert.False(await provider.CheckValidName<IWopiFile>(name));
+    }
+
+    [Fact]
+    public async Task CheckValidName_AcceptsTypicalName()
+    {
+        var (provider, _) = await CreateProviderAsync();
+
+        Assert.True(await provider.CheckValidName<IWopiFile>("my-file_2.docx"));
+    }
+
+    [Fact]
+    public async Task GetAncestors_File_IncludesParentChain()
+    {
+        var (provider, _) = await CreateProviderAsync();
+        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(null, "outer"))!;
+        var inner = (await provider.CreateWopiChildResource<IWopiFolder>(folder.Identifier, "inner"))!;
+        var file = (await provider.CreateWopiChildResource<IWopiFile>(inner.Identifier, "deep.txt"))!;
+
+        var ancestors = await provider.GetAncestors<IWopiFile>(file.Identifier);
+
+        // Expected: [root, outer, inner]
+        Assert.Equal(3, ancestors.Count);
+        Assert.Equal(provider.RootContainerPointer.Identifier, ancestors[0].Identifier);
+        Assert.Equal("outer", ancestors[1].Name);
+        Assert.Equal("inner", ancestors[2].Name);
+    }
+}

--- a/test/WopiHost.AzureStorageProvider.Tests/WopiBlobFileTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/WopiBlobFileTests.cs
@@ -1,0 +1,193 @@
+using Azure.Storage.Blobs;
+using Xunit;
+
+namespace WopiHost.AzureStorageProvider.Tests;
+
+[Collection(AzuriteCollection.Name)]
+public class WopiBlobFileTests(AzuriteFixture azurite)
+{
+    private async Task<BlobContainerClient> CreateContainerAsync()
+    {
+        var serviceClient = azurite.CreateBlobServiceClient();
+        var container = serviceClient.GetBlobContainerClient($"blobfile-{Guid.NewGuid():N}");
+        await container.CreateIfNotExistsAsync();
+        return container;
+    }
+
+    [Fact]
+    public async Task CreateAsync_NonExistentBlob_ReturnsInstance_WithExistsFalse()
+    {
+        var container = await CreateContainerAsync();
+        var blob = container.GetBlobClient("ghost.txt");
+
+        var file = await WopiBlobFile.CreateAsync(blob, "ghost.txt", "fake-id", CancellationToken.None);
+
+        Assert.False(file.Exists);
+        Assert.Equal(0, file.Length);
+        Assert.Equal(0, file.Size);
+        Assert.Equal(DateTime.MinValue, file.LastWriteTimeUtc);
+        Assert.Null(file.Version);
+        Assert.Equal(string.Empty, file.Owner);
+        Assert.Null(file.Checksum);
+    }
+
+    [Fact]
+    public async Task ExistingBlob_NoMetadata_OwnerIsEmpty_ChecksumIsNull()
+    {
+        var container = await CreateContainerAsync();
+        var blob = container.GetBlobClient("plain.txt");
+        using (var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes("body")))
+        {
+            await blob.UploadAsync(stream, overwrite: true);
+        }
+
+        var file = await WopiBlobFile.CreateAsync(blob, "plain.txt", "id", CancellationToken.None);
+
+        Assert.True(file.Exists);
+        Assert.Equal(string.Empty, file.Owner);
+        Assert.Null(file.Checksum);
+        Assert.Equal(4, file.Length);
+        Assert.NotNull(file.Version);
+    }
+
+    [Fact]
+    public async Task ExistingBlob_WithOwnerMetadata_OwnerIsReturned()
+    {
+        var container = await CreateContainerAsync();
+        var blob = container.GetBlobClient("with-owner.txt");
+        using (var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes("body")))
+        {
+            await blob.UploadAsync(stream, overwrite: true);
+        }
+        await blob.SetMetadataAsync(new Dictionary<string, string> { [WopiBlobFile.OwnerMetadataKey] = "alice" });
+
+        var file = await WopiBlobFile.CreateAsync(blob, "with-owner.txt", "id", CancellationToken.None);
+
+        Assert.Equal("alice", file.Owner);
+    }
+
+    [Fact]
+    public async Task ExistingBlob_WithSha256Metadata_ChecksumIsDecoded()
+    {
+        var container = await CreateContainerAsync();
+        var blob = container.GetBlobClient("with-hash.bin");
+        using (var stream = new MemoryStream(new byte[] { 0xAB, 0xCD }))
+        {
+            await blob.UploadAsync(stream, overwrite: true);
+        }
+        const string hex = "deadbeefcafebabe";
+        await blob.SetMetadataAsync(new Dictionary<string, string> { [WopiBlobFile.Sha256MetadataKey] = hex });
+
+        var file = await WopiBlobFile.CreateAsync(blob, "with-hash.bin", "id", CancellationToken.None);
+
+        Assert.NotNull(file.Checksum);
+        Assert.Equal(Convert.FromHexString(hex), file.Checksum);
+    }
+
+    [Fact]
+    public async Task ExistingBlob_WithEmptySha256Metadata_ChecksumIsNull()
+    {
+        // Empty hash string should fall through the !string.IsNullOrEmpty check.
+        var container = await CreateContainerAsync();
+        var blob = container.GetBlobClient("empty-hash.bin");
+        using (var stream = new MemoryStream(new byte[] { 0x01 }))
+        {
+            await blob.UploadAsync(stream, overwrite: true);
+        }
+        await blob.SetMetadataAsync(new Dictionary<string, string> { [WopiBlobFile.Sha256MetadataKey] = "" });
+
+        var file = await WopiBlobFile.CreateAsync(blob, "empty-hash.bin", "id", CancellationToken.None);
+
+        Assert.Null(file.Checksum);
+    }
+
+    [Fact]
+    public async Task NameWithoutExtension_ReturnsWholeNameAsName_AndEmptyExtension()
+    {
+        var container = await CreateContainerAsync();
+        var blob = container.GetBlobClient("readme");
+        using (var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes("x")))
+        {
+            await blob.UploadAsync(stream, overwrite: true);
+        }
+
+        var file = await WopiBlobFile.CreateAsync(blob, "readme", "id", CancellationToken.None);
+
+        Assert.Equal("readme", file.Name);
+        Assert.Equal(string.Empty, file.Extension);
+    }
+
+    [Fact]
+    public async Task NestedPath_NameAndExtension_AreParsedFromLastSegment()
+    {
+        var container = await CreateContainerAsync();
+        var blob = container.GetBlobClient("a/b/c/file.docx");
+        using (var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes("x")))
+        {
+            await blob.UploadAsync(stream, overwrite: true);
+        }
+
+        var file = await WopiBlobFile.CreateAsync(blob, "a/b/c/file.docx", "id", CancellationToken.None);
+
+        Assert.Equal("file", file.Name);
+        Assert.Equal("docx", file.Extension);
+        Assert.Equal("a/b/c/file.docx", file.BlobPath);
+    }
+
+    [Fact]
+    public async Task GetReadStream_ReturnsContent()
+    {
+        var container = await CreateContainerAsync();
+        var blob = container.GetBlobClient("read.txt");
+        const string body = "read-me";
+        using (var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(body)))
+        {
+            await blob.UploadAsync(stream, overwrite: true);
+        }
+        var file = await WopiBlobFile.CreateAsync(blob, "read.txt", "id", CancellationToken.None);
+
+        await using var s = await file.GetReadStream();
+        using var reader = new StreamReader(s);
+        Assert.Equal(body, await reader.ReadToEndAsync());
+    }
+
+    [Fact]
+    public async Task GetWriteStream_NoExistingMetadata_StillPersistsHash()
+    {
+        // GetWriteStream when properties.Metadata is empty exercises the fallback
+        // `new Dictionary<string, string>(StringComparer.Ordinal)` branch.
+        var container = await CreateContainerAsync();
+        var blob = container.GetBlobClient("nometa.bin");
+        using (var stream = new MemoryStream(Array.Empty<byte>()))
+        {
+            await blob.UploadAsync(stream, overwrite: true);
+        }
+        var file = await WopiBlobFile.CreateAsync(blob, "nometa.bin", "id", CancellationToken.None);
+
+        await using (var s = await file.GetWriteStream())
+        {
+            await s.WriteAsync(new byte[] { 1, 2, 3 });
+        }
+
+        var props = await blob.GetPropertiesAsync();
+        Assert.True(props.Value.Metadata.ContainsKey(WopiBlobFile.Sha256MetadataKey));
+    }
+
+    [Fact]
+    public async Task GetWriteStream_OnNonExistentBlob_StillProducesUploadableStream()
+    {
+        // properties is null when the blob doesn't exist; the preserved-metadata branch falls back
+        // to a fresh dictionary and OpenWriteAsync(overwrite:true) will create the blob.
+        var container = await CreateContainerAsync();
+        var blob = container.GetBlobClient("freshly-created.bin");
+        var file = await WopiBlobFile.CreateAsync(blob, "freshly-created.bin", "id", CancellationToken.None);
+        Assert.False(file.Exists);
+
+        await using (var s = await file.GetWriteStream())
+        {
+            await s.WriteAsync(new byte[] { 9, 8, 7 });
+        }
+
+        Assert.True(await blob.ExistsAsync());
+    }
+}

--- a/test/WopiHost.AzureStorageProvider.Tests/WopiHost.AzureStorageProvider.Tests.csproj
+++ b/test/WopiHost.AzureStorageProvider.Tests/WopiHost.AzureStorageProvider.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+	</PropertyGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\WopiHost.AzureStorageProvider\WopiHost.AzureStorageProvider.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Testcontainers.Azurite" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+	</ItemGroup>
+	<ItemGroup>
+	  <PackageReference Update="coverlet.collector">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
+	  <PackageReference Update="coverlet.msbuild">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
+	  <PackageReference Update="xunit.runner.console">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
+	  <PackageReference Update="xunit.runner.visualstudio">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
+	</ItemGroup>
+</Project>

--- a/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
@@ -300,8 +300,8 @@ public class ContainersControllerTests
             .ReturnsAsync(existingFile);
         writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
-        lockProviderMock.Setup(lp => lp.TryGetLock(It.IsAny<string>(), out lockInfo))
-            .Returns(true);
+        lockProviderMock.Setup(lp => lp.GetLockAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(lockInfo);
 
         var result = await _controller.CreateChildFile("containerId", relativeTarget: UtfString.FromDecoded("relativeTarget"), overwriteRelativeTarget: true);
 

--- a/test/WopiHost.Core.Tests/Controllers/FilesControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/FilesControllerTests.cs
@@ -1292,6 +1292,25 @@ public class FilesControllerTests
     }
 
     [Fact]
+    public async Task ProcessLock_Put_MatchingOldLock_EmptyNewLockId_ReturnsLockMismatch()
+    {
+        var fileId = "test-file-id";
+        var oldLockId = "old-lock-id";
+        SetupFileMock(fileId);
+        var lockInfo = new WopiLockInfo { LockId = oldLockId, FileId = fileId };
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
+
+        var result = await controller.ProcessLock(
+            fileId,
+            WopiFileOperations.Put,
+            oldLockIdentifier: oldLockId,
+            newLockIdentifier: null);
+
+        var lockMismatch = Assert.IsType<LockMismatchResult>(result);
+        Assert.Equal("Missing new lock identifier", lockMismatch.Reason);
+    }
+
+    [Fact]
     public async Task ProcessLock_Put_MatchingOldLock_Success_ReturnsOk()
     {
         var fileId = "test-file-id";

--- a/test/WopiHost.Core.Tests/Controllers/FilesControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/FilesControllerTests.cs
@@ -489,7 +489,7 @@ public class FilesControllerTests
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => fileMock.Object);
         var wopiLockInfo = new WopiLockInfo() { LockId = "lockId", FileId = fileId };
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out wopiLockInfo)).Returns(true);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(wopiLockInfo);
 
         var result = await controller.DeleteFile(fileId);
 
@@ -504,8 +504,7 @@ public class FilesControllerTests
         storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        WopiLockInfo? noLock = null;
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out noLock)).Returns(false);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
         writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
@@ -526,8 +525,7 @@ public class FilesControllerTests
         storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        WopiLockInfo? noLock = null;
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out noLock)).Returns(false);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
         writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
@@ -578,7 +576,7 @@ public class FilesControllerTests
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
         var existingLock = new WopiLockInfo { LockId = "differentLockId", FileId = fileId };
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out existingLock)).Returns(true);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(existingLock);
 
         var result = await controller.RenameFile(fileId, UtfString.FromDecoded("newName"), lockIdentifier: "myLockId");
 
@@ -593,8 +591,7 @@ public class FilesControllerTests
         storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        WopiLockInfo? noLock = null;
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out noLock)).Returns(false);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
         writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
@@ -613,8 +610,7 @@ public class FilesControllerTests
         storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        WopiLockInfo? noLock = null;
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out noLock)).Returns(false);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
         writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
@@ -639,8 +635,7 @@ public class FilesControllerTests
         storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        WopiLockInfo? noLock = null;
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out noLock)).Returns(false);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
         writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
@@ -664,8 +659,7 @@ public class FilesControllerTests
         storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        WopiLockInfo? noLock = null;
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out noLock)).Returns(false);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
         writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
@@ -687,8 +681,7 @@ public class FilesControllerTests
         storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        WopiLockInfo? noLock = null;
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out noLock)).Returns(false);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
         writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
@@ -709,8 +702,7 @@ public class FilesControllerTests
         storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        WopiLockInfo? noLock = null;
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out noLock)).Returns(false);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
         writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
@@ -731,8 +723,7 @@ public class FilesControllerTests
         storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        WopiLockInfo? noLock = null;
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out noLock)).Returns(false);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
         writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
@@ -826,11 +817,10 @@ public class FilesControllerTests
         storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        WopiLockInfo? noLock = null;
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out noLock)).Returns(false);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
         lockProviderMock
-            .Setup(x => x.AddLock(fileId, lockId))
-            .Returns(new WopiLockInfo { LockId = lockId, FileId = fileId });
+            .Setup(x => x.AddLockAsync(fileId, lockId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WopiLockInfo { LockId = lockId, FileId = fileId });
 
         controller.ControllerContext = new ControllerContext
         {
@@ -854,7 +844,7 @@ public class FilesControllerTests
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
         var existingLock = new WopiLockInfo { LockId = "other-lock", FileId = fileId };
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out existingLock)).Returns(true);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(existingLock);
 
         controller.ControllerContext = new ControllerContext
         {
@@ -1008,8 +998,8 @@ public class FilesControllerTests
             .Setup(w => w.CheckValidName<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
         lockProviderMock
-            .Setup(x => x.TryGetLock("existingFileId", out lockInfo))
-            .Returns(true);
+            .Setup(x => x.GetLockAsync("existingFileId", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(lockInfo);
 
         var result = await controller.PutRelativeFile(
             fileId,
@@ -1174,7 +1164,7 @@ public class FilesControllerTests
 
         var wopiOverrideHeader = WopiFileOperations.GetLock;
         var lockInfo = new WopiLockInfo { LockId = "existing-lock-id", FileId = fileId };
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out lockInfo)).Returns(true);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
 
         var result = await controller.ProcessLock(fileId, wopiOverrideHeader);
 
@@ -1183,30 +1173,13 @@ public class FilesControllerTests
     }
 
     [Fact]
-    public async Task ProcessLock_GetLock_NoLockInfo_ReturnsLockMismatchResult()
+    public async Task ProcessLock_GetLock_NoExistingLock_ReturnsOkWithEmptyLockHeader()
     {
         var fileId = "test-file-id";
         SetupFileMock(fileId);
 
         var wopiOverrideHeader = WopiFileOperations.GetLock;
-        WopiLockInfo? lockInfo = null;
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out lockInfo)).Returns(true);
-
-        var result = await controller.ProcessLock(fileId, wopiOverrideHeader);
-
-        var lockMismatchResult = Assert.IsType<LockMismatchResult>(result);
-        Assert.Equal("Missing existing lock", lockMismatchResult.Reason);
-    }
-
-    [Fact]
-    public async Task ProcessLock_GetLock_Expired_ReturnsOkResultWithLockHeader()
-    {
-        var fileId = "test-file-id";
-        SetupFileMock(fileId);
-
-        var wopiOverrideHeader = WopiFileOperations.GetLock;
-        var lockInfo = new WopiLockInfo { LockId = "existing-lock-id", FileId = fileId, DateCreated = DateTimeOffset.MinValue };
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out lockInfo)).Returns(false);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
 
         var result = await controller.ProcessLock(fileId, wopiOverrideHeader);
 
@@ -1222,8 +1195,8 @@ public class FilesControllerTests
 
         var wopiOverrideHeader = WopiFileOperations.Lock;
         var newLockIdentifier = "new-lock-id";
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out It.Ref<WopiLockInfo?>.IsAny)).Returns(false);
-        lockProviderMock.Setup(x => x.AddLock(fileId, newLockIdentifier)).Returns(new WopiLockInfo { LockId = newLockIdentifier, FileId = fileId });
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        lockProviderMock.Setup(x => x.AddLockAsync(fileId, newLockIdentifier, It.IsAny<CancellationToken>())).ReturnsAsync(new WopiLockInfo { LockId = newLockIdentifier, FileId = fileId });
 
         var result = await controller.ProcessLock(fileId, wopiOverrideHeader, newLockIdentifier: newLockIdentifier);
 
@@ -1239,8 +1212,8 @@ public class FilesControllerTests
         var wopiOverrideHeader = WopiFileOperations.Unlock;
         var newLockIdentifier = "existing-lock-id";
         var lockInfo = new WopiLockInfo { LockId = newLockIdentifier, FileId = fileId };
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out lockInfo)).Returns(true);
-        lockProviderMock.Setup(x => x.RemoveLock(fileId)).Returns(true);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
+        lockProviderMock.Setup(x => x.RemoveLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
         var result = await controller.ProcessLock(fileId, wopiOverrideHeader, newLockIdentifier: newLockIdentifier);
 
@@ -1256,8 +1229,8 @@ public class FilesControllerTests
         var wopiOverrideHeader = WopiFileOperations.RefreshLock;
         var newLockIdentifier = "existing-lock-id";
         var lockInfo = new WopiLockInfo { LockId = newLockIdentifier, FileId = fileId };
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out lockInfo)).Returns(true);
-        lockProviderMock.Setup(x => x.RefreshLock(fileId, null)).Returns(true);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
+        lockProviderMock.Setup(x => x.RefreshLockAsync(fileId, null, It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
         var result = await controller.ProcessLock(fileId, wopiOverrideHeader, newLockIdentifier: newLockIdentifier);
 
@@ -1269,8 +1242,7 @@ public class FilesControllerTests
     {
         var fileId = "test-file-id";
         SetupFileMock(fileId);
-        WopiLockInfo? noLock = null;
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out noLock)).Returns(false);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
 
         var result = await controller.ProcessLock(fileId, WopiFileOperations.Lock, newLockIdentifier: null);
 
@@ -1285,8 +1257,8 @@ public class FilesControllerTests
         var lockId = "same-lock-id";
         SetupFileMock(fileId);
         var lockInfo = new WopiLockInfo { LockId = lockId, FileId = fileId };
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out lockInfo)).Returns(true);
-        lockProviderMock.Setup(x => x.RefreshLock(fileId, It.IsAny<string?>())).Returns(true);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
+        lockProviderMock.Setup(x => x.RefreshLockAsync(fileId, It.IsAny<string?>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
         var result = await controller.ProcessLock(fileId, WopiFileOperations.Lock, newLockIdentifier: lockId);
 
@@ -1299,7 +1271,7 @@ public class FilesControllerTests
         var fileId = "test-file-id";
         SetupFileMock(fileId);
         var lockInfo = new WopiLockInfo { LockId = "existing-lock", FileId = fileId };
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out lockInfo)).Returns(true);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
 
         var result = await controller.ProcessLock(fileId, WopiFileOperations.Lock, newLockIdentifier: "different-lock");
 
@@ -1311,9 +1283,8 @@ public class FilesControllerTests
     {
         var fileId = "test-file-id";
         SetupFileMock(fileId);
-        WopiLockInfo? noLock = null;
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out noLock)).Returns(false);
-        lockProviderMock.Setup(x => x.AddLock(fileId, It.IsAny<string>())).Returns((WopiLockInfo?)null);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        lockProviderMock.Setup(x => x.AddLockAsync(fileId, It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
 
         var result = await controller.ProcessLock(fileId, WopiFileOperations.Lock, newLockIdentifier: "new-lock");
 
@@ -1328,8 +1299,8 @@ public class FilesControllerTests
         var newLockId = "new-lock-id";
         SetupFileMock(fileId);
         var lockInfo = new WopiLockInfo { LockId = oldLockId, FileId = fileId };
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out lockInfo)).Returns(true);
-        lockProviderMock.Setup(x => x.RefreshLock(fileId, newLockId)).Returns(true);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
+        lockProviderMock.Setup(x => x.RefreshLockAsync(fileId, newLockId, It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
         var result = await controller.ProcessLock(
             fileId,
@@ -1346,7 +1317,7 @@ public class FilesControllerTests
         var fileId = "test-file-id";
         SetupFileMock(fileId);
         var lockInfo = new WopiLockInfo { LockId = "actual-lock", FileId = fileId };
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out lockInfo)).Returns(true);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
 
         var result = await controller.ProcessLock(
             fileId,
@@ -1362,8 +1333,7 @@ public class FilesControllerTests
     {
         var fileId = "test-file-id";
         SetupFileMock(fileId);
-        WopiLockInfo? noLock = null;
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out noLock)).Returns(false);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
 
         var result = await controller.ProcessLock(
             fileId,
@@ -1381,7 +1351,7 @@ public class FilesControllerTests
         var fileId = "test-file-id";
         SetupFileMock(fileId);
         var lockInfo = new WopiLockInfo { LockId = "actual-lock", FileId = fileId };
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out lockInfo)).Returns(true);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
 
         var result = await controller.ProcessLock(
             fileId,
@@ -1396,8 +1366,7 @@ public class FilesControllerTests
     {
         var fileId = "test-file-id";
         SetupFileMock(fileId);
-        WopiLockInfo? noLock = null;
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out noLock)).Returns(false);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
 
         var result = await controller.ProcessLock(
             fileId,
@@ -1415,8 +1384,8 @@ public class FilesControllerTests
         var lockId = "lock-id";
         SetupFileMock(fileId);
         var lockInfo = new WopiLockInfo { LockId = lockId, FileId = fileId };
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out lockInfo)).Returns(true);
-        lockProviderMock.Setup(x => x.RemoveLock(fileId)).Returns(false);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
+        lockProviderMock.Setup(x => x.RemoveLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(false);
 
         var result = await controller.ProcessLock(
             fileId,
@@ -1431,8 +1400,7 @@ public class FilesControllerTests
     {
         var fileId = "test-file-id";
         SetupFileMock(fileId);
-        WopiLockInfo? noLock = null;
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out noLock)).Returns(false);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
 
         var result = await controller.ProcessLock(
             fileId,
@@ -1450,7 +1418,7 @@ public class FilesControllerTests
         var lockId = "lock-id";
         SetupFileMock(fileId);
         var lockInfo = new WopiLockInfo { LockId = lockId, FileId = fileId };
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out lockInfo)).Returns(true);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
 
         var result = await controller.ProcessLock(
             fileId,
@@ -1467,7 +1435,7 @@ public class FilesControllerTests
         var fileId = "test-file-id";
         SetupFileMock(fileId);
         var lockInfo = new WopiLockInfo { LockId = "actual-lock", FileId = fileId };
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out lockInfo)).Returns(true);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
 
         var result = await controller.ProcessLock(
             fileId,
@@ -1484,8 +1452,8 @@ public class FilesControllerTests
         var lockId = "lock-id";
         SetupFileMock(fileId);
         var lockInfo = new WopiLockInfo { LockId = lockId, FileId = fileId };
-        lockProviderMock.Setup(x => x.TryGetLock(fileId, out lockInfo)).Returns(true);
-        lockProviderMock.Setup(x => x.RefreshLock(fileId, It.IsAny<string?>())).Returns(false);
+        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
+        lockProviderMock.Setup(x => x.RefreshLockAsync(fileId, It.IsAny<string?>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
 
         var result = await controller.ProcessLock(
             fileId,

--- a/test/WopiHost.MemoryLockProvider.Tests/MemoryLockProviderTests.cs
+++ b/test/WopiHost.MemoryLockProvider.Tests/MemoryLockProviderTests.cs
@@ -15,12 +15,12 @@ public class MemoryLockProviderTests
     }
 
     [Fact]
-    public void AddLock_ShouldAddLock()
+    public async Task AddLock_ShouldAddLock()
     {
-        var fileId = "file1";
+        var fileId = $"add-{Guid.NewGuid()}";
         var lockId = "lock1";
 
-        var lockInfo = _lockProvider.AddLock(fileId, lockId);
+        var lockInfo = await _lockProvider.AddLockAsync(fileId, lockId);
 
         Assert.NotNull(lockInfo);
         Assert.Equal(fileId, lockInfo.FileId);
@@ -28,85 +28,82 @@ public class MemoryLockProviderTests
     }
 
     [Fact]
-    public void TryGetLock_ShouldReturnTrue_WhenLockExists()
+    public async Task GetLockAsync_ShouldReturnLock_WhenLockExists()
     {
-        var fileId = "file2";
+        var fileId = $"get-{Guid.NewGuid()}";
         var lockId = "lock2";
-        _lockProvider.AddLock(fileId, lockId);
+        await _lockProvider.AddLockAsync(fileId, lockId);
 
-        var result = _lockProvider.TryGetLock(fileId, out var lockInfo);
+        var lockInfo = await _lockProvider.GetLockAsync(fileId);
 
-        Assert.True(result);
         Assert.NotNull(lockInfo);
         Assert.Equal(fileId, lockInfo.FileId);
         Assert.Equal(lockId, lockInfo.LockId);
     }
 
     [Fact]
-    public void TryGetLock_ShouldReturnFalse_WhenLockDoesNotExist()
+    public async Task GetLockAsync_ShouldReturnNull_WhenLockDoesNotExist()
     {
-        var result = _lockProvider.TryGetLock("nonexistentFile", out var lockInfo);
+        var lockInfo = await _lockProvider.GetLockAsync($"missing-{Guid.NewGuid()}");
 
-        Assert.False(result);
         Assert.Null(lockInfo);
     }
 
     [Fact]
-    public void RefreshLock_ShouldUpdateLock()
+    public async Task RefreshLock_ShouldUpdateLock()
     {
-        var fileId = "file3";
+        var fileId = $"refresh-{Guid.NewGuid()}";
         var lockId = "lock3";
-        _lockProvider.AddLock(fileId, lockId);
+        await _lockProvider.AddLockAsync(fileId, lockId);
 
-        var result = _lockProvider.RefreshLock(fileId);
+        var result = await _lockProvider.RefreshLockAsync(fileId);
 
         Assert.True(result);
-        _lockProvider.TryGetLock(fileId, out var lockInfo);
+        var lockInfo = await _lockProvider.GetLockAsync(fileId);
         Assert.NotNull(lockInfo);
         Assert.Equal(fileId, lockInfo.FileId);
         Assert.Equal(lockId, lockInfo.LockId);
     }
 
     [Fact]
-    public void RemoveLock_ShouldRemoveLock()
+    public async Task RemoveLock_ShouldRemoveLock()
     {
-        var fileId = "file4";
+        var fileId = $"remove-{Guid.NewGuid()}";
         var lockId = "lock4";
-        _lockProvider.AddLock(fileId, lockId);
+        await _lockProvider.AddLockAsync(fileId, lockId);
 
-        var result = _lockProvider.RemoveLock(fileId);
+        var result = await _lockProvider.RemoveLockAsync(fileId);
 
         Assert.True(result);
-        var lockExists = _lockProvider.TryGetLock(fileId, out var lockInfo);
-        Assert.False(lockExists);
+        var lockInfo = await _lockProvider.GetLockAsync(fileId);
         Assert.Null(lockInfo);
     }
 
     [Fact]
-    public void AddLock_DuplicateFileId_ReturnsNull()
+    public async Task AddLock_DuplicateFileId_ReturnsNull()
     {
         var fileId = $"dup-{Guid.NewGuid()}";
-        _lockProvider.AddLock(fileId, "first");
+        await _lockProvider.AddLockAsync(fileId, "first");
 
-        var second = _lockProvider.AddLock(fileId, "second");
+        var second = await _lockProvider.AddLockAsync(fileId, "second");
 
         Assert.Null(second);
     }
 
     [Fact]
-    public void RefreshLock_NoExistingLock_ReturnsFalse()
+    public async Task RefreshLock_NoExistingLock_ReturnsFalse()
     {
         var fileId = $"missing-{Guid.NewGuid()}";
 
-        var result = _lockProvider.RefreshLock(fileId);
+        var result = await _lockProvider.RefreshLockAsync(fileId);
 
         Assert.False(result);
     }
 
     [Fact]
-    public void TryGetLock_ExpiredLock_RemovesAndReturnsFalse()
+    public async Task GetLockAsync_ExpiredLock_RemovesAndReturnsNull()
     {
-        // The provider's AddLock always stamps DateCreated with UtcNow, so the
+        // The provider's AddLockAsync always stamps DateCreated with UtcNow, so the
         // only way to seed an expired entry is to inject one directly into the
         // private static dictionary backing the provider.
         var fileId = $"expired-{Guid.NewGuid()}";
@@ -118,9 +115,9 @@ public class MemoryLockProviderTests
             DateCreated = DateTimeOffset.UtcNow.AddHours(-1),
         };
 
-        var found = _lockProvider.TryGetLock(fileId, out _);
+        var found = await _lockProvider.GetLockAsync(fileId);
 
-        Assert.False(found);
+        Assert.Null(found);
         Assert.False(locks.ContainsKey(fileId));
     }
 


### PR DESCRIPTION
## Summary

Closes #26.

- Adds **WopiHost.AzureStorageProvider** (`IWopiStorageProvider` + `IWopiWritableStorageProvider`) over plain Azure Blob Storage. Files map to blobs, folders are virtual `/`-delimited prefixes with a hidden zero-byte `.wopi.folder` marker for empty folders, identifiers are hex-MD5 of the lowercased blob path (matches `WopiHost.FileSystemProvider`'s scheme), `Version` is the blob ETag, SHA-256 is computed streaming on upload and stored as `wopi_sha256` metadata.
- Adds **WopiHost.AzureLockProvider** (`IWopiLockProvider`) using **blob leases + metadata** for true cross-instance exclusion. Per-`fileId` placeholder blob holds an infinite Azure lease; metadata carries the WOPI lock id, lease GUID, and a creation timestamp so any host can renew/release across instances. Crash recovery via the WOPI 30-min auto-expiry — no background sweeper needed.
- **Makes `IWopiLockProvider` async** (the friction point exposed by writing a real out-of-process provider). The sync interface forced sync-over-async on every external store; converted to `Task<WopiLockInfo?>` / `Task<bool>` with `CancellationToken`. `MemoryLockProvider` becomes a one-line `Task.FromResult` wrapper. **Breaking change** — `PackageValidationBaselineVersion` bumped 5.0 → 6.0.
- Both providers support connection-string (Azurite/dev) and `TokenCredential` (managed identity / service principal) auth via the same options-binding pattern.
- Aspire AppHost gets an opt-in Azurite resource gated on `AppHost:UseAzureStorage=true` so newcomers cloning the repo still get the FS+Memory sample out of the box (no Docker / Azure required).

## Why plain Blob, not ADLS Gen2

Originally wanted ADLS Gen2 for atomic rename and POSIX owner. Discovered [Azure/Azurite#553](https://github.com/Azure/Azurite/issues/553) is still open after 5+ years — Azurite has no HNS support. ADLS Gen2 would have left half the surface uncoverable in CI, undermining the "battle-test the abstractions" framing of issue #26. As a bonus, plain Blob's _weaknesses_ (virtual folders, non-atomic prefix rename, no native SHA-256) actually exposed more interesting friction in the abstractions than ADLS Gen2 ever would have.

## Test plan

- [x] `dotnet build WOPI.slnx` — clean
- [x] AzureStorageProvider tests — 22 × 3 frameworks (net8 / net9 / net10), all green against Azurite via Testcontainers
- [x] AzureLockProvider tests — 11 × 3 frameworks, all green
- [x] MemoryLockProvider tests — 8 × 3 frameworks (rewritten async)
- [x] Core controller tests — 312 × 2 frameworks (lock-related Moq setups rewritten async)
- [x] FileSystemProvider, Discovery, Url, Integration — all unchanged surface, all green
- [x] Sample app default config (`sample/WopiHost/appsettings.json`) still uses FS + MemoryLockProvider — verified Azure isn't default anywhere
- [x] AppHost without `AppHost:UseAzureStorage` set — runs with no Azurite resource, same as before
- [ ] (Manual) Real Azure Storage account smoke test — left to you / a follow-up issue

## Caveats worth knowing

- **Folder rename / delete-folder are O(N)** over the children — plain Blob has no atomic prefix rename. ADLS Gen2 would fix this once Azurite supports HNS.
- **Every WOPI lock op is one or two round-trips** to Azure Blob; measure under high-volume editing.
- The Testcontainers `Testcontainers.Azurite` 4.7 ships an outdated Azurite image (3.28.0) and the SDK default API (`2026-02-06`) is too new for it. Tests pin both `mcr.microsoft.com/azure-storage/azurite:3.35.0` and `BlobClientOptions.ServiceVersion.V2025_11_05`. Both pins are scoped to the test fixtures only; production code uses SDK defaults.

## Files

```
src/WopiHost.AzureStorageProvider/   IWopiStorageProvider + IWopiWritableStorageProvider over Azure Blob
src/WopiHost.AzureLockProvider/      IWopiLockProvider over Azure Blob leases
test/WopiHost.AzureStorageProvider.Tests/   22 tests vs Azurite
test/WopiHost.AzureLockProvider.Tests/      11 tests vs Azurite
```

Plus 19 modifications: async lock provider migration across `IWopiLockProvider`, `MemoryLockProvider`, controllers + their tests; `WopiConfigurationSections.LOCK_OPTIONS` added; Aspire wiring; sample dispatch helpers; READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)