### PR TITLE
refactor: address qlty code-smell findings (selective)

### DIFF
--- a/src/WopiHost.AzureStorageProvider/WopiAzureStorageProvider.cs
+++ b/src/WopiHost.AzureStorageProvider/WopiAzureStorageProvider.cs
@@ -243,33 +243,16 @@ public class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWritableStora
     public Task<bool> CheckValidName<T>(string name, CancellationToken cancellationToken = default)
         where T : class, IWopiResource
     {
-        if (string.IsNullOrWhiteSpace(name))
-        {
-            return Task.FromResult(false);
-        }
-        if (name.Length > FileNameMaxLength)
-        {
-            return Task.FromResult(false);
-        }
-        // Single segment — no slashes, no path nav.
-        if (name.Contains('/') || name.Contains('\\') || name == "." || name == "..")
-        {
-            return Task.FromResult(false);
-        }
-        // Azure blob naming spec disallows control characters.
-        foreach (var ch in name)
-        {
-            if (char.IsControl(ch))
-            {
-                return Task.FromResult(false);
-            }
-        }
-        // Folder-marker is reserved.
-        if (name == BlobIdMap.FolderMarker)
-        {
-            return Task.FromResult(false);
-        }
-        return Task.FromResult(true);
+        var valid =
+            !string.IsNullOrWhiteSpace(name)
+            && name.Length <= FileNameMaxLength
+            // Single segment — no slashes, no path nav.
+            && !name.Contains('/') && !name.Contains('\\') && name != "." && name != ".."
+            // Folder-marker is reserved.
+            && name != BlobIdMap.FolderMarker
+            // Azure blob naming spec disallows control characters.
+            && !name.Any(char.IsControl);
+        return Task.FromResult(valid);
     }
 
     /// <inheritdoc/>

--- a/src/WopiHost.Core/Controllers/ContainersController.cs
+++ b/src/WopiHost.Core/Controllers/ContainersController.cs
@@ -207,14 +207,13 @@ public class ContainersController(
                 else
                 {
                     // a file matching the target name might be locked
-                    if (lockProvider is not null)
+                    var existingLock = lockProvider is null
+                        ? null
+                        : await lockProvider.GetLockAsync(newFile.Identifier, cancellationToken);
+                    if (existingLock is not null)
                     {
-                        var existingLock = await lockProvider.GetLockAsync(newFile.Identifier, cancellationToken);
-                        if (existingLock is not null)
-                        {
-                            // the host must respond with a 409 Conflict and include a X-WOPI-Lock response header
-                            return new LockMismatchResult(Response, existingLock.LockId, reason: "File already exists and is currently locked");
-                        }
+                        // the host must respond with a 409 Conflict and include a X-WOPI-Lock response header
+                        return new LockMismatchResult(Response, existingLock.LockId, reason: "File already exists and is currently locked");
                     }
                 }
             }

--- a/src/WopiHost.Core/Controllers/FilesController.cs
+++ b/src/WopiHost.Core/Controllers/FilesController.cs
@@ -420,14 +420,13 @@ public class FilesController(
                 else
                 {
                     // a file matching the target name might be locked
-                    if (lockProvider is not null)
+                    var existingLock = lockProvider is null
+                        ? null
+                        : await lockProvider.GetLockAsync(newFile.Identifier, cancellationToken);
+                    if (existingLock is not null)
                     {
-                        var existingLock = await lockProvider.GetLockAsync(newFile.Identifier, cancellationToken);
-                        if (existingLock is not null)
-                        {
-                            // the host must respond with a 409 Conflict and include a X-WOPI-Lock response header
-                            return new LockMismatchResult(Response, existingLock.LockId, reason: "File already exists and is currently locked");
-                        }
+                        // the host must respond with a 409 Conflict and include a X-WOPI-Lock response header
+                        return new LockMismatchResult(Response, existingLock.LockId, reason: "File already exists and is currently locked");
                     }
                 }
             }
@@ -637,10 +636,14 @@ public class FilesController(
         Response.Headers[WopiHeaders.ITEM_VERSION] = file.Version;
 
         var existingLock = await lockProvider.GetLockAsync(id, cancellationToken);
+        // The Lock override doubles as UnlockAndRelock when X-WOPI-OldLock is present, so dispatch
+        // by header presence rather than baking a third branch into the switch.
         return wopiOverrideHeader switch
         {
             WopiFileOperations.GetLock => HandleGetLock(existingLock),
-            WopiFileOperations.Lock or WopiFileOperations.Put => await HandleLockOrPut(id, oldLockIdentifier, newLockIdentifier, existingLock, cancellationToken),
+            WopiFileOperations.Lock or WopiFileOperations.Put => oldLockIdentifier is null
+                ? await HandleLock(id, newLockIdentifier, existingLock, cancellationToken)
+                : await HandleUnlockAndRelock(id, oldLockIdentifier, newLockIdentifier, existingLock, cancellationToken),
             WopiFileOperations.Unlock => await HandleUnlock(id, newLockIdentifier, existingLock, cancellationToken),
             WopiFileOperations.RefreshLock => await HandleRefreshLock(newLockIdentifier, existingLock, cancellationToken),
             _ => new NotImplementedResult(),
@@ -656,32 +659,35 @@ public class FilesController(
     }
 
     /// <summary>
-    /// Handles Lock and UnlockAndRelock operations.
-    /// When <paramref name="oldLockIdentifier"/> is null, this is a Lock request.
-    /// When <paramref name="oldLockIdentifier"/> is present, this is an UnlockAndRelock request:
-    /// the existing lock matching oldLockIdentifier is atomically replaced with a new lock using newLockIdentifier.
-    /// Specification: https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/unlockandrelock
+    /// Handles a Lock request (X-WOPI-OldLock absent). Acquires a new lock when the file is unlocked,
+    /// or refreshes the existing one if the lock IDs match. Spec:
+    /// https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/lock
     /// </summary>
-    private async Task<IActionResult> HandleLockOrPut(string id, string? oldLockIdentifier, string? newLockIdentifier, WopiLockInfo? existingLock, CancellationToken cancellationToken)
+    private async Task<IActionResult> HandleLock(string id, string? newLockIdentifier, WopiLockInfo? existingLock, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(lockProvider);
-        if (oldLockIdentifier is null)
+        if (string.IsNullOrWhiteSpace(newLockIdentifier))
         {
-            if (string.IsNullOrWhiteSpace(newLockIdentifier))
-            {
-                return new LockMismatchResult(Response, reason: "Missing new lock identifier");
-            }
-
-            if (existingLock is not null)
-            {
-                return await LockOrRefresh(newLockIdentifier, existingLock, cancellationToken);
-            }
-
-            return await lockProvider.AddLockAsync(id, newLockIdentifier, cancellationToken) is not null
-                ? Ok()
-                : new LockMismatchResult(Response, "Could not create lock");
+            return new LockMismatchResult(Response, reason: "Missing new lock identifier");
         }
+        if (existingLock is not null)
+        {
+            return await LockOrRefresh(newLockIdentifier, existingLock, cancellationToken);
+        }
+        return await lockProvider.AddLockAsync(id, newLockIdentifier, cancellationToken) is not null
+            ? Ok()
+            : new LockMismatchResult(Response, "Could not create lock");
+    }
 
+    /// <summary>
+    /// Handles an UnlockAndRelock request (X-WOPI-OldLock present). Atomically replaces the existing
+    /// lock matching <paramref name="oldLockIdentifier"/> with a new lock using
+    /// <paramref name="newLockIdentifier"/>. Spec:
+    /// https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/unlockandrelock
+    /// </summary>
+    private async Task<IActionResult> HandleUnlockAndRelock(string id, string oldLockIdentifier, string? newLockIdentifier, WopiLockInfo? existingLock, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(lockProvider);
         if (existingLock is null)
         {
             return new LockMismatchResult(Response, reason: "File not locked");
@@ -694,7 +700,6 @@ public class FilesController(
         {
             return new LockMismatchResult(Response, reason: "Missing new lock identifier");
         }
-
         return await lockProvider.RefreshLockAsync(id, newLockIdentifier, cancellationToken)
             ? Ok()
             : new LockMismatchResult(Response, "Could not create lock");


### PR DESCRIPTION
## Summary

Stacked on top of #323. Addresses 4 of the 6 qlty code-smell findings; deliberately skips the other 2 because applying them would have made the code worse.

## What was applied

| Finding | Fix |
|---|---|
| `WopiAzureStorageProvider.CheckValidName` (6 returns) | Collapsed into a single boolean expression returned via one `Task.FromResult`. Reads more like a spec — each rule is one `&&` clause. |
| `FilesController.HandleLockOrPut` (7 returns) | Split into `HandleLock` (3 returns) and `HandleUnlockAndRelock` (4 returns). The function comment already explicitly said it handled two distinct WOPI ops; the split matches the conceptual structure. `ProcessLock` dispatches based on whether `X-WOPI-OldLock` is present. |
| `ContainersController:216` (nesting level 5) | The async lock-provider migration in #323 introduced an extra `if (lockProvider is not null) { ... if (existingLock is not null) ... }` pyramid. Collapsed to `lockProvider is null ? null : await GetLockAsync(...)` — drops one nesting level, same semantics. |
| `FilesController:429` (nesting level 5) | Same shape, same fix. |

## What was deliberately skipped

| Finding | Reason |
|---|---|
| `WopiAzureLockProvider.RefreshLockAsync` (6 returns) | Each return is a distinct precondition guard (props missing, parse fail, expired, lease GUID missing, renew fail, set-metadata fail). Combining them into one boolean would obscure intent — these are spec-driven failure modes worth surfacing distinctly. |
| `WopiAzureStorageProvider.cs` (file complexity 108) | The class implements two interfaces (`IWopiStorageProvider` + `IWopiWritableStorageProvider`) with ~12 methods that share state (`BlobIdMap`, init lock). Splitting it just to satisfy a metric trades cohesion for class proliferation. |

## Test plan

- [x] Build clean
- [x] `WopiHost.Core.Tests` — 313 passing (no behavior change)
- [x] `WopiHost.AzureStorageProvider.Tests` — 97 passing
- [x] `WopiHost.AzureLockProvider.Tests` — 28 passing
- [x] No new tests added — the existing suite already covers every reachable WOPI-spec branch in the refactored helpers, and the `CheckValidName` boolean expression is the same predicate as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)