### PR TITLE
chore: clean up Roslyn analyzer messages

### DIFF
--- a/infra/WopiHost.ServiceDefaults/Extensions.cs
+++ b/infra/WopiHost.ServiceDefaults/Extensions.cs
@@ -2,12 +2,13 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
-namespace Microsoft.Extensions.Hosting;
+namespace WopiHost.ServiceDefaults;
 
 // Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
 // This project should be referenced by each service project in your solution.

--- a/sample/WopiHost.Validator/Pages/HostPage.cshtml.cs
+++ b/sample/WopiHost.Validator/Pages/HostPage.cshtml.cs
@@ -28,7 +28,7 @@ public class HostPageModel(
 
     public string AccessToken { get; set; } = string.Empty;
     public string AccessTokenTtl { get; set; } = string.Empty;
-    public string UrlSrc { get; set; } = string.Empty;
+    public Uri? UrlSrc { get; set; }
 
     private readonly WopiUrlBuilder urlGenerator = new(discoverer, new WopiUrlSettings { UiLlcc = CultureInfo.CurrentUICulture });
 
@@ -67,8 +67,9 @@ public class HostPageModel(
             wopiOptions.Value.HostUrl,
             linkGenerator.GetPathByRouteValues(WopiRouteNames.CheckFileInfo, new { id = FileId })
             ?? throw new InvalidOperationException($"Could not generate route for '{WopiRouteNames.CheckFileInfo}'"));
-        UrlSrc = await urlGenerator.GetFileUrlAsync(extension, wopiFileUrl, WopiAction)
+        var urlSrcString = await urlGenerator.GetFileUrlAsync(extension, wopiFileUrl, WopiAction)
             ?? throw new InvalidOperationException($"Could not retrieve WopiUrl for extension '{extension}'");
+        UrlSrc = new Uri(urlSrcString, UriKind.Absolute);
         ViewData["favicon"] = await discoverer.GetApplicationFavIconAsync(extension);
         return Page();
     }

--- a/sample/WopiHost.Web.Oidc/Models/OidcOptions.cs
+++ b/sample/WopiHost.Web.Oidc/Models/OidcOptions.cs
@@ -29,7 +29,7 @@ public class OidcOptions
     public string SignedOutCallbackPath { get; set; } = "/signout-callback-oidc";
 
     /// <summary>Scopes to request from the IdP. Defaults to <c>openid profile email</c>.</summary>
-    public string[] Scopes { get; set; } = ["openid", "profile", "email"];
+    public IList<string> Scopes { get; set; } = ["openid", "profile", "email"];
 
     /// <summary>Whether to use PKCE. Default true; recommended for all clients per OAuth 2.1.</summary>
     public bool UsePkce { get; set; } = true;

--- a/sample/WopiHost.Web.Oidc/Program.cs
+++ b/sample/WopiHost.Web.Oidc/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.IdentityModel.Logging;
 using WopiHost.Abstractions;
 using WopiHost.Discovery;
 using WopiHost.FileSystemProvider;
+using WopiHost.ServiceDefaults;
 using WopiHost.Web.Oidc.Infrastructure;
 using WopiHost.Web.Oidc.Models;
 

--- a/sample/WopiHost.Web/Program.cs
+++ b/sample/WopiHost.Web/Program.cs
@@ -1,6 +1,7 @@
 using WopiHost.Abstractions;
 using WopiHost.Discovery;
 using WopiHost.FileSystemProvider;
+using WopiHost.ServiceDefaults;
 using WopiHost.Web.Models;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/sample/WopiHost/Program.cs
+++ b/sample/WopiHost/Program.cs
@@ -6,6 +6,7 @@ using WopiHost.Core.Extensions;
 using WopiHost.Core.Infrastructure;
 using WopiHost.Core.Security.Authentication;
 using WopiHost.Discovery;
+using WopiHost.ServiceDefaults;
 using Scalar.AspNetCore;
 
 namespace WopiHost;

--- a/src/WopiHost.Abstractions/IWopiFile.cs
+++ b/src/WopiHost.Abstractions/IWopiFile.cs
@@ -1,4 +1,6 @@
-﻿namespace WopiHost.Abstractions;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace WopiHost.Abstractions;
 
 /// <summary>
 /// Representation of a file.
@@ -38,6 +40,8 @@ public interface IWopiFile : IWopiResource
     /// <summary>
     /// SHA256 checksum
     /// </summary>
+    [SuppressMessage("Performance", "CA1819:Properties should not return arrays",
+        Justification = "SHA-256 hash bytes; byte[] is the natural shape and matches SHA256.ComputeHash output.")]
     byte[]? Checksum { get; }
 
     /// <summary>

--- a/src/WopiHost.Cobalt/CobaltSession.cs
+++ b/src/WopiHost.Cobalt/CobaltSession.cs
@@ -127,7 +127,7 @@ public sealed class CobaltProcessor : ICobaltProcessor, IDisposable
         // the closest equivalent (in-memory by default; can be backed by a
         // directory if a `dirPathForFileBackedBlobs` is supplied — left null here
         // to match the old temp-only behavior).
-        CobaltFilePartitionConfig MakePartition(FilePartitionId partition, bool genericFda) => new()
+        static CobaltFilePartitionConfig MakePartition(FilePartitionId partition, bool genericFda) => new()
         {
             IsNewFile = true,
             HostBlobStore = new LocalHostBlobStore(new LocalHostBlobStore.Config()),
@@ -213,7 +213,7 @@ public sealed class CobaltProcessor : ICobaltProcessor, IDisposable
 
     private void ThrowIfDisposed()
     {
-        if (Volatile.Read(ref _disposed) != 0) throw new ObjectDisposedException(nameof(CobaltProcessor));
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, typeof(CobaltProcessor));
     }
 
     private sealed class CobaltSessionEntry(CobaltFile file, DisposalEscrow disposal) : IDisposable

--- a/src/WopiHost.Core/Controllers/ContainersController.cs
+++ b/src/WopiHost.Core/Controllers/ContainersController.cs
@@ -260,8 +260,8 @@ public class ContainersController(
                     newFile.Name + '.' + newFile.Extension,
                     Url.GetWopiSrc(WopiResourceType.File, newFile.Identifier))
                 {
-                    HostEditUrl = checkFileInfo.HostEditUrl?.ToString(),
-                    HostViewUrl = checkFileInfo.HostViewUrl?.ToString()
+                    HostEditUrl = checkFileInfo.HostEditUrl,
+                    HostViewUrl = checkFileInfo.HostViewUrl,
                 });
         }
 

--- a/src/WopiHost.Core/Controllers/FilesController.cs
+++ b/src/WopiHost.Core/Controllers/FilesController.cs
@@ -475,8 +475,8 @@ public class FilesController(
                     newFile.Name + '.' + newFile.Extension,
                     Url.GetWopiSrc(WopiResourceType.File, newFile.Identifier))
                 {
-                    HostEditUrl = checkFileInfo.HostEditUrl?.ToString(),
-                    HostViewUrl = checkFileInfo.HostViewUrl?.ToString() 
+                    HostEditUrl = checkFileInfo.HostEditUrl,
+                    HostViewUrl = checkFileInfo.HostViewUrl,
                 });
         }
 

--- a/src/WopiHost.Core/Extensions/HttpRequestExtensions.cs
+++ b/src/WopiHost.Core/Extensions/HttpRequestExtensions.cs
@@ -68,16 +68,16 @@ public static class HttpRequestExtensions
     public static (string? scheme, string? host, string? pathBase, string? path, string? queryString)
         GetProxyAwareUrlParts(this HttpRequest request)
     {
-        var scheme = request.Headers.ContainsKey("X-Forwarded-Proto") 
-            ? request.Headers["X-Forwarded-Proto"].ToString() 
+        var scheme = request.Headers.TryGetValue("X-Forwarded-Proto", out var forwardedProto)
+            ? forwardedProto.ToString()
             : request.Scheme;
-        
-        var host = request.Headers.ContainsKey("X-Forwarded-Host") 
-            ? request.Headers["X-Forwarded-Host"].ToString() 
+
+        var host = request.Headers.TryGetValue("X-Forwarded-Host", out var forwardedHost)
+            ? forwardedHost.ToString()
             : request.Host.Value;
-        
-        var pathBase = request.Headers.ContainsKey("X-Forwarded-PathBase") 
-            ? request.Headers["X-Forwarded-PathBase"].ToString() 
+
+        var pathBase = request.Headers.TryGetValue("X-Forwarded-PathBase", out var forwardedPathBase)
+            ? forwardedPathBase.ToString()
             : request.PathBase.Value;
         
         var path = request.Path.Value;

--- a/src/WopiHost.Core/Models/ChildFile.cs
+++ b/src/WopiHost.Core/Models/ChildFile.cs
@@ -25,10 +25,10 @@ public record ChildFile(string Name, string Url) : AbstractChildBase(Name, Url)
     /// <summary>
     /// URL to view the file in the host's web interface.
     /// </summary>
-    public string? HostViewUrl { get; set; }
+    public Uri? HostViewUrl { get; set; }
 
     /// <summary>
     /// URL to edit the file in the host's web interface.
     /// </summary>
-    public string? HostEditUrl { get; set; }
+    public Uri? HostEditUrl { get; set; }
 }

--- a/src/WopiHost.Core/Security/Authentication/AccessTokenHandler.cs
+++ b/src/WopiHost.Core/Security/Authentication/AccessTokenHandler.cs
@@ -15,12 +15,15 @@ namespace WopiHost.Core.Security.Authentication;
 /// Only requests under <c>/wopi</c> are handled — for any other path the handler returns
 /// <see cref="AuthenticateResult.NoResult"/> so other authentication schemes can take over.
 /// </remarks>
-public class AccessTokenHandler(
+public partial class AccessTokenHandler(
     IWopiAccessTokenService accessTokenService,
     IOptionsMonitor<AccessTokenAuthenticationOptions> options,
     ILoggerFactory logger,
     UrlEncoder encoder) : AuthenticationHandler<AccessTokenAuthenticationOptions>(options, logger, encoder)
 {
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Access token validation failed: {Reason}")]
+    private static partial void LogTokenValidationFailed(ILogger logger, string? reason);
+
     /// <summary>
     /// Validates the <c>access_token</c> query parameter on WOPI requests.
     /// </summary>
@@ -40,7 +43,7 @@ public class AccessTokenHandler(
         var validation = await accessTokenService.ValidateAsync(token, Context.RequestAborted);
         if (!validation.IsValid || validation.Principal is null)
         {
-            Logger.LogDebug("Access token validation failed: {Reason}", validation.FailureReason);
+            LogTokenValidationFailed(Logger, validation.FailureReason);
             return AuthenticateResult.Fail(validation.FailureReason ?? "Invalid access token.");
         }
 

--- a/src/WopiHost.Core/Security/Authentication/JwtAccessTokenService.cs
+++ b/src/WopiHost.Core/Security/Authentication/JwtAccessTokenService.cs
@@ -12,37 +12,37 @@ namespace WopiHost.Core.Security.Authentication;
 /// Default <see cref="IWopiAccessTokenService"/> implementation. Issues signed JWTs that bind
 /// a user to a single <c>(resource, permissions, lifetime)</c> tuple.
 /// </summary>
-public class JwtAccessTokenService : IWopiAccessTokenService
+/// <remarks>
+/// Creates a new instance of the <see cref="JwtAccessTokenService"/>.
+/// </remarks>
+public partial class JwtAccessTokenService(
+    IOptionsMonitor<WopiSecurityOptions> options,
+    ILogger<JwtAccessTokenService> logger,
+    TimeProvider? timeProvider = null) : IWopiAccessTokenService
 {
-    private readonly IOptionsMonitor<WopiSecurityOptions> _options;
-    private readonly ILogger<JwtAccessTokenService> _logger;
-    private readonly TimeProvider _timeProvider;
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Access token rejected: {Reason}")]
+    private static partial void LogAccessTokenRejected(ILogger logger, Exception ex, string reason);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "WopiSecurityOptions.SigningKey is not configured; generated an ephemeral in-memory key. " +
+            "Tokens will be invalidated on restart and cannot work across multiple host instances. " +
+            "Configure Wopi:Security:SigningKey for any non-development scenario.")]
+    private static partial void LogEphemeralSigningKey(ILogger logger);
+
+    private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
     // MapInboundClaims maps short JWT names back to long ClaimTypes.* on validation, so
     // downstream code (e.g. ClaimsPrincipal.FindFirst(ClaimTypes.NameIdentifier)) keeps working.
     private readonly JwtSecurityTokenHandler _handler = new() { MapInboundClaims = true };
     private SymmetricSecurityKey? _ephemeralDevKey;
-
-    /// <summary>
-    /// Creates a new instance of the <see cref="JwtAccessTokenService"/>.
-    /// </summary>
-    public JwtAccessTokenService(
-        IOptionsMonitor<WopiSecurityOptions> options,
-        ILogger<JwtAccessTokenService> logger,
-        TimeProvider? timeProvider = null)
-    {
-        _options = options;
-        _logger = logger;
-        _timeProvider = timeProvider ?? TimeProvider.System;
-    }
 
     /// <inheritdoc/>
     public Task<WopiAccessToken> IssueAsync(WopiAccessTokenRequest request, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        var options = _options.CurrentValue;
+        var opts = options.CurrentValue;
         var now = _timeProvider.GetUtcNow();
-        var lifetime = request.Lifetime ?? options.DefaultTokenLifetime;
+        var lifetime = request.Lifetime ?? opts.DefaultTokenLifetime;
         var expires = now.Add(lifetime);
 
         var claims = new List<Claim>
@@ -88,9 +88,9 @@ public class JwtAccessTokenService : IWopiAccessTokenService
             IssuedAt = now.UtcDateTime,
             NotBefore = now.UtcDateTime,
             Expires = expires.UtcDateTime,
-            Issuer = options.Issuer,
-            Audience = options.Audience,
-            SigningCredentials = new SigningCredentials(GetSigningKey(options), options.SigningAlgorithm),
+            Issuer = opts.Issuer,
+            Audience = opts.Audience,
+            SigningCredentials = new SigningCredentials(GetSigningKey(opts), opts.SigningAlgorithm),
         };
 
         var token = _handler.CreateToken(descriptor);
@@ -106,9 +106,9 @@ public class JwtAccessTokenService : IWopiAccessTokenService
             return Task.FromResult(WopiAccessTokenValidationResult.Failure("Token is empty."));
         }
 
-        var options = _options.CurrentValue;
-        var validationKeys = new List<SecurityKey> { GetSigningKey(options) };
-        foreach (var extraKey in options.AdditionalValidationKeys)
+        var opts = options.CurrentValue;
+        var validationKeys = new List<SecurityKey> { GetSigningKey(opts) };
+        foreach (var extraKey in opts.AdditionalValidationKeys)
         {
             validationKeys.Add(new SymmetricSecurityKey(extraKey));
         }
@@ -118,11 +118,11 @@ public class JwtAccessTokenService : IWopiAccessTokenService
             ValidateIssuerSigningKey = true,
             IssuerSigningKeys = validationKeys,
             ValidateLifetime = true,
-            ValidateIssuer = !string.IsNullOrEmpty(options.Issuer),
-            ValidIssuer = options.Issuer,
-            ValidateAudience = !string.IsNullOrEmpty(options.Audience),
-            ValidAudience = options.Audience,
-            ClockSkew = options.ClockSkew,
+            ValidateIssuer = !string.IsNullOrEmpty(opts.Issuer),
+            ValidIssuer = opts.Issuer,
+            ValidateAudience = !string.IsNullOrEmpty(opts.Audience),
+            ValidAudience = opts.Audience,
+            ClockSkew = opts.ClockSkew,
             NameClaimType = ClaimTypes.NameIdentifier,
         };
 
@@ -137,20 +137,20 @@ public class JwtAccessTokenService : IWopiAccessTokenService
             // so the auth pipeline returns 401, not 500. SecurityTokenException covers most cases (expiry,
             // signature, audience). Malformed inputs throw ArgumentException, base64 decode errors throw
             // FormatException, and structurally-broken JWT JSON throws JsonException.
-            _logger.LogDebug(ex, "Access token rejected: {Reason}", ex.Message);
+            LogAccessTokenRejected(logger, ex, ex.Message);
             return Task.FromResult(WopiAccessTokenValidationResult.Failure(ex.Message));
         }
     }
 
-    private SecurityKey GetSigningKey(WopiSecurityOptions options)
+    private SecurityKey GetSigningKey(WopiSecurityOptions opts)
     {
-        if (options.SecurityKey is not null)
+        if (opts.SecurityKey is not null)
         {
-            return options.SecurityKey;
+            return opts.SecurityKey;
         }
-        if (options.SigningKey is { Length: > 0 })
+        if (opts.SigningKey is { Length: > 0 })
         {
-            return new SymmetricSecurityKey(options.SigningKey);
+            return new SymmetricSecurityKey(opts.SigningKey);
         }
         // No key configured: generate a per-process random key. Loud warning so this is
         // never silently used in production.
@@ -158,10 +158,7 @@ public class JwtAccessTokenService : IWopiAccessTokenService
         {
             var keyBytes = RandomNumberGenerator.GetBytes(64);
             _ephemeralDevKey = new SymmetricSecurityKey(keyBytes);
-            _logger.LogWarning(
-                "WopiSecurityOptions.SigningKey is not configured; generated an ephemeral in-memory key. " +
-                "Tokens will be invalidated on restart and cannot work across multiple host instances. " +
-                "Configure Wopi:Security:SigningKey for any non-development scenario.");
+            LogEphemeralSigningKey(logger);
         }
         return _ephemeralDevKey;
     }

--- a/src/WopiHost.Core/Security/Authentication/WopiOriginValidationActionFilter.cs
+++ b/src/WopiHost.Core/Security/Authentication/WopiOriginValidationActionFilter.cs
@@ -15,6 +15,7 @@ namespace WopiHost.Core.Security.Authentication;
 /// </remarks>
 /// <param name="proofValidator">The service used to validate WOPI proof keys.</param>
 /// <param name="logger">Logger instance.</param>
+[AttributeUsage(AttributeTargets.Class)]
 public class WopiOriginValidationActionFilter(IWopiProofValidator proofValidator, ILogger<WopiOriginValidationActionFilter> logger) : Attribute, IAsyncActionFilter
 {
     /// <summary>

--- a/src/WopiHost.Core/Security/Authorization/WopiAuthorizationHandler.cs
+++ b/src/WopiHost.Core/Security/Authorization/WopiAuthorizationHandler.cs
@@ -26,9 +26,14 @@ namespace WopiHost.Core.Security.Authorization;
 /// the requirement on mismatch.
 /// </para>
 /// </remarks>
-public class WopiAuthorizationHandler(ILogger<WopiAuthorizationHandler> logger)
+public partial class WopiAuthorizationHandler(ILogger<WopiAuthorizationHandler> logger)
     : AuthorizationHandler<WopiAuthorizeAttribute, HttpContext>
 {
+    [LoggerMessage(Level = LogLevel.Debug,
+        Message = "Token bound to resource '{TokenRid}' is being used against route id '{RouteId}'. " +
+            "This is allowed by default (WOPI tokens are session-scoped); register a stricter IAuthorizationHandler if you need to block cross-resource reuse.")]
+    private static partial void LogResourceBindingMismatch(ILogger logger, string tokenRid, string? routeId);
+
     /// <inheritdoc/>
     protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, WopiAuthorizeAttribute requirement, HttpContext resource)
     {
@@ -44,7 +49,7 @@ public class WopiAuthorizationHandler(ILogger<WopiAuthorizationHandler> logger)
             return Task.CompletedTask;
         }
 
-        LogResourceBindingMismatch(user, requirement);
+        WarnIfResourceBindingMismatch(user, requirement);
 
         if (!HasRequiredPermission(user, requirement))
         {
@@ -56,15 +61,13 @@ public class WopiAuthorizationHandler(ILogger<WopiAuthorizationHandler> logger)
         return Task.CompletedTask;
     }
 
-    private void LogResourceBindingMismatch(ClaimsPrincipal user, WopiAuthorizeAttribute requirement)
+    private void WarnIfResourceBindingMismatch(ClaimsPrincipal user, WopiAuthorizeAttribute requirement)
     {
         if (string.IsNullOrEmpty(requirement.ResourceId)) return;
         var ridClaim = user.FindFirstValue(WopiClaimTypes.ResourceId);
         if (!string.IsNullOrEmpty(ridClaim) && !string.Equals(ridClaim, requirement.ResourceId, StringComparison.Ordinal))
         {
-            logger.LogDebug("Token bound to resource '{TokenRid}' is being used against route id '{RouteId}'. " +
-                "This is allowed by default (WOPI tokens are session-scoped); register a stricter IAuthorizationHandler if you need to block cross-resource reuse.",
-                ridClaim, requirement.ResourceId);
+            LogResourceBindingMismatch(logger, ridClaim, requirement.ResourceId);
         }
     }
 

--- a/src/WopiHost.Core/Security/WopiSecurityOptions.cs
+++ b/src/WopiHost.Core/Security/WopiSecurityOptions.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.IdentityModel.Tokens;
 
 namespace WopiHost.Core.Security;
@@ -28,6 +29,8 @@ public class WopiSecurityOptions
     /// key on startup and logs a warning. This is convenient for local dev but means tokens are
     /// invalidated on every restart and cannot work across multiple host instances.
     /// </remarks>
+    [SuppressMessage("Performance", "CA1819:Properties should not return arrays",
+        Justification = "Bound from a base64 config string by the IConfiguration BinaryConverter, which only targets byte[].")]
     public byte[]? SigningKey { get; set; }
 
     /// <summary>

--- a/src/WopiHost.FileSystemProvider/InMemoryFileIds.cs
+++ b/src/WopiHost.FileSystemProvider/InMemoryFileIds.cs
@@ -9,8 +9,11 @@ namespace WopiHost.FileSystemProvider;
 /// Provides unique file identifiers for files.
 /// </summary>
 /// <remarks>very basic in-memory for sample purposes only</remarks>
-public class InMemoryFileIds(ILogger<InMemoryFileIds> logger)
+public partial class InMemoryFileIds(ILogger<InMemoryFileIds> logger)
 {
+    [LoggerMessage(Level = LogLevel.Information, Message = "Scanned {total} items")]
+    private static partial void LogScannedItems(ILogger logger, int total);
+
     private readonly Dictionary<string, string> fileIds = [];
 
     /// <summary>
@@ -110,7 +113,7 @@ public class InMemoryFileIds(ILogger<InMemoryFileIds> logger)
             fileIds[newId] = file;
         }
 
-        logger.LogInformation("Scanned {total} items", fileIds.Count);
+        LogScannedItems(logger, fileIds.Count);
     }
 
     /// <summary>

--- a/src/WopiHost.FileSystemProvider/LinuxFileOwner.cs
+++ b/src/WopiHost.FileSystemProvider/LinuxFileOwner.cs
@@ -15,7 +15,7 @@ namespace WopiHost.FileSystemProvider;
 /// P/Invoke fragile. Available on glibc ≥ 2.28 and musl ≥ 1.2.
 /// </remarks>
 [SupportedOSPlatform("linux")]
-internal static class LinuxFileOwner
+internal static partial class LinuxFileOwner
 {
     private const int AT_FDCWD = -100;
     private const uint STATX_UID = 0x00000008;
@@ -95,16 +95,16 @@ internal static class LinuxFileOwner
     }
 
 #pragma warning disable CA5392 // Use DefaultDllImportSearchPaths attribute for P/Invokes
-    [DllImport("libc", EntryPoint = "statx", SetLastError = true)]
-    private static extern int Statx(
+    [LibraryImport("libc", EntryPoint = "statx", SetLastError = true, StringMarshalling = StringMarshalling.Utf8)]
+    private static partial int Statx(
         int dirfd,
-        [MarshalAs(UnmanagedType.LPUTF8Str)] string pathname,
+        string pathname,
         int flags,
         uint mask,
         out StatxBuf statxbuf);
 
-    [DllImport("libc", EntryPoint = "getpwuid_r", SetLastError = false)]
-    private static extern int GetPwUid_R(
+    [LibraryImport("libc", EntryPoint = "getpwuid_r", SetLastError = false)]
+    private static partial int GetPwUid_R(
         uint uid,
         ref Passwd pwd,
         IntPtr buf,

--- a/src/WopiHost.FileSystemProvider/WopiHost.FileSystemProvider.csproj
+++ b/src/WopiHost.FileSystemProvider/WopiHost.FileSystemProvider.csproj
@@ -5,6 +5,8 @@
 		<Description>WopiHost.FileSystemProvider Class Library</Description>
 		<Authors>Petr Svihlik</Authors>
 		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<!-- Required by [LibraryImport] generated marshalling code (uses pointers internally). -->
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<AssemblyName>WopiHost.FileSystemProvider</AssemblyName>
 		<PackageId>WopiHost.FileSystemProvider</PackageId>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>

--- a/test/WopiHost.Core.Tests/Extensions/HttpRequestExtensionsTests.cs
+++ b/test/WopiHost.Core.Tests/Extensions/HttpRequestExtensionsTests.cs
@@ -239,7 +239,7 @@ public class HttpRequestExtensionsTests
     public void GetAccessToken_FromBearerHeader_ReturnsToken()
     {
         var ctx = new DefaultHttpContext();
-        ctx.Request.Headers["Authorization"] = "Bearer from-header";
+        ctx.Request.Headers.Authorization = "Bearer from-header";
 
         Assert.Equal("from-header", ctx.Request.GetAccessToken());
     }
@@ -248,7 +248,7 @@ public class HttpRequestExtensionsTests
     public void GetAccessToken_FromNonBearerAuthorizationHeader_ReturnsEmpty()
     {
         var ctx = new DefaultHttpContext();
-        ctx.Request.Headers["Authorization"] = "Basic abc123";
+        ctx.Request.Headers.Authorization = "Basic abc123";
 
         Assert.Equal(string.Empty, ctx.Request.GetAccessToken());
     }

--- a/test/WopiHost.Core.Tests/Security/Authentication/WopiBootstrapChallengeTests.cs
+++ b/test/WopiHost.Core.Tests/Security/Authentication/WopiBootstrapChallengeTests.cs
@@ -96,7 +96,7 @@ public class WopiBootstrapChallengeTests
         WopiBootstrapChallenge.Apply(ctx.Response, AuthUri, TokenUri, providerId: "tpcontoso");
 
         Assert.Equal(StatusCodes.Status401Unauthorized, ctx.Response.StatusCode);
-        var header = Assert.Single(ctx.Response.Headers["WWW-Authenticate"]!);
+        var header = Assert.Single(ctx.Response.Headers.WWWAuthenticate!);
         Assert.StartsWith("Bearer ", header);
         Assert.Contains("authorization_uri=\"https://idp.contoso.com/oauth2/authorize\"", header);
         Assert.Contains("tokenIssuance_uri=\"https://idp.contoso.com/oauth2/token\"", header);

--- a/test/WopiHost.Core.Tests/Security/Authentication/WopiOriginValidationActionFilterTests.cs
+++ b/test/WopiHost.Core.Tests/Security/Authentication/WopiOriginValidationActionFilterTests.cs
@@ -35,9 +35,9 @@ public class WopiOriginValidationActionFilterTests
     {
         var ctx = BuildContext(new DefaultHttpContext());
         var nextCalled = false;
-        ActionExecutionDelegate next = () => { nextCalled = true; return Task.FromResult<ActionExecutedContext>(null!); };
+        Task<ActionExecutedContext> Next() { nextCalled = true; return Task.FromResult<ActionExecutedContext>(null!); }
 
-        await BuildSut().OnActionExecutionAsync(ctx, next);
+        await BuildSut().OnActionExecutionAsync(ctx, Next);
 
         Assert.Equal(StatusCodes.Status500InternalServerError, ctx.HttpContext.Response.StatusCode);
         Assert.False(nextCalled);
@@ -53,9 +53,9 @@ public class WopiOriginValidationActionFilterTests
             .ReturnsAsync(false);
         var ctx = BuildContext(http);
         var nextCalled = false;
-        ActionExecutionDelegate next = () => { nextCalled = true; return Task.FromResult<ActionExecutedContext>(null!); };
+        Task<ActionExecutedContext> Next() { nextCalled = true; return Task.FromResult<ActionExecutedContext>(null!); }
 
-        await BuildSut().OnActionExecutionAsync(ctx, next);
+        await BuildSut().OnActionExecutionAsync(ctx, Next);
 
         var statusResult = Assert.IsType<StatusCodeResult>(ctx.Result);
         Assert.Equal(StatusCodes.Status500InternalServerError, statusResult.StatusCode);
@@ -72,13 +72,13 @@ public class WopiOriginValidationActionFilterTests
             .ReturnsAsync(true);
         var ctx = BuildContext(http);
         var nextCalled = false;
-        ActionExecutionDelegate next = () =>
+        Task<ActionExecutedContext> Next()
         {
             nextCalled = true;
             return Task.FromResult(new ActionExecutedContext(ctx, [], controller: new object()));
-        };
+        }
 
-        await BuildSut().OnActionExecutionAsync(ctx, next);
+        await BuildSut().OnActionExecutionAsync(ctx, Next);
 
         Assert.True(nextCalled);
         Assert.Null(ctx.Result);

--- a/test/WopiHost.FileSystemProvider.Tests/InMemoryFileIdsTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/InMemoryFileIdsTests.cs
@@ -7,7 +7,11 @@ public class InMemoryFileIdsTests : IDisposable
     private readonly InMemoryFileIds _sut = new(NullLogger<InMemoryFileIds>.Instance);
     private readonly DirectoryInfo _tempDir = Directory.CreateTempSubdirectory("WopiTest_");
 
-    public void Dispose() => _tempDir.Delete(recursive: true);
+    public void Dispose()
+    {
+        _tempDir.Delete(recursive: true);
+        GC.SuppressFinalize(this);
+    }
 
     [Fact]
     public void ScanAll_SamePath_ProducesSameIds()

--- a/test/WopiHost.FileSystemProvider.Tests/WopiFileSystemProviderTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/WopiFileSystemProviderTests.cs
@@ -41,6 +41,7 @@ public class WopiFileSystemProviderTests : IDisposable
     {
         _root.Refresh();
         if (_root.Exists) _root.Delete(recursive: true);
+        GC.SuppressFinalize(this);
     }
 
     private WopiFileSystemProvider CreateProvider(

--- a/test/WopiHost.FileSystemProvider.Tests/WopiFileTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/WopiFileTests.cs
@@ -17,6 +17,7 @@ public class WopiFileTests : IDisposable
     {
         _tempDir.Refresh();
         if (_tempDir.Exists) _tempDir.Delete(recursive: true);
+        GC.SuppressFinalize(this);
     }
 
     [Fact]

--- a/test/WopiHost.FileSystemProvider.Tests/WopiFolderTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/WopiFolderTests.cs
@@ -8,6 +8,7 @@ public class WopiFolderTests : IDisposable
     {
         _tempDir.Refresh();
         if (_tempDir.Exists) _tempDir.Delete(recursive: true);
+        GC.SuppressFinalize(this);
     }
 
     [Fact]

--- a/test/WopiHost.IntegrationTests/Fixtures/OidcWebAppFactory.cs
+++ b/test/WopiHost.IntegrationTests/Fixtures/OidcWebAppFactory.cs
@@ -12,19 +12,8 @@ namespace WopiHost.IntegrationTests.Fixtures;
 /// OIDC authority and signing key so the sample talks to a controllable mock IdP and shares
 /// a known WOPI access-token secret with <see cref="WopiBackendFactory"/>.
 /// </summary>
-public sealed class OidcWebAppFactory : WebApplicationFactory<OidcSampleEntryPoint>
+public sealed class OidcWebAppFactory(Uri authority, string wopiSigningSecret, string wopiBackendUrl) : WebApplicationFactory<OidcSampleEntryPoint>
 {
-    private readonly Uri _authority;
-    private readonly string _wopiSigningSecret;
-    private readonly string _wopiBackendUrl;
-
-    public OidcWebAppFactory(Uri authority, string wopiSigningSecret, string wopiBackendUrl)
-    {
-        _authority = authority;
-        _wopiSigningSecret = wopiSigningSecret;
-        _wopiBackendUrl = wopiBackendUrl;
-    }
-
     /// <summary>Client id the sample registers with the mock IdP. Mock-oauth2-server accepts any id.</summary>
     public const string TestClientId = OidcSampleTestConfig.TestClientId;
 
@@ -36,9 +25,9 @@ public sealed class OidcWebAppFactory : WebApplicationFactory<OidcSampleEntryPoi
         builder.ConfigureAppConfiguration((_, config) =>
         {
             config.AddInMemoryCollection(OidcSampleTestConfig.Build(
-                oidcAuthority: _authority.AbsoluteUri.TrimEnd('/'),
-                wopiSigningSecret: _wopiSigningSecret,
-                wopiBackendUrl: _wopiBackendUrl));
+                oidcAuthority: authority.AbsoluteUri.TrimEnd('/'),
+                wopiSigningSecret: wopiSigningSecret,
+                wopiBackendUrl: wopiBackendUrl));
         });
 
         builder.ConfigureServices(services =>
@@ -48,7 +37,7 @@ public sealed class OidcWebAppFactory : WebApplicationFactory<OidcSampleEntryPoi
             services.Configure<OpenIdConnectOptions>(OpenIdConnectDefaults.AuthenticationScheme, options =>
             {
                 options.RequireHttpsMetadata = false;
-                options.Authority = _authority.AbsoluteUri.TrimEnd('/');
+                options.Authority = authority.AbsoluteUri.TrimEnd('/');
                 options.BackchannelHttpHandler = new HttpClientHandler();
             });
         });

--- a/test/WopiHost.IntegrationTests/Fixtures/TestAuthOidcWebAppFactory.cs
+++ b/test/WopiHost.IntegrationTests/Fixtures/TestAuthOidcWebAppFactory.cs
@@ -14,21 +14,12 @@ namespace WopiHost.IntegrationTests.Fixtures;
 /// live IdP. The mock OIDC server still has to exist (the OIDC handler validates discovery at
 /// startup) — this factory just routes the actual authentication to the test handler.
 /// </summary>
-public sealed class TestAuthOidcWebAppFactory : WebApplicationFactory<OidcSampleEntryPoint>
+public sealed class TestAuthOidcWebAppFactory(string wopiSigningSecret, string wopiBackendUrl, Uri? authority = null) : WebApplicationFactory<OidcSampleEntryPoint>
 {
-    private readonly Uri _authority;
-    private readonly string _wopiSigningSecret;
-    private readonly string _wopiBackendUrl;
+    private readonly Uri _authority = authority ?? new Uri(PlaceholderAuthority);
 
     /// <summary>Default placeholder authority — never contacted because TestAuth bypasses OIDC.</summary>
     public const string PlaceholderAuthority = "https://placeholder.invalid/";
-
-    public TestAuthOidcWebAppFactory(string wopiSigningSecret, string wopiBackendUrl, Uri? authority = null)
-    {
-        _authority = authority ?? new Uri(PlaceholderAuthority);
-        _wopiSigningSecret = wopiSigningSecret;
-        _wopiBackendUrl = wopiBackendUrl;
-    }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
@@ -36,8 +27,8 @@ public sealed class TestAuthOidcWebAppFactory : WebApplicationFactory<OidcSample
         {
             config.AddInMemoryCollection(OidcSampleTestConfig.Build(
                 oidcAuthority: _authority.AbsoluteUri.TrimEnd('/'),
-                wopiSigningSecret: _wopiSigningSecret,
-                wopiBackendUrl: _wopiBackendUrl));
+                wopiSigningSecret: wopiSigningSecret,
+                wopiBackendUrl: wopiBackendUrl));
         });
 
         builder.ConfigureServices(services =>

--- a/test/WopiHost.IntegrationTests/Fixtures/WopiBackendFactory.cs
+++ b/test/WopiHost.IntegrationTests/Fixtures/WopiBackendFactory.cs
@@ -12,15 +12,8 @@ namespace WopiHost.IntegrationTests.Fixtures;
 /// <see cref="OidcWebAppFactory"/>) and replaces the default proof validator with a no-op so
 /// tests can synthesize WOPI requests without forging proof-key headers.
 /// </summary>
-public sealed class WopiBackendFactory : WebApplicationFactory<global::WopiHost.Program>
+public sealed class WopiBackendFactory(string wopiSigningSecret) : WebApplicationFactory<global::WopiHost.Program>
 {
-    private readonly string _wopiSigningSecret;
-
-    public WopiBackendFactory(string wopiSigningSecret)
-    {
-        _wopiSigningSecret = wopiSigningSecret;
-    }
-
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.ConfigureAppConfiguration((_, config) =>
@@ -34,7 +27,7 @@ public sealed class WopiBackendFactory : WebApplicationFactory<global::WopiHost.
                 ["Wopi:ClientUrl"] = "https://office.example.test",
                 ["Wopi:Discovery:NetZone"] = "ExternalHttps",
                 ["Wopi:Discovery:RefreshInterval"] = "12:00:00",
-                ["Wopi:Security:SigningKey"] = Convert.ToBase64String(OidcSampleTestConfig.SigningKeyBytes(_wopiSigningSecret)),
+                ["Wopi:Security:SigningKey"] = Convert.ToBase64String(OidcSampleTestConfig.SigningKeyBytes(wopiSigningSecret)),
             });
         });
 

--- a/test/WopiHost.IntegrationTests/WopiTokenRoundTripTests.cs
+++ b/test/WopiHost.IntegrationTests/WopiTokenRoundTripTests.cs
@@ -13,19 +13,17 @@ namespace WopiHost.IntegrationTests;
 /// from their identity + roles, and the WOPI backend accepts that token and reflects the user
 /// identity in CheckFileInfo. No Docker required (TestAuthHandler stands in for the OIDC handler).
 /// </summary>
-public sealed class WopiTokenRoundTripTests : IClassFixture<WopiTokenRoundTripTests.Fixture>
+public sealed partial class WopiTokenRoundTripTests(WopiTokenRoundTripTests.Fixture fixture) : IClassFixture<WopiTokenRoundTripTests.Fixture>
 {
     private const string SharedSigningSecret = "integration-test-shared-key-32bytes!";
-    private static readonly Regex AccessTokenInput = new(
-        """<input name="access_token" value="([^"]+)" type="hidden" />""",
-        RegexOptions.Compiled);
 
-    private readonly Fixture _fixture;
+    [GeneratedRegex("""<input name="access_token" value="([^"]+)" type="hidden" />""")]
+    private static partial Regex AccessTokenInputRegex();
 
-    public WopiTokenRoundTripTests(Fixture fixture)
-    {
-        _fixture = fixture;
-    }
+    [GeneratedRegex("""asp-route-id="([^"]+)"|/Home/Detail/([^?"]+)\?""")]
+    private static partial Regex DetailLinkRegex();
+
+    private readonly Fixture _fixture = fixture;
 
     [Fact]
     public async Task SignedInEditor_HostpageEmitsToken_ContainingOidcIdentity()
@@ -143,7 +141,7 @@ public sealed class WopiTokenRoundTripTests : IClassFixture<WopiTokenRoundTripTe
         index.EnsureSuccessStatusCode();
         var html = await index.Content.ReadAsStringAsync();
 
-        var match = Regex.Match(html, """asp-route-id="([^"]+)"|/Home/Detail/([^?"]+)\?""");
+        var match = DetailLinkRegex().Match(html);
         if (!match.Success)
         {
             throw new InvalidOperationException("No file id found on the index page. Did sample/wopi-docs lose its files?");
@@ -153,7 +151,7 @@ public sealed class WopiTokenRoundTripTests : IClassFixture<WopiTokenRoundTripTe
 
     private static string ExtractAccessToken(string html)
     {
-        var match = AccessTokenInput.Match(html);
+        var match = AccessTokenInputRegex().Match(html);
         if (!match.Success)
         {
             throw new InvalidOperationException("Hostpage did not contain an access_token input.");


### PR DESCRIPTION
## Summary
Clean up the IDE/analyzer hints surfaced by the project's enabled rule set, fixing the underlying issues rather than suppressing them wherever it's safe to do so.

### Refactors (no behavior change)
- **CA1854** ×3 — `ContainsKey` + indexer → `TryGetValue` in `HttpRequestExtensions`
- **CA1018** — `[AttributeUsage]` on `WopiOriginValidationActionFilter`
- **CA1513** + **IDE0062** — `ObjectDisposedException.ThrowIf` and static local function in `CobaltSession`
- **CA1816** ×4 — `GC.SuppressFinalize(this)` in test `Dispose()` methods
- **ASP0015** ×3 — typed `Headers.Authorization` / `Headers.WWWAuthenticate` in tests
- **IDE0039** ×3 — lambdas → local functions in `WopiOriginValidationActionFilterTests`
- **IDE0290** ×5 — primary constructors (`JwtAccessTokenService` + 4 integration-test fixtures)
- **SYSLIB1045** ×2 — `[GeneratedRegex]` for compile-time regex in tests

### Type / API improvements
- **CA1056** ×3 — `ChildFile.HostViewUrl/HostEditUrl` and `HostPageModel.UrlSrc` `string` → `Uri`. Controllers pass the `Uri` through directly; JSON wire format is unchanged because `System.Text.Json` serializes `Uri` to its string form.
- **CA1819** — `OidcOptions.Scopes` `string[]` → `IList<string>`; suppress on `IWopiFile.Checksum` (hash semantics) and `WopiSecurityOptions.SigningKey` (the config `BinaryConverter` only handles `byte[]`) with inline justifications.

### Performance
- **CA1873** ×4 — 4 hot-path logs converted to `LoggerMessage` source-generated partial methods (`AccessTokenHandler`, `JwtAccessTokenService`, `WopiAuthorizationHandler`, `InMemoryFileIds`).

### Native interop
- **SYSLIB1054** + **CA2101** — `LinuxFileOwner` `DllImport` → `LibraryImport` with `StringMarshalling.Utf8`; enable `AllowUnsafeBlocks` in the project (required by the generated marshalling code).

### Project structure
- **IDE0130** — `WopiHost.ServiceDefaults` extensions move from the `Microsoft.Extensions.Hosting` namespace to `WopiHost.ServiceDefaults`; callers add a `using` directive.

## Test plan
- [x] `dotnet build WOPI.slnx` — 0 warnings, 0 errors
- [x] `dotnet test WOPI.slnx` — all suites pass on net9 / net10 (Core.Tests + IntegrationTests + AzureLockProvider.Tests + AzureStorageProvider.Tests + others)
- [ ] CI on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)