### PR TITLE
fix(web): make file-icon fallback root-relative

### DIFF
--- a/sample/WopiHost.Web/Controllers/HomeController.cs
+++ b/sample/WopiHost.Web/Controllers/HomeController.cs
@@ -54,7 +54,10 @@ public class HomeController(
                     FileName = file.Name + "." + file.Extension,
                     SupportsEdit = await discoverer.SupportsActionAsync(file.Extension, WopiActionEnum.Edit),
                     SupportsView = await discoverer.SupportsActionAsync(file.Extension, WopiActionEnum.View),
-                    IconUri = (await discoverer.GetApplicationFavIconAsync(file.Extension)) ?? new Uri("file.ico", UriKind.Relative)
+                    // Leading slash so the fallback resolves to /file.ico regardless of the
+                    // current URL — without it the browser resolves "file.ico" relative to
+                    // the current path (e.g. /Home/Index → /Home/file.ico → 404).
+                    IconUri = (await discoverer.GetApplicationFavIconAsync(file.Extension)) ?? new Uri("/file.ico", UriKind.Relative)
                 });
             }
             return View(fileViewModels);


### PR DESCRIPTION
## Summary
The file-icon fallback in the WopiHost.Web sample (used when an extension isn't claimed by any Office Online Server app — `test.wopitest` is the obvious example) was constructed as `new Uri("file.ico", UriKind.Relative)`, with no leading slash.

The browser resolves that relative path against the current document URL. With the default MVC route `{controller=Home}/{action=Index}/{id?}` the document URL is effectively `/Home/Index`, so `file.ico` resolves to `/Home/file.ico` → 404 → broken-image glyph for any file whose extension OOS doesn't recognize.

## Fix
Leading slash in the fallback Uri (`/file.ico`) so it's root-relative.

## Test plan
- [x] `dotnet build` clean.
- [ ] `dotnet run --project sample/WopiHost.Web`, browse to `https://localhost:6001/`, confirm `test.wopitest` shows the file icon instead of a broken-image glyph. Other rows (whose extensions OOS does claim, like `.docx`) should still get their OOS-provided favicon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)