### PR TITLE
feat(apphost): optional Collabora Online for end-to-end editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ graph TB
     end
     
     subgraph "WOPI Client"
-        OOS["**Office Online Server**<br/>Microsoft 365 for the Web"]
+        OOS["**Office Online Server**<br/>Microsoft 365 for the Web<br/>Collabora Online (dev)"]
     end
     
     subgraph "WopiHost Backend API"
@@ -222,6 +222,63 @@ You can also customize application settings through:
 - `infra/WopiHost.AppHost/appsettings.json`
 - `infra/WopiHost.AppHost/appsettings.Development.json`
 
+#### Optional resources (opt-in flags)
+
+The AppHost reads a few `AppHost:*` flags so the default first-run flow stays minimal. Set them
+in `infra/WopiHost.AppHost/appsettings.Development.json` (or via environment variables / user secrets):
+
+| Flag | Adds | Notes |
+|---|---|---|
+| `AppHost:UseAzureStorage` | Azurite emulator + `BlobStorage` connection string forwarded to the WOPI host | Pair with `Wopi:StorageProviderAssemblyName=WopiHost.AzureStorageProvider` in `sample/WopiHost`. |
+| `AppHost:UseCollabora` | Collabora Online Development Edition (CODE) container as a real WOPI client | See [End-to-end editing with Collabora Online](#end-to-end-editing-with-collabora-online) below. |
+| `AppHost:IncludeOidcSample` | `WopiHost.Web.Oidc` frontend | Requires IdP configuration — see [`sample/WopiHost.Web.Oidc/README.md`](sample/WopiHost.Web.Oidc/README.md). |
+
+#### End-to-end editing with Collabora Online
+
+Office Online Server / M365 for the Web cannot legally be redistributed in a Docker image, so the
+AppHost ships [Collabora Online Development Edition](https://www.collaboraonline.com/code/) (the
+free, redistributable WOPI client from Collabora Productivity) as the optional in-the-loop client
+for end-to-end editing. CODE is **not** a substitute for OOS / M365 for the Web — discovery output
+and supported features differ — but it exercises the host across a real WOPI client without
+requiring a Microsoft Volume Licensing agreement or Windows containers.
+
+**Enable it:**
+
+```jsonc
+// infra/WopiHost.AppHost/appsettings.Development.json
+{
+  "AppHost": { "UseCollabora": true }
+}
+```
+
+Then `dotnet run --project infra/WopiHost.AppHost`. The dashboard will show a `collabora`
+container resource. The first run pulls the `collabora/code` image (~1 GB) and takes a minute or two.
+
+**Open a document:** browse to `http://localhost:6000`, pick a file from `sample/wopi-docs`, and
+the iframe will load Collabora at `http://localhost:9980/...`. Plain HTTP, signed WOPI proof keys,
+host-issued JWT access tokens — the whole flow.
+
+**How the wiring works:**
+
+| Hop | URL | Why |
+|---|---|---|
+| Browser → Collabora | `http://localhost:9980` | Container's published port. |
+| Collabora → WopiHost | `http://host.docker.internal:5000` | `host.docker.internal` is the Docker Desktop alias for the host machine — the WOPI host runs on the host, not in a container. |
+| WopiHost → Collabora (discovery) | `http://localhost:9980/hosting/discovery` | Server-to-server, fetched at startup. |
+
+The AppHost overrides `Wopi:ClientUrl` and `Wopi:HostUrl` env vars on the affected projects when
+`UseCollabora=true`, so no manual `appsettings.json` edits are needed.
+
+**Linux Docker** (not Docker Desktop): `host.docker.internal` is not auto-mapped. Run the engine
+with `--add-host=host.docker.internal:host-gateway` or change the override URLs in
+`infra/WopiHost.AppHost/Program.cs` to your host's LAN address.
+
+**Caveats:**
+- `extra_params: --o:ssl.enable=false --o:ssl.termination=false` — plain HTTP, dev only.
+- Collabora's `domain` env is a regex; the AppHost passes `host\.docker\.internal:5000`. If you
+  remap the WOPI host port, update both sides or Collabora silently rejects callbacks.
+- The `WopiHost.Validator` project does not need Collabora — it's a protocol-conformance tool.
+
 ### Alternative: Running individual projects
 
 If you prefer to run the projects individually without Aspire:
@@ -400,6 +457,14 @@ You can [use WopiHost to integrate with Microsoft 365 for the web](https://learn
 - onboarding - [apply for CSPP](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/online/apply-for-cspp-program)
 - extending the provided interfaces to support the required features by Microsoft; we provide a sample implementation of the interfaces that pass the interactive [WOPI-Validator](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/online/build-test-ship/validator) tests
 - [Test Microsoft 365 for the web integration](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/online/build-test-ship/testing)
+
+#### Collabora Online (development)
+
+[Collabora Online Development Edition](https://www.collaboraonline.com/code/) (CODE) is a free,
+redistributable WOPI client. The Aspire AppHost can spin it up as a Docker container so the host
+can be exercised end-to-end without a CSPP application or an Office Online Server install — see
+[End-to-end editing with Collabora Online](#end-to-end-editing-with-collabora-online). Treat CODE
+as a development client only; passing through CODE is not a guarantee of M365 conformance.
 
 Cobalt
 ------

--- a/infra/WopiHost.AppHost/Program.cs
+++ b/infra/WopiHost.AppHost/Program.cs
@@ -23,12 +23,44 @@ if (builder.Configuration.GetValue<bool>("AppHost:UseAzureStorage"))
     wopiHost.WithReference(blobs);
 }
 
+// Optional: Collabora Online Development Edition (CODE) as a real WOPI client for end-to-end
+// editing. Opt-in via "AppHost:UseCollabora"=true. CODE is free and Docker-distributable; it is
+// a development substitute for Office Online Server / M365 for the Web (discovery output and
+// supported features differ — do NOT treat a green Collabora run as M365 conformance).
+//
+// Wiring:
+//  - Browser reaches Collabora at http://localhost:9980.
+//  - Collabora (in Docker) reaches the WOPI host via host.docker.internal:5000, which Docker
+//    Desktop maps to the host. On Linux Docker, run with --add-host=host.docker.internal:host-gateway.
+//  - "domain" is a regex (escape dots) of WOPI hosts Collabora is allowed to call back to;
+//    a mismatch with the WopiSrc query param yields a silent 401.
+//  - SSL is disabled for local dev only.
+var useCollabora = builder.Configuration.GetValue<bool>("AppHost:UseCollabora");
+if (useCollabora)
+{
+    builder.AddContainer("collabora", "collabora/code")
+           .WithEnvironment("domain", "host\\.docker\\.internal:5000")
+           .WithEnvironment("extra_params", "--o:ssl.enable=false --o:ssl.termination=false")
+           .WithHttpEndpoint(targetPort: 9980, port: 9980, name: "collabora");
+
+    // Backend fetches /hosting/discovery from Collabora at startup.
+    wopiHost.WithEnvironment("Wopi__ClientUrl", "http://localhost:9980");
+}
+
 // Add WopiHost.Web frontend that depends on WopiHost
-builder.AddProject<Projects.WopiHost_Web>("wopihost-web")
+var wopiHostWeb = builder.AddProject<Projects.WopiHost_Web>("wopihost-web")
        .WithReference(wopiHost)
        .WithEndpoint(name: "web-http", port: 6000, scheme: "http")
        .WithEndpoint(name: "web-https", port: 6001, scheme: "https")
        .WithExternalHttpEndpoints();
+
+if (useCollabora)
+{
+    // The frontend embeds Collabora; the iframe URL must come from Collabora's discovery, and
+    // the WopiSrc it carries must resolve from inside the Collabora container.
+    wopiHostWeb.WithEnvironment("Wopi__ClientUrl", "http://localhost:9980")
+               .WithEnvironment("Wopi__HostUrl", "http://host.docker.internal:5000");
+}
 
 // Add Validator project for testing
 builder.AddProject<Projects.WopiHost_Validator>("wopihost-validator")

--- a/sample/README.md
+++ b/sample/README.md
@@ -22,13 +22,13 @@ Three runnable samples + a folder of test documents. The recommended way to laun
 | `Wopi:StorageProvider:RootPath` | `"../wopi-docs"` | Root of the directory tree the file-system provider exposes. |
 | `Wopi:LockProviderAssemblyName` | `"WopiHost.MemoryLockProvider"` | Assembly providing `IWopiLockProvider`. See [src/WopiHost.MemoryLockProvider](../src/WopiHost.MemoryLockProvider/README.md). |
 | `Wopi:UseCobalt` | `false` | Reflectively register [WopiHost.Cobalt](../src/WopiHost.Cobalt/README.md) when `true`. Requires a private `Microsoft.CobaltCore` package. |
-| `Wopi:ClientUrl` | `"https://ffc-onenote.officeapps.live.com"` | Base URI of the WOPI client (Office Online Server / M365 for the Web). Used by discovery. |
+| `Wopi:ClientUrl` | `"https://ffc-onenote.officeapps.live.com"` | Base URI of the WOPI client (Office Online Server / M365 for the Web / Collabora). Used by discovery. The AppHost overrides this to `http://localhost:9980` when run with `AppHost:UseCollabora=true` — see [End-to-end editing with Collabora Online](../README.md#end-to-end-editing-with-collabora-online). |
 
 ### `WopiHost.Web` ([appsettings.json](WopiHost.Web/appsettings.json))
 
 | Key | Sample value | Purpose |
 |---|---|---|
-| `Wopi:HostUrl` | `"http://wopihost"` | Base URI of the backend (above). Used to construct WopiSrc URLs. |
+| `Wopi:HostUrl` | `"http://wopihost"` | Base URI of the backend (above). Used to construct WopiSrc URLs. AppHost overrides this to `http://host.docker.internal:5000` when `AppHost:UseCollabora=true`, so callbacks from the Collabora container resolve to the host machine. |
 | `Wopi:ClientUrl` | `"https://ffc-onenote.officeapps.live.com"` | Base URI of the WOPI client. Used by the discovery cache. |
 | `Wopi:Discovery:NetZone` | `"ExternalHttps"` | Which discovery zone to read URL templates from. Values: see [`NetZoneEnum`](../src/WopiHost.Discovery/NetZoneEnum.cs). |
 | `Wopi:UiCulture` | (unset) | Optional IETF BCP 47 tag (e.g. `en-US`) for the `UI_LLCC` placeholder. Defaults to `CultureInfo.CurrentUICulture`. |

--- a/src/WopiHost.Discovery/README.md
+++ b/src/WopiHost.Discovery/README.md
@@ -3,7 +3,7 @@
 [![NuGet](https://img.shields.io/nuget/v/WopiHost.Discovery.svg)](https://www.nuget.org/packages/WopiHost.Discovery)
 [![NuGet](https://img.shields.io/nuget/dt/WopiHost.Discovery.svg)](https://www.nuget.org/packages/WopiHost.Discovery)
 
-Parses the [WOPI client discovery XML](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/online/discovery) to determine which file extensions and actions a WOPI client (Office Online Server / Microsoft 365 for the Web) supports, and returns the corresponding URL templates. Used by [WopiHost.Url](../WopiHost.Url/README.md) and consumed indirectly by host pages.
+Parses the [WOPI client discovery XML](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/online/discovery) to determine which file extensions and actions a WOPI client (Office Online Server / Microsoft 365 for the Web / Collabora Online) supports, and returns the corresponding URL templates. Used by [WopiHost.Url](../WopiHost.Url/README.md) and consumed indirectly by host pages.
 
 ## Install
 


### PR DESCRIPTION
## Summary

- Adds an opt-in [Collabora Online Development Edition](https://www.collaboraonline.com/code/) (CODE) container to `WopiHost.AppHost`, gated on `AppHost:UseCollabora=true`. Default flow (no Docker pull, no extra resources) is unchanged.
- When enabled, the AppHost automatically wires `Wopi:ClientUrl` on the backend (server-to-server discovery → `http://localhost:9980`) and `Wopi:ClientUrl` + `Wopi:HostUrl` on `wopihost-web` (so `WopiSrc` callbacks from inside the Collabora container resolve to the host via `host.docker.internal:5000`). No manual `appsettings.json` edits needed.
- READMEs updated: root README gets a new "Optional resources" table + an "End-to-end editing with Collabora Online" section explaining browser ↔ Collabora ↔ WOPI-host wiring, the `domain` regex gotcha, and the Linux-Docker `host.docker.internal` caveat. Sample and Discovery READMEs get one-liner updates.

CODE is **not** a substitute for OOS / M365 for the Web — discovery output and supported features differ. It is a development client suitable for exercising the host across a real WOPI client without a CSPP application or a Windows-container OOS install.

## Test plan

- [x] `dotnet build infra/WopiHost.AppHost` — clean, 0 warnings.
- [ ] `dotnet run --project infra/WopiHost.AppHost` with default config (no flag) — verify Collabora resource is **not** added and existing flow is unchanged.
- [ ] Set `"AppHost": { "UseCollabora": true }` in `infra/WopiHost.AppHost/appsettings.Development.json`, run AppHost, browse to `http://localhost:6000`, open a `.docx` from `sample/wopi-docs`, verify the iframe loads via `localhost:9980` and edits round-trip.
- [ ] On Linux Docker (no Docker Desktop): confirm `host.docker.internal:host-gateway` workaround documented in README is correct.

## Follow-up

A monthly remote agent has been scheduled to check Docker Hub for newer stable `collabora/code` tags and open a follow-up PR pinning to the latest one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)