### PR TITLE
fix(apphost): force NetZone=ExternalHttp when Collabora is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,8 +266,11 @@ host-issued JWT access tokens — the whole flow.
 | Collabora → WopiHost | `http://host.docker.internal:5000` | `host.docker.internal` is the Docker Desktop alias for the host machine — the WOPI host runs on the host, not in a container. |
 | WopiHost → Collabora (discovery) | `http://localhost:9980/hosting/discovery` | Server-to-server, fetched at startup. |
 
-The AppHost overrides `Wopi:ClientUrl` and `Wopi:HostUrl` env vars on the affected projects when
-`UseCollabora=true`, so no manual `appsettings.json` edits are needed.
+The AppHost overrides `Wopi:ClientUrl`, `Wopi:HostUrl`, and `Wopi:Discovery:NetZone` env vars
+on the affected projects when `UseCollabora=true`, so no manual `appsettings.json` edits are
+needed. (`NetZone` is forced to `ExternalHttp` because Collabora's `/hosting/discovery` XML
+emits only a single `<net-zone name="external-http">` — leaving the default `ExternalHttps`
+filters every action and icon out, and files render with the generic icon and disabled buttons.)
 
 **Linux Docker** (not Docker Desktop): `host.docker.internal` is not auto-mapped. Run the engine
 with `--add-host=host.docker.internal:host-gateway` or change the override URLs in

--- a/infra/WopiHost.AppHost/Program.cs
+++ b/infra/WopiHost.AppHost/Program.cs
@@ -57,9 +57,13 @@ var wopiHostWeb = builder.AddProject<Projects.WopiHost_Web>("wopihost-web")
 if (useCollabora)
 {
     // The frontend embeds Collabora; the iframe URL must come from Collabora's discovery, and
-    // the WopiSrc it carries must resolve from inside the Collabora container.
+    // the WopiSrc it carries must resolve from inside the Collabora container. Collabora's
+    // discovery XML emits a single <net-zone name="external-http"> only — defaulting to
+    // ExternalHttps (as appsettings does for OOS/M365) silently filters every action and icon
+    // out, so files render with the generic icon and edit/view buttons stay disabled.
     wopiHostWeb.WithEnvironment("Wopi__ClientUrl", "http://localhost:9980")
-               .WithEnvironment("Wopi__HostUrl", "http://host.docker.internal:5000");
+               .WithEnvironment("Wopi__HostUrl", "http://host.docker.internal:5000")
+               .WithEnvironment("Wopi__Discovery__NetZone", "ExternalHttp");
 }
 
 // Add Validator project for testing


### PR DESCRIPTION
## Summary

Follow-up to [#327](https://github.com/petrsvihlik/WopiHost/pull/327). When testing the new `AppHost:UseCollabora` flag end-to-end, the `wopihost-web` file list rendered every file with the **generic icon** and **all view/edit actions disabled**, even though Collabora's `/hosting/discovery` XML returned the full set of `<action>` entries with `urlsrc` and `favIconUrl`.

Root cause: Collabora emits a single `<net-zone name="external-http">` (no HTTPS variant). The default `Wopi:Discovery:NetZone=ExternalHttps` (which is correct for OOS / M365 for the Web) then matches zero zones, `WopiDiscoverer.GetAppsAsync` returns empty, and downstream lookups (`GetUrlTemplateAsync`, `GetApplicationFavIconAsync`) all return null.

Fix: when `UseCollabora=true`, the AppHost now also forces `Wopi__Discovery__NetZone=ExternalHttp` on `wopihost-web`, alongside the existing `ClientUrl` / `HostUrl` overrides. Default flow (Collabora disabled) is unchanged.

README updated to call out the discovery-zone difference.

## Test plan

- [x] `dotnet build infra/WopiHost.AppHost` — clean.
- [ ] With `AppHost:UseCollabora=true`, run AppHost, browse to `https://localhost:6001`, verify Writer/Calc/Impress icons appear and view/edit buttons enable on the corresponding files.
- [ ] Open a `.docx` → iframe loads Collabora → edits round-trip back through the WOPI host.
- [ ] With `AppHost:UseCollabora` unset, confirm `wopihost-web` still uses `ExternalHttps` (default) — no regression to the OOS / M365 flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)