### PR TITLE
fix(apphost): allow disabling WOPI proof validation for Collabora dev loop

### DIFF
--- a/infra/WopiHost.AppHost/Program.cs
+++ b/infra/WopiHost.AppHost/Program.cs
@@ -43,8 +43,14 @@ if (useCollabora)
            .WithEnvironment("extra_params", "--o:ssl.enable=false --o:ssl.termination=false")
            .WithHttpEndpoint(targetPort: 9980, port: 9980, name: "collabora");
 
-    // Backend fetches /hosting/discovery from Collabora at startup.
-    wopiHost.WithEnvironment("Wopi__ClientUrl", "http://localhost:9980");
+    // Backend fetches /hosting/discovery from Collabora at startup. Collabora does not sign WOPI
+    // callbacks with proof keys (those are an OOS / M365-for-the-Web feature) and emits no
+    // <proof-key> element in discovery, so the default WopiProofValidator rejects every request
+    // and CheckFileInfo 500s — the editor loads but the document never appears. The sample WOPI
+    // host honours Wopi:Security:DisableProofValidation in Development to swap in a no-op
+    // validator; refuse to run in non-Development if the flag is set.
+    wopiHost.WithEnvironment("Wopi__ClientUrl", "http://localhost:9980")
+            .WithEnvironment("Wopi__Security__DisableProofValidation", "true");
 }
 
 // Add WopiHost.Web frontend that depends on WopiHost

--- a/sample/WopiHost/Program.cs
+++ b/sample/WopiHost/Program.cs
@@ -1,4 +1,6 @@
-﻿using Serilog;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Serilog;
 using Serilog.Events;
 using WopiHost.Abstractions;
 using WopiHost.Core.Models;
@@ -90,6 +92,23 @@ public partial class Program
                     : Convert.FromBase64String(configured);
             });
 
+            // Dev-only escape hatch for WOPI clients that do not sign requests with proof keys
+            // (e.g. Collabora Online — proof keys are an OOS / M365-for-the-Web feature). Without
+            // this, every WOPI callback 500s in WopiOriginValidationActionFilter because
+            // sourceProofKeys.Value is null. Refuses to enable outside Development so a stray
+            // production config cannot silently disable signature checking.
+            if (builder.Configuration.GetValue<bool>("Wopi:Security:DisableProofValidation"))
+            {
+                if (!builder.Environment.IsDevelopment())
+                {
+                    throw new InvalidOperationException(
+                        "Wopi:Security:DisableProofValidation can only be enabled in the Development environment.");
+                }
+                Log.Warning("WOPI proof validation is DISABLED. This is a development-only setting.");
+                builder.Services.RemoveAll<IWopiProofValidator>();
+                builder.Services.AddSingleton<IWopiProofValidator, NoOpProofValidator>();
+            }
+
             var app = builder.Build();
 
             // Configure the HTTP request pipeline
@@ -138,4 +157,15 @@ public partial class Program
             Log.CloseAndFlush();
         }
     }
+}
+
+/// <summary>
+/// Dev-only no-op proof validator used when <c>Wopi:Security:DisableProofValidation</c> is set
+/// (typically with the AppHost's <c>UseCollabora</c> flag, since Collabora does not sign WOPI
+/// callbacks with proof keys). Real hosts must keep <c>WopiProofValidator</c>.
+/// </summary>
+internal sealed class NoOpProofValidator : IWopiProofValidator
+{
+    public Task<bool> ValidateProofAsync(HttpContext httpContext, string accessToken)
+        => Task.FromResult(true);
 }


### PR DESCRIPTION
## Summary

Follow-up to [#327](https://github.com/petrsvihlik/WopiHost/pull/327) / [#328](https://github.com/petrsvihlik/WopiHost/pull/328). When testing the new `AppHost:UseCollabora` flag end-to-end, the Collabora editor loaded its iframe shell but the document never appeared. Collabora's logs:

```
WOPI::CheckFileInfo returned 500 (Internal Server Error)
  for URI [http://host.docker.internal:5000/wopi/files/.../...&access_token=...]
Failed or timed-out CheckFileInfo
CheckFileInfo failed for [...], State::Fail
```

Root cause: `WopiOriginValidationActionFilter` rejects the request because Collabora does not sign WOPI callbacks with proof keys (proof keys are an OOS / M365-for-the-Web feature), and Collabora's `/hosting/discovery` XML emits no `<proof-key>` element. `WopiProofValidator.ValidateProofAsync` then early-exits via `sourceProofKeys.Value is null` → returns false → 500.

## Fix

`sample/WopiHost` now honours a new `Wopi:Security:DisableProofValidation` config flag. When set, the sample swaps `IWopiProofValidator` for a NoOp implementation — matching the pattern `WopiBackendFactory` already uses for integration tests. Two guardrails:

1. The flag is **refused** (throws on startup) in any environment other than `Development`, so a stray production config cannot silently disable signature checking.
2. A loud `WARN`-level Serilog message fires at startup whenever the no-op is registered.

The AppHost sets the env var automatically when `AppHost:UseCollabora=true`, so the end-to-end Collabora loop works with no manual appsettings edits.

## Why not change the library

`WopiHost.Core` stays strict. Production hosts that integrate with OOS / M365 must continue to validate proof keys. The escape hatch lives only in `sample/WopiHost` (which is dev-oriented anyway) and is fully gated.

## Test plan

- [x] `dotnet build infra/WopiHost.AppHost` — clean.
- [ ] With `AppHost:UseCollabora=true`, run AppHost, browse to the web sample, open a `.docx` → document content appears in the Collabora iframe and edits round-trip back through the host (no 500s in the WOPI host logs).
- [ ] Without the flag (default, OOS / M365 case): proof validation still strictly enforced — confirm `WopiProofValidator` is still the registered `IWopiProofValidator`.
- [ ] With `Wopi:Security:DisableProofValidation=true` in a non-Development environment: host fails to start with a clear `InvalidOperationException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)