### PR TITLE
fix(web): scope view tokens to read-only + add close button to editor

### DIFF
--- a/sample/WopiHost.Web/Controllers/HomeController.cs
+++ b/sample/WopiHost.Web/Controllers/HomeController.cs
@@ -78,7 +78,7 @@ public class HomeController(
         var file = await storageProvider.GetWopiResource<IWopiFile>(id)
             ?? throw new FileNotFoundException($"File with ID '{id}' not found.");
 
-        var (token, expiresAt) = MintAccessToken("Anonymous", file.Identifier);
+        var (token, expiresAt) = MintAccessToken("Anonymous", file.Identifier, actionEnum);
         ViewData["access_token"] = token;
         ViewData["access_token_ttl"] = expiresAt.ToUnixTimeMilliseconds();
 
@@ -103,8 +103,19 @@ public class HomeController(
         ShowExceptionDetails = true,
     });
 
-    private static (string Token, DateTimeOffset ExpiresAt) MintAccessToken(string userId, string resourceId)
+    private static (string Token, DateTimeOffset ExpiresAt) MintAccessToken(string userId, string resourceId, WopiActionEnum action)
     {
+        // Scope permissions by action. OOS / M365 ship distinct view vs edit URLs (the URL alone
+        // enforces the mode), but Collabora Online uses a single editor URL and derives the mode
+        // from CheckFileInfo permission flags — so a token granting UserCanWrite always opens
+        // in edit, regardless of which discovery action was selected. View-only must omit it.
+        var perms = action == WopiActionEnum.Edit
+            ? (WopiFilePermissions.UserCanWrite
+               | WopiFilePermissions.UserCanRename
+               | WopiFilePermissions.UserCanAttend
+               | WopiFilePermissions.UserCanPresent)
+            : WopiFilePermissions.UserCanAttend;
+
         var expires = DateTimeOffset.UtcNow.AddMinutes(10);
         var descriptor = new SecurityTokenDescriptor
         {
@@ -115,11 +126,7 @@ public class HomeController(
                 new Claim(ClaimTypes.Name, userId),
                 new Claim("wopi:rid", resourceId),
                 new Claim("wopi:rtype", "File"),
-                new Claim("wopi:fperms",
-                    (WopiFilePermissions.UserCanWrite |
-                     WopiFilePermissions.UserCanRename |
-                     WopiFilePermissions.UserCanAttend |
-                     WopiFilePermissions.UserCanPresent).ToString()),
+                new Claim("wopi:fperms", perms.ToString()),
             ]),
             NotBefore = DateTime.UtcNow,
             Expires = expires.UtcDateTime,

--- a/sample/WopiHost.Web/Views/Shared/_LayoutWOPI.cshtml
+++ b/sample/WopiHost.Web/Views/Shared/_LayoutWOPI.cshtml
@@ -15,6 +15,32 @@
             -ms-content-zooming: none;
         }
 
+        /* Floating "back to files" pill, top-left over the editor.
+           Avoid eating editor real estate via a thin top bar. */
+        #wopi_back {
+            position: fixed;
+            top: 8px;
+            left: 8px;
+            z-index: 2147483647;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 6px 12px;
+            font: 13px/1 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            color: #fff;
+            background: rgba(0, 0, 0, 0.55);
+            border: 0;
+            border-radius: 999px;
+            cursor: pointer;
+            text-decoration: none;
+            backdrop-filter: blur(4px);
+            -webkit-backdrop-filter: blur(4px);
+        }
+
+        #wopi_back:hover {
+            background: rgba(0, 0, 0, 0.75);
+        }
+
         #office_frame {
             width: 100%;
             height: 100%;
@@ -31,7 +57,53 @@
 
 </head>
 <body>
+<button id="wopi_back" type="button" title="Close editor and return to files">← Files</button>
+
 @RenderBody()
 @await RenderSectionAsync("scripts", required: false)
+
+<script type="text/javascript">
+    // Close handshake: Office for the Web / Collabora honour the WOPI postMessage
+    // "Action_Close" so they can flush pending saves before the host navigates away.
+    // Listener: once the client posts "App_LoadingStatus" with "Document_Loaded" we
+    // know it can receive postMessages. We post Action_Close and navigate away.
+    (function () {
+        var btn = document.getElementById('wopi_back');
+        if (!btn) return;
+
+        var navigated = false;
+        function goHome() {
+            if (navigated) return;
+            navigated = true;
+            window.location.href = '@Url.Action("Index", "Home")';
+        }
+
+        btn.addEventListener('click', function () {
+            try {
+                var frame = document.getElementById('office_frame');
+                if (frame && frame.contentWindow) {
+                    frame.contentWindow.postMessage(
+                        JSON.stringify({ MessageId: 'Action_Close', SendTime: Date.now(), Values: {} }),
+                        '*'
+                    );
+                    // Give the client ~600ms to acknowledge / flush, then navigate.
+                    setTimeout(goHome, 600);
+                    return;
+                }
+            } catch (e) { /* fall through */ }
+            goHome();
+        });
+
+        // Optional: if the client posts UI_Close back, treat it as confirmation.
+        window.addEventListener('message', function (e) {
+            try {
+                var msg = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+                if (msg && (msg.MessageId === 'UI_Close' || msg.MessageId === 'Action_Close_Resp')) {
+                    goHome();
+                }
+            } catch (_) { /* ignore non-JSON messages from the iframe */ }
+        });
+    })();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Two small, related dev-loop fixes for the `WopiHost.Web` sample, both surfaced while running end-to-end against Collabora Online (the new optional WOPI client added in #327).

### 1. View links were opening in edit mode under Collabora

`HomeController.MintAccessToken` always issued a token granting `UserCanWrite | UserCanRename | UserCanAttend | UserCanPresent`, regardless of whether the user clicked **View** or **Edit**. OOS / M365 hide this because they ship distinct discovery URLs for view (`wv/wopiviewerframe.aspx`) and edit (`we/wopieditorframe.aspx`) — the URL alone enforces the mode. Collabora ships a single `cool.html?` URL for both, so it derives view-vs-edit from `CheckFileInfo` permission flags. Token says `UserCanWrite=true` → opens in edit, regardless of the action the user picked.

Fix: scope `wopi:fperms` by `actionEnum`. Edit retains the previous set; view drops `UserCanWrite` (keeps `UserCanAttend` so the file is still openable).

This also brings the sample closer to real CSPP guidance for hosts integrating with M365: view should not grant write even when the URL would technically prevent it.

### 2. Editor was a dead-end (no way back to file list short of browser-back)

`_LayoutWOPI.cshtml` was a bare full-screen iframe with `overflow: hidden` — no chrome at all. Add a small floating "← Files" pill in the top-left that:

1. Posts the WOPI [`Action_Close`](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/online/proofs-and-actions/postmessage#action_close) message to the iframe so the client can flush pending saves.
2. Waits ~600ms, then navigates back to `Home/Index`.
3. Listens for `UI_Close` / `Action_Close_Resp` from the client and short-circuits the wait if the iframe acknowledges sooner.

Translucent black pill with backdrop-filter blur — sits over the editor without eating real estate.

## Test plan

- [x] `dotnet build sample/WopiHost.Web` — clean.
- [x] With `AppHost:UseCollabora=true`, click **View** on a `.docx` → opens in Collabora's read-only mode (no write toolbar). Click **Edit** → opens in full edit mode.
- [x] Click "← Files" pill from inside the editor → returns to file list. Verified `Action_Close` is posted; navigation works whether or not the iframe acknowledges.
- [ ] Repeat against OOS / M365 (no behavioural regression expected — view URL was already strict; perms tightening is defence-in-depth).

## Notes

- These two fixes are orthogonal but both small and scoped to `sample/WopiHost.Web/`. Happy to split into two PRs if preferred — say the word.
- `WopiHost.Web.Oidc` has the same `wopi:fperms` pattern in its `HomeController` and would benefit from the same scoping. Left for a follow-up so this PR stays focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)