### PR TITLE
docs(memory-lock): warn about IIS app-pool recycling

### DIFF
--- a/src/WopiHost.MemoryLockProvider/README.md
+++ b/src/WopiHost.MemoryLockProvider/README.md
@@ -8,6 +8,8 @@ Backed by a static `ConcurrentDictionary<string, WopiLockInfo>`. Locks auto-expi
 
 Use it for development, single-instance hosts, and tests. **Don't** use it for multi-instance deployments — locks are not shared across processes and are lost on restart.
 
+> **IIS / app-pool recycling.** "Single-instance" includes single-worker IIS sites only as long as the app pool stays warm. Recycles, idle shutdowns, and overlapped recycling all wipe the in-memory store, which surfaces as *"Sorry, you cannot edit this document with others"* on the next open of a previously-locked file (the WOPI client still holds the old lock id, the host no longer recognises it). For IIS — and any host with a non-trivial recycle policy — use a distributed provider such as [`WopiHost.AzureLockProvider`](../WopiHost.AzureLockProvider/README.md).
+
 ## Install
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds a callout in [`src/WopiHost.MemoryLockProvider/README.md`](src/WopiHost.MemoryLockProvider/README.md) explaining the IIS app-pool recycling failure mode and pointing to `WopiHost.AzureLockProvider` as the distributed alternative.

## Context

Issue #159 reports *"Sorry, you cannot edit this document with others"* on the second edit of Word/PPTX after IIS deployment. The smell fits exactly with the in-memory provider losing state across IIS app-pool recycles (Excel survives because Cobalt co-authoring locks differently). The README already says "don't use for multi-instance," but doesn't call out the IIS recycle case explicitly — and that's the trap the user hit.

Closing #159 with a pointer to this PR.

## Test plan

- [ ] Render the README on GitHub and confirm the blockquote / link to AzureLockProvider resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)