### PR TITLE
ci: report public API breaks on PRs and auto-bump release baseline

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: read
   id-token: write # Required for OIDC
+  pull-requests: write # Required for the api-compat sticky comment
 
 jobs:
   approve:
@@ -67,3 +68,146 @@ jobs:
     #  uses: fossa-contrib/fossa-action@v1
     #  with:
     #    fossa-api-key: ${{ secrets.FOSSA_API_KEY }}
+
+  api-compat:
+    name: API Compatibility
+    runs-on: ubuntu-latest
+    needs: [approve]
+    environment:
+      name: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'Integrate Pull Request' || '' }}
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 1
+    - name: Setup .NET 8.0
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: '8.0.x'
+    - name: Setup .NET 9.0
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: '9.0.x'
+    - name: Setup .NET 10.0
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: '10.0.x'
+    - name: Set Cobalt packages token
+      run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> $GITHUB_ENV
+    - name: Pack PR nupkgs
+      # Use a high version so AssemblyVersion sorts above any baseline release (avoids CP0003 noise).
+      # PackageValidation is intentionally disabled here — we run ApiCompat directly below.
+      run: |
+        dotnet pack --configuration Release \
+          -p:ContinuousIntegrationBuild=true \
+          -p:Version=99.99.99 \
+          -p:EnablePackageValidation=false \
+          --output ./artifacts/new
+    - name: Install Microsoft.DotNet.ApiCompat.Tool
+      run: dotnet tool install --global Microsoft.DotNet.ApiCompat.Tool
+    - name: Run ApiCompat against latest released packages
+      id: apicompat
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p ./artifacts/baseline
+
+        PACKAGES=(
+          "WopiHost.Abstractions"
+          "WopiHost.Core"
+          "WopiHost.Discovery"
+          "WopiHost.Url"
+          "WopiHost.FileSystemProvider"
+          "WopiHost.MemoryLockProvider"
+          "WopiHost.AzureStorageProvider"
+          "WopiHost.AzureLockProvider"
+        )
+
+        REPORT_FILE="$GITHUB_WORKSPACE/apicompat-report.md"
+        {
+          echo "<!-- apicompat-report -->"
+          echo "## API Compatibility Report"
+          echo ""
+          echo "Compared this PR's packed assemblies against the latest stable release on [NuGet.org](https://www.nuget.org/packages?q=WopiHost) for each library. This check is **informational only** — intentional breaks at major version bumps are expected."
+          echo ""
+        } > "$REPORT_FILE"
+
+        ANY_DIFFS=0
+
+        for pkg in "${PACKAGES[@]}"; do
+          pkg_lower="$(echo "$pkg" | tr '[:upper:]' '[:lower:]')"
+
+          # Find the freshly-packed nupkg.
+          new_nupkg="$(ls ./artifacts/new/${pkg}.99.99.99.nupkg 2>/dev/null || true)"
+          if [[ -z "$new_nupkg" ]]; then
+            echo "### :grey_question: ${pkg}" >> "$REPORT_FILE"
+            echo "_No nupkg produced for this package — skipped._" >> "$REPORT_FILE"
+            echo "" >> "$REPORT_FILE"
+            continue
+          fi
+
+          # Resolve latest stable on NuGet.org (filter out prereleases by '-').
+          versions_json="$(curl -fsSL "https://api.nuget.org/v3-flatcontainer/${pkg_lower}/index.json" || echo '{"versions":[]}')"
+          baseline_version="$(echo "$versions_json" | grep -oE '"[0-9][^"]+"' | tr -d '"' | grep -v -- '-' | tail -n 1 || true)"
+
+          if [[ -z "$baseline_version" ]]; then
+            echo "### :grey_question: ${pkg}" >> "$REPORT_FILE"
+            echo "_No prior stable release on NuGet.org — skipped._" >> "$REPORT_FILE"
+            echo "" >> "$REPORT_FILE"
+            continue
+          fi
+
+          # Download baseline nupkg.
+          baseline_nupkg="./artifacts/baseline/${pkg}.${baseline_version}.nupkg"
+          curl -fsSL \
+            "https://api.nuget.org/v3-flatcontainer/${pkg_lower}/${baseline_version}/${pkg_lower}.${baseline_version}.nupkg" \
+            -o "$baseline_nupkg"
+
+          # Run apicompat. Note: <package> is positional, --baseline-package is named, --run-api-compat is required.
+          # The tool installs as 'apicompat' (not 'dotnet apicompat') and exits 0 on both clean and break
+          # cases; detect findings via output text.
+          set +e
+          output="$(apicompat package "$new_nupkg" \
+            --baseline-package "$baseline_nupkg" \
+            --run-api-compat \
+            --verbosity Normal 2>&1)"
+          set -e
+
+          if grep -Eq '^(CP|PKV)[0-9]+:' <<< "$output"; then
+            ANY_DIFFS=1
+            {
+              echo "### :warning: ${pkg} vs \`${baseline_version}\`"
+              echo "<details><summary>API differences found — click to expand</summary>"
+              echo ""
+              echo '```'
+              echo "${output}"
+              echo '```'
+              echo ""
+              echo "</details>"
+              echo ""
+            } >> "$REPORT_FILE"
+          else
+            {
+              echo "### :white_check_mark: ${pkg} vs \`${baseline_version}\`"
+              echo "No public API breaking changes detected."
+              echo ""
+            } >> "$REPORT_FILE"
+          fi
+        done
+
+        {
+          echo "---"
+          if [[ $ANY_DIFFS -eq 0 ]]; then
+            echo "_No API differences detected across any package._"
+          else
+            echo "_Diagnostic IDs starting with \`CP\` are assembly-level diffs; \`PKV\` are package-shape diffs. See the [ApiCompat docs](https://learn.microsoft.com/dotnet/fundamentals/apicompat/diagnostic-ids) for details._"
+          fi
+        } >> "$REPORT_FILE"
+
+        # Surface in the job log too.
+        cat "$REPORT_FILE"
+    - name: Post sticky PR comment
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: apicompat-report
+        path: apicompat-report.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   id-token: write # Required for OIDC
+  pull-requests: write # Required for the baseline-bump PR
 
 jobs:
   build:
@@ -68,3 +69,56 @@ jobs:
         args: artifacts/package/release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  bump-baseline:
+    name: Bump PackageValidationBaselineVersion
+    needs: [build]
+    if: ${{ !github.event.release.prerelease && !github.event.release.draft }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: master
+        fetch-depth: 0
+    - name: Extract version from tag
+      id: get_version
+      run: |
+        REF="${GITHUB_REF#refs/tags/}"
+        echo "version-without-v=${REF#v}" >> $GITHUB_OUTPUT
+    - name: Update PackageValidationBaselineVersion
+      id: bump
+      shell: bash
+      run: |
+        set -euo pipefail
+        NEW_VERSION="${{ steps.get_version.outputs.version-without-v }}"
+        FILE="Directory.Build.props"
+
+        CURRENT="$(sed -n 's:.*<PackageValidationBaselineVersion>\([^<]*\)</PackageValidationBaselineVersion>.*:\1:p' "$FILE" | head -n 1)"
+        echo "Current baseline: ${CURRENT:-<unset>}"
+        echo "New baseline:     ${NEW_VERSION}"
+
+        if [[ "$CURRENT" == "$NEW_VERSION" ]]; then
+          echo "Baseline already matches the released version — no PR needed."
+          echo "changed=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        sed -i "s|<PackageValidationBaselineVersion>[^<]*</PackageValidationBaselineVersion>|<PackageValidationBaselineVersion>${NEW_VERSION}</PackageValidationBaselineVersion>|g" "$FILE"
+        echo "changed=true" >> $GITHUB_OUTPUT
+    - name: Open PR with the bump
+      if: steps.bump.outputs.changed == 'true'
+      uses: peter-evans/create-pull-request@v7
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        branch: chore/bump-package-validation-baseline-${{ steps.get_version.outputs.version-without-v }}
+        base: master
+        commit-message: "chore: bump PackageValidationBaselineVersion to ${{ steps.get_version.outputs.version-without-v }}"
+        title: "chore: bump PackageValidationBaselineVersion to ${{ steps.get_version.outputs.version-without-v }}"
+        body: |
+          Auto-generated after the [${{ github.event.release.tag_name }}](${{ github.event.release.html_url }}) release.
+
+          Bumps `PackageValidationBaselineVersion` in `Directory.Build.props` so the SDK's pack-time package validator compares against the version that was just published to NuGet.org.
+        labels: |
+          chore
+          automated
+        delete-branch: true

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,7 @@
 	</PropertyGroup>
 
 	<!-- Package Validation Configuration for NuGet packages -->
+	<!-- Baseline is auto-bumped by .github/workflows/release.yml after each stable release. -->
 	<PropertyGroup Condition="$(IsPackable) == 'true' AND $(PackageId) != ''">
 		<EnablePackageValidation>true</EnablePackageValidation>
 		<!-- Baseline used to detect public-API breaks against the last released version.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.203" PrivateAssets="All" />
-    <PackageVersion Include="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" PrivateAssets="All" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.14.9" />
     <PackageVersion Include="Scrutor" Version="7.0.0" />
     <PackageVersion Include="System.Linq" Version="4.3.0" />

--- a/PACKAGE_VALIDATION_IMPLEMENTATION.md
+++ b/PACKAGE_VALIDATION_IMPLEMENTATION.md
@@ -1,121 +1,48 @@
-# Package Validation Implementation for WopiHost
+# Package & API Compatibility Validation
 
-## Overview
+WopiHost validates the public API surface of its NuGet packages on two layers.
 
-This document describes the implementation of .NET Package Validation tooling for the WopiHost solution. Package Validation helps ensure that NuGet packages are consistent, well-formed, and free from breaking changes across versions and target frameworks.
+## 1. Pack-time validation (release safety net)
 
-## What Was Implemented
-
-### 1. Package Validation SDK Integration
-
-Added the `Microsoft.DotNet.PackageValidation` package to all NuGet package projects:
-
-- **WopiHost.Abstractions**
-- **WopiHost.Core** 
-- **WopiHost.Discovery**
-- **WopiHost.FileSystemProvider**
-- **WopiHost.MemoryLockProvider**
-- **WopiHost.Url**
-
-### 2. Global Configuration
-
-#### Directory.Build.props
-Added global package validation configuration that applies to all packable projects:
+`Directory.Build.props` enables the SDK-built-in package validator for every packable project:
 
 ```xml
-<!-- Package Validation Configuration for NuGet packages -->
 <PropertyGroup Condition="$(IsPackable) == 'true' AND $(PackageId) != ''">
     <EnablePackageValidation>true</EnablePackageValidation>
-    <!-- Set baseline version to a reasonable previous version for breaking change detection -->
-    <!-- This should be updated to the actual previous stable version before release -->
-    <PackageValidationBaselineVersion>4.0.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>6.0.0</PackageValidationBaselineVersion>
 </PropertyGroup>
 ```
 
-#### Directory.Packages.props
-Added the Package Validation package version:
+This runs after `dotnet pack` and **fails the release build** if the new package introduces breaking changes versus `PackageValidationBaselineVersion` on NuGet.org. It also enforces that all TFMs (`net8.0`, `net9.0`, `net10.0`) expose the same public surface.
 
-```xml
-<PackageVersion Include="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" PrivateAssets="All" />
-```
+`PackageValidationBaselineVersion` is auto-bumped to the latest stable release by [`.github/workflows/release.yml`](.github/workflows/release.yml) — after a successful publish-to-NuGet, that workflow opens a PR updating the value.
 
-### 3. Project-Level Configuration
+> Since .NET 6.0.100 the validator ships in the SDK; no `PackageReference` is required.
 
-Each NuGet package project now includes:
+## 2. PR-time API-compat report (informational)
 
-```xml
-<PackageReference Include="Microsoft.DotNet.PackageValidation" PrivateAssets="All" />
-```
+[`.github/workflows/pull_request.yml`](.github/workflows/pull_request.yml) runs the `Microsoft.DotNet.ApiCompat.Tool` global tool against every packable project on each PR. For each package it:
 
-## Benefits
+1. Packs the PR's nupkg.
+2. Downloads the latest stable nupkg from NuGet.org.
+3. Diffs the two with `dotnet apicompat package`.
+4. Aggregates findings into a sticky markdown comment on the PR.
 
-### 1. Framework Compatibility Validation
-- Ensures that all target frameworks (.NET 8, 9, 10) expose the same public APIs
-- Catches issues where different target frameworks have incompatible public APIs
-- Validates that code compiled against one framework can run against another
+The job is **non-blocking** — intentional breaks at major version bumps are expected. The comment is purely informational so reviewers can see the impact of a change before approving.
 
-### 2. Breaking Change Detection
-- Compares new releases against previous stable versions
-- Catches issues like:
-  - Adding default parameters (binary breaking change)
-  - Changing constant values
-  - Removing public APIs
-  - Changing method signatures
+## Packages covered
 
-### 3. Cross-Platform Consistency
-- Ensures packages work correctly across different .NET versions
-- Validates runtime-specific implementations are compatible with compile-time assemblies
-
-## Validation Types
-
-The implementation includes three types of validation:
-
-1. **Compatible Framework Validation**: Ensures .NET 8, 9, and 10 targets are compatible
-2. **Baseline Version Validation**: Compares against version 4.0.0 (to be updated before release)
-3. **Runtime Validation**: Ensures different runtime implementations are compatible
-
-## CI/CD Integration
-
-The package validation is fully integrated with the existing CI/CD pipeline:
-
-- ✅ Works with `dotnet build --configuration Release /p:ContinuousIntegrationBuild=true`
-- ✅ Works with `dotnet pack --configuration Release --include-symbols`
-- ✅ Compatible with existing GitHub Actions workflows
-- ✅ No changes required to existing CI/CD configuration
-
-## Testing Results
-
-All tests passed successfully:
-
-- ✅ Build succeeds for all target frameworks
-- ✅ Package creation succeeds with validation
-- ✅ CI simulation build succeeds
-- ✅ All 6 NuGet packages created successfully with symbols
-
-## Usage
-
-Package validation runs automatically during:
-
-1. **Build**: `dotnet build --configuration Release`
-2. **Pack**: `dotnet pack --configuration Release`
-3. **CI/CD**: All existing GitHub Actions workflows
-
-## Configuration Notes
-
-### Baseline Version
-The baseline version is currently set to `4.0.0` in `Directory.Build.props`. This should be updated to the actual previous stable version before each release.
-
-### Package Version
-Using preview version `1.0.0-preview.7.21379.12` of the Package Validation SDK. This is the latest available version that works with the current .NET SDK.
-
-## Future Considerations
-
-1. **Update Baseline Version**: Before each release, update `PackageValidationBaselineVersion` to the previous stable version
-2. **Monitor Package Validation SDK**: Watch for stable releases of the Package Validation SDK
-3. **Custom Validation Rules**: Consider adding custom validation rules for WopiHost-specific requirements
+| Package | On NuGet | Validated |
+| --- | --- | --- |
+| WopiHost.Abstractions | ✅ | ✅ |
+| WopiHost.Core | ✅ | ✅ |
+| WopiHost.Discovery | ✅ | ✅ |
+| WopiHost.Url | ✅ | ✅ |
+| WopiHost.FileSystemProvider | ✅ | ✅ |
+| WopiHost.MemoryLockProvider | ✅ | ✅ |
+| WopiHost.Cobalt | ❌ (`IsPackable=false`) | n/a |
 
 ## References
 
-- [Microsoft Package Validation Documentation](https://devblogs.microsoft.com/dotnet/package-validation/)
-- [Package Validation Overview](https://learn.microsoft.com/dotnet/fundamentals/apicompat/package-validation/overview)
-- [Baseline Version Validator](https://learn.microsoft.com/dotnet/fundamentals/apicompat/package-validation/baseline-version-validator)
+- [Package Validation overview](https://learn.microsoft.com/dotnet/fundamentals/apicompat/package-validation/overview)
+- [Microsoft.DotNet.ApiCompat.Tool](https://learn.microsoft.com/dotnet/fundamentals/apicompat/global-tool)

--- a/src/WopiHost.Abstractions/WopiHost.Abstractions.csproj
+++ b/src/WopiHost.Abstractions/WopiHost.Abstractions.csproj
@@ -41,7 +41,6 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.AspNetCore.Authorization" />
 		<PackageReference Include="Microsoft.IdentityModel.Tokens" />
-		<PackageReference Include="Microsoft.DotNet.PackageValidation" PrivateAssets="All" />
 	</ItemGroup>
 
 </Project>

--- a/src/WopiHost.AzureLockProvider/WopiHost.AzureLockProvider.csproj
+++ b/src/WopiHost.AzureLockProvider/WopiHost.AzureLockProvider.csproj
@@ -41,7 +41,6 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-		<PackageReference Include="Microsoft.DotNet.PackageValidation" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/WopiHost.AzureStorageProvider/WopiHost.AzureStorageProvider.csproj
+++ b/src/WopiHost.AzureStorageProvider/WopiHost.AzureStorageProvider.csproj
@@ -42,7 +42,6 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-		<PackageReference Include="Microsoft.DotNet.PackageValidation" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/WopiHost.Core/WopiHost.Core.csproj
+++ b/src/WopiHost.Core/WopiHost.Core.csproj
@@ -33,7 +33,6 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
 		<PackageReference Include="System.IdentityModel.Tokens.Jwt" />
-		<PackageReference Include="Microsoft.DotNet.PackageValidation" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/WopiHost.Discovery/WopiHost.Discovery.csproj
+++ b/src/WopiHost.Discovery/WopiHost.Discovery.csproj
@@ -35,7 +35,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
-		<PackageReference Include="Microsoft.DotNet.PackageValidation" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/WopiHost.FileSystemProvider/WopiHost.FileSystemProvider.csproj
+++ b/src/WopiHost.FileSystemProvider/WopiHost.FileSystemProvider.csproj
@@ -41,7 +41,6 @@
 		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
-		<PackageReference Include="Microsoft.DotNet.PackageValidation" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/WopiHost.MemoryLockProvider/WopiHost.MemoryLockProvider.csproj
+++ b/src/WopiHost.MemoryLockProvider/WopiHost.MemoryLockProvider.csproj
@@ -34,10 +34,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.DotNet.PackageValidation" PrivateAssets="All" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<ProjectReference Include="..\WopiHost.Abstractions\WopiHost.Abstractions.csproj" />
 	</ItemGroup>
 

--- a/src/WopiHost.Url/WopiHost.Url.csproj
+++ b/src/WopiHost.Url/WopiHost.Url.csproj
@@ -35,7 +35,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
-		<PackageReference Include="Microsoft.DotNet.PackageValidation" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary

Closes #153.

Two-layer setup for tracking public-API impact across releases:

- **PR-time, informational** — new `api-compat` job in `pull_request.yml` packs the PR's nupkgs, diffs each one against the latest stable release on NuGet.org with `Microsoft.DotNet.ApiCompat.Tool`, and posts a sticky markdown comment summarizing CP*/PKV* findings. Non-blocking — major-version breaks are expected.
- **Release-time, automated** — new `bump-baseline` job in `release.yml` opens a follow-up PR after each stable release, updating `PackageValidationBaselineVersion` in `Directory.Build.props` to the freshly published version. Drafts and prereleases skipped.

## Cleanup

- Remove obsolete `Microsoft.DotNet.PackageValidation` `PackageReference` items from every packable csproj — the validator has shipped in the SDK since 6.0.100, so a separate package reference is no longer required.
- Drop matching `PackageVersion` entry from `Directory.Packages.props`.
- Refresh `PACKAGE_VALIDATION_IMPLEMENTATION.md` to document the new two-layer setup.

## Adjustments during rebase onto current master

- `PackageValidationBaselineVersion` left at master's `6.0.0` (the original commit's `4.0.0 → 5.1.0` bump is moot now).
- `api-compat` job env var changed from the obsolete `MYGET_FEED` to `COBALT_PACKAGES_TOKEN` — the Cobalt feed migration ([#320](https://github.com/petrsvihlik/WopiHost/pull/320)) landed after this branch was first authored.
- Stale `Microsoft.DotNet.PackageValidation` references also removed from `WopiHost.AzureStorageProvider` and `WopiHost.AzureLockProvider` csprojs (added later in master).

## Test plan

- [x] `dotnet build WOPI.slnx --configuration Release` — 0 warnings, 0 errors locally.
- [ ] CI build passes.
- [ ] `api-compat` job runs and posts the sticky report on this PR.