### PR TITLE
test(observability): isolate WopiTelemetryTests from cross-class meter pollution

### DIFF
--- a/test/WopiHost.Core.Tests/Infrastructure/WopiTelemetryTests.cs
+++ b/test/WopiHost.Core.Tests/Infrastructure/WopiTelemetryTests.cs
@@ -79,17 +79,19 @@ public sealed class WopiTelemetryTests : IDisposable
     [Fact]
     public void RecordOutcome_Success_TagsActivityAndIncrementsRequests()
     {
-        var measurements = CollectRequests();
-        using var activity = WopiTelemetry.StartActivity("PutFile", "file-1");
+        // Use a unique operation name so this test's measurements aren't intermixed with
+        // other tests publishing to the same static Meter when xUnit runs classes in parallel.
+        const string Op = nameof(RecordOutcome_Success_TagsActivityAndIncrementsRequests);
+        var measurements = CollectRequests(Op);
+        using var activity = WopiTelemetry.StartActivity(Op, "file-1");
 
-        WopiTelemetry.RecordOutcome(activity, "PutFile", WopiTelemetry.Outcomes.Success);
+        WopiTelemetry.RecordOutcome(activity, Op, WopiTelemetry.Outcomes.Success);
 
         Assert.NotNull(activity);
         Assert.Equal(WopiTelemetry.Outcomes.Success, activity.GetTagItem(WopiTelemetry.Tags.Outcome));
         Assert.Equal(ActivityStatusCode.Unset, activity.Status);
         var m = Assert.Single(measurements);
         Assert.Equal(1, m.value);
-        Assert.Contains(m.tags, t => t.Key == WopiTelemetry.Tags.Operation && (string?)t.Value == "PutFile");
         Assert.Contains(m.tags, t => t.Key == WopiTelemetry.Tags.Outcome && (string?)t.Value == WopiTelemetry.Outcomes.Success);
     }
 
@@ -108,35 +110,42 @@ public sealed class WopiTelemetryTests : IDisposable
     [Fact]
     public void RecordOutcome_LockMismatch_AlsoIncrementsLockConflicts()
     {
-        var requestMeasurements = CollectRequests();
-        var lockMeasurements = CollectLockConflicts();
-        using var activity = WopiTelemetry.StartActivity("Lock", "file-1");
+        const string Op = nameof(RecordOutcome_LockMismatch_AlsoIncrementsLockConflicts);
+        var requestMeasurements = CollectRequests(Op);
+        var lockMeasurements = CollectLockConflicts(Op);
+        using var activity = WopiTelemetry.StartActivity(Op, "file-1");
 
-        WopiTelemetry.RecordOutcome(activity, "Lock", WopiTelemetry.Outcomes.LockMismatch);
+        WopiTelemetry.RecordOutcome(activity, Op, WopiTelemetry.Outcomes.LockMismatch);
 
         Assert.Single(requestMeasurements);
         var lockHit = Assert.Single(lockMeasurements);
         Assert.Equal(1, lockHit.value);
-        Assert.Contains(lockHit.tags, t => t.Key == WopiTelemetry.Tags.Operation && (string?)t.Value == "Lock");
     }
 
     [Fact]
     public void RecordOutcome_NullActivity_StillIncrementsRequestsCounter()
     {
-        var measurements = CollectRequests();
+        const string Op = nameof(RecordOutcome_NullActivity_StillIncrementsRequestsCounter);
+        var measurements = CollectRequests(Op);
 
-        WopiTelemetry.RecordOutcome(activity: null, "GetFile", WopiTelemetry.Outcomes.Success);
+        WopiTelemetry.RecordOutcome(activity: null, Op, WopiTelemetry.Outcomes.Success);
 
         Assert.Single(measurements);
     }
 
-    private static List<(long value, IReadOnlyList<KeyValuePair<string, object?>> tags)> CollectRequests()
-        => CollectFromCounter(WopiTelemetry.Requests.Name);
+    private static List<(long value, IReadOnlyList<KeyValuePair<string, object?>> tags)> CollectRequests(string operationFilter)
+        => CollectFromCounter(WopiTelemetry.Requests.Name, operationFilter);
 
-    private static List<(long value, IReadOnlyList<KeyValuePair<string, object?>> tags)> CollectLockConflicts()
-        => CollectFromCounter(WopiTelemetry.LockConflicts.Name);
+    private static List<(long value, IReadOnlyList<KeyValuePair<string, object?>> tags)> CollectLockConflicts(string operationFilter)
+        => CollectFromCounter(WopiTelemetry.LockConflicts.Name, operationFilter);
 
-    private static List<(long value, IReadOnlyList<KeyValuePair<string, object?>> tags)> CollectFromCounter(string instrumentName)
+    /// <summary>
+    /// Collects measurements published to the named WopiTelemetry counter, filtered to those
+    /// whose <see cref="WopiTelemetry.Tags.Operation"/> tag equals <paramref name="operationFilter"/>.
+    /// The filter prevents cross-test pollution when xUnit runs other test classes concurrently
+    /// against the same static <see cref="Meter"/>.
+    /// </summary>
+    private static List<(long value, IReadOnlyList<KeyValuePair<string, object?>> tags)> CollectFromCounter(string instrumentName, string operationFilter)
     {
         var measurements = new List<(long, IReadOnlyList<KeyValuePair<string, object?>>)>();
         var listener = new MeterListener
@@ -151,7 +160,12 @@ public sealed class WopiTelemetryTests : IDisposable
         };
         listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) =>
         {
-            measurements.Add((value, tags.ToArray()));
+            var tagsArray = tags.ToArray();
+            var matches = tagsArray.Any(t => t.Key == WopiTelemetry.Tags.Operation && (string?)t.Value == operationFilter);
+            if (matches)
+            {
+                measurements.Add((value, tagsArray));
+            }
         });
         listener.Start();
         return measurements;


### PR DESCRIPTION
## Summary

Fixes the flaky CI failure in [`WopiTelemetryTests.RecordOutcome_Success_TagsActivityAndIncrementsRequests`](https://github.com/petrsvihlik/WopiHost/actions/runs/25446760300/job/74652869064) on master after #338 merged.

## Root cause

xUnit runs different test classes in parallel by default. `WopiTelemetry.Meter` is a static field — both `WopiTelemetryTests` and `WopiTelemetryActionFilterTests` publish to the same instrument. The `MeterListener` the test attaches catches measurements from *every* test that runs concurrently, so:

```
Expected: Single(measurements)
Actual:   3 entries — the test's own "PutFile/success" plus
          "TestAction/lock_mismatch" + "TestAction/error" leaking in from
          WopiTelemetryActionFilterTests
```

## Fix

Filter the collected measurements by the `wopi.operation` tag using a per-test operation name (`nameof(testMethod)`). Each test now sees only its own measurements regardless of cross-class parallelism.

No production code changes; test-only.

## Test plan

- [x] `dotnet test --filter FullyQualifiedName~WopiTelemetry` — all 22 telemetry tests pass on net10.0 locally
- [ ] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)