### PR TITLE
ci(dependabot): authenticate against the cobalt GitHub Packages feed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,23 @@
 version: 2
+
+# The repo's nuget.config registers a private GitHub Packages feed
+# (nuget.pkg.github.com/petrsvihlik) for Microsoft.CobaltCore. CI workflows
+# authenticate to it via the COBALT_PACKAGES_TOKEN Actions secret, but
+# Dependabot has its own separate secret store and won't see Actions secrets.
+# Add the same token at https://github.com/petrsvihlik/WopiHost/settings/secrets/dependabot
+# so the cobalt-github-packages registry below can authenticate.
+registries:
+  cobalt-github-packages:
+    type: nuget-feed
+    url: https://nuget.pkg.github.com/petrsvihlik/index.json
+    username: petrsvihlik
+    password: ${{secrets.COBALT_PACKAGES_TOKEN}}
+
 updates:
   - package-ecosystem: nuget
     directory: "/"
+    registries:
+      - cobalt-github-packages
     schedule:
       interval: daily
     open-pull-requests-limit: 20


### PR DESCRIPTION
## Summary

Fixes the Dependabot run that has been failing for several days with `private_source_authentication_failure`.

## Root cause

The repo's [`nuget.config`](nuget.config) registers `nuget.pkg.github.com/petrsvihlik` as a private feed for `Microsoft.CobaltCore`, authenticated via `COBALT_PACKAGES_TOKEN`. CI workflows pass that secret in via **Actions secrets**, but **Dependabot has its own separate secret store** and isn't told how to authenticate against the feed — so it tries the request unauthenticated and gets rejected:

```
2026/05/06 07:49:00 [844] Remote response: {"error":"Your request could not be authenticated by the GitHub Packages service. Please ensure your access token is valid and has the appropriate scopes configured."}
updater | 2026/05/06 07:49:05 ERROR Error type: private_source_authentication_failure
```

## Fix

Add a `registries:` block to [`.github/dependabot.yml`](.github/dependabot.yml) pointing at the cobalt feed and reference it from the nuget update config. The `${{secrets.COBALT_PACKAGES_TOKEN}}` reference resolves against Dependabot's own secret store — confirmed by the repo owner that the secret is already configured there.

## Failing run

https://github.com/petrsvihlik/WopiHost/actions/runs/25422893758/job/74569082943

## Test plan

- [ ] Once merged, the next Dependabot run should resolve the cobalt feed successfully (or fail with a different/no error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)