### PR TITLE
test(observability): IDE0028/IDE0039/IDE0042/IDE0059/IDE0350 cleanups in telemetry tests

### DIFF
--- a/test/WopiHost.Core.Tests/Infrastructure/WopiTelemetryActionFilterTests.cs
+++ b/test/WopiHost.Core.Tests/Infrastructure/WopiTelemetryActionFilterTests.cs
@@ -29,7 +29,7 @@ public sealed class WopiTelemetryActionFilterTests : IDisposable
         _listener = new ActivityListener
         {
             ShouldListenTo = source => source.Name == WopiTelemetry.Name,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            Sample = (ref _) => ActivitySamplingResult.AllData,
         };
         ActivitySource.AddActivityListener(_listener);
     }
@@ -48,7 +48,7 @@ public sealed class WopiTelemetryActionFilterTests : IDisposable
     {
         var result = (IActionResult)Activator.CreateInstance(resultType)!;
 
-        var (executing, recordedActivity) = await RunFilterAsync(controller: new FilesController(null!, null!), result);
+        var (_, recordedActivity) = await RunFilterAsync(controller: new FilesController(null!, null!), result);
 
         Assert.NotNull(recordedActivity);
         Assert.Equal(expectedOutcome, recordedActivity.GetTagItem(WopiTelemetry.Tags.Outcome));
@@ -166,24 +166,24 @@ public sealed class WopiTelemetryActionFilterTests : IDisposable
 
         var executingContext = new ActionExecutingContext(
             actionContext,
-            filters: new List<IFilterMetadata>(),
-            actionArguments: actionArguments ?? new Dictionary<string, object?>(),
+            filters: [],
+            actionArguments: actionArguments ?? [],
             controller: controller);
 
         Activity? captured = null;
-        ActionExecutionDelegate next = () =>
+        Task<ActionExecutedContext> Next()
         {
             captured = Activity.Current;
-            var executed = new ActionExecutedContext(actionContext, new List<IFilterMetadata>(), controller)
+            var executed = new ActionExecutedContext(actionContext, [], controller)
             {
                 Result = result,
                 Exception = exception,
             };
             return Task.FromResult(executed);
-        };
+        }
 
         var filter = new WopiTelemetryActionFilter(NullLogger<WopiTelemetryActionFilter>.Instance);
-        await filter.OnActionExecutionAsync(executingContext, next);
+        await filter.OnActionExecutionAsync(executingContext, Next);
         return (executingContext, captured);
     }
 }

--- a/test/WopiHost.Core.Tests/Infrastructure/WopiTelemetryTests.cs
+++ b/test/WopiHost.Core.Tests/Infrastructure/WopiTelemetryTests.cs
@@ -19,7 +19,7 @@ public sealed class WopiTelemetryTests : IDisposable
         _listener = new ActivityListener
         {
             ShouldListenTo = source => source.Name == WopiTelemetry.Name,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            Sample = (ref _) => ActivitySamplingResult.AllData,
         };
         ActivitySource.AddActivityListener(_listener);
     }
@@ -90,9 +90,9 @@ public sealed class WopiTelemetryTests : IDisposable
         Assert.NotNull(activity);
         Assert.Equal(WopiTelemetry.Outcomes.Success, activity.GetTagItem(WopiTelemetry.Tags.Outcome));
         Assert.Equal(ActivityStatusCode.Unset, activity.Status);
-        var m = Assert.Single(measurements);
-        Assert.Equal(1, m.value);
-        Assert.Contains(m.tags, t => t.Key == WopiTelemetry.Tags.Outcome && (string?)t.Value == WopiTelemetry.Outcomes.Success);
+        var (value, tags) = Assert.Single(measurements);
+        Assert.Equal(1, value);
+        Assert.Contains(tags, t => t.Key == WopiTelemetry.Tags.Outcome && (string?)t.Value == WopiTelemetry.Outcomes.Success);
     }
 
     [Fact]
@@ -118,8 +118,8 @@ public sealed class WopiTelemetryTests : IDisposable
         WopiTelemetry.RecordOutcome(activity, Op, WopiTelemetry.Outcomes.LockMismatch);
 
         Assert.Single(requestMeasurements);
-        var lockHit = Assert.Single(lockMeasurements);
-        Assert.Equal(1, lockHit.value);
+        var (lockValue, _) = Assert.Single(lockMeasurements);
+        Assert.Equal(1, lockValue);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Cosmetic-only test cleanups surfaced by the IDE analyzers in the new telemetry test files. No production code changes.

### `WopiTelemetryActionFilterTests.cs`
- **IDE0350** — drop the explicit `ref ActivityCreationOptions<ActivityContext>` type annotation on the listener `Sample` lambda (C# 14 implicit-ref-param).
- **IDE0059** — drop the unused `executing` from the deconstruct in `Outcome_From_Result_Type`.
- **IDE0028** — replace `new List<IFilterMetadata>()` / `new Dictionary<…>()` with `[]` collection expressions inside `RunFilterAsync`.
- **IDE0039** — convert the inline `ActionExecutionDelegate next = () => …` lambda to a local function `Next()` (method-group conversion does the rest).

### `WopiTelemetryTests.cs`
- **IDE0350** — same `Sample`-lambda simplification.
- **IDE0042** — deconstruct the `(value, tags)` measurement tuples returned by `Assert.Single(...)` instead of accessing them via `.value` / `.tags`.

## Note on CI

This PR touches the same file as #339 (the meter-pollution test fix). The pre-existing flake on `RecordOutcome_Success_TagsActivityAndIncrementsRequests` will still appear here until #339 lands or this is rebased on top of it. Either merge order works; the rebase is mechanical.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors across net8.0/9.0/10.0
- [ ] CI green after #339 merges (or after rebase on top of it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)