### PR TITLE
chore(test): commit IntegrationTests launchSettings.json for parity

### DIFF
--- a/test/WopiHost.IntegrationTests/Properties/launchSettings.json
+++ b/test/WopiHost.IntegrationTests/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "WopiHost.IntegrationTests": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:10394;http://localhost:10395"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Visual Studio scaffolded `test/WopiHost.IntegrationTests/Properties/launchSettings.json` locally during recent work but it was never committed. Every other project in the solution already tracks its `launchSettings.json`:

```
✓ infra/WopiHost.AppHost/Properties/launchSettings.json
✓ sample/WopiHost/Properties/launchSettings.json
✓ sample/WopiHost.Validator/Properties/launchSettings.json
✓ sample/WopiHost.Web/Properties/launchSettings.json
✓ sample/WopiHost.Web.Oidc/Properties/launchSettings.json
+ test/WopiHost.IntegrationTests/Properties/launchSettings.json   ← this PR
```

Committing for consistency so a fresh clone gets a working F5 experience without contributors having to recreate it.

## Content review

```json
{ "profiles": { "WopiHost.IntegrationTests": {
    "commandName": "Project",
    "launchBrowser": true,
    "environmentVariables": { "ASPNETCORE_ENVIRONMENT": "Development" },
    "applicationUrl": "https://localhost:10394;http://localhost:10395"
}}}
```

Vanilla VS scaffold — no secrets. Anything sensitive belongs in `dotnet user-secrets`, which has a separate per-developer store outside the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)