### PR TITLE
chore(deps): bump Testcontainers + Testcontainers.Azurite to 4.11.0 (supersedes #348, #349)

### DIFF
--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -18,8 +18,8 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
-    <PackageVersion Include="Testcontainers" Version="4.7.0" />
-    <PackageVersion Include="Testcontainers.Azurite" Version="4.7.0" />
+    <PackageVersion Include="Testcontainers" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.Azurite" Version="4.11.0" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.console" Version="2.9.3">

--- a/test/WopiHost.AzureLockProvider.Tests/AzuriteFixture.cs
+++ b/test/WopiHost.AzureLockProvider.Tests/AzuriteFixture.cs
@@ -14,8 +14,7 @@ public sealed class AzuriteFixture : IAsyncLifetime
     /// </summary>
     public const BlobClientOptions.ServiceVersion AzuriteSupportedVersion = BlobClientOptions.ServiceVersion.V2025_11_05;
 
-    private readonly AzuriteContainer container = new AzuriteBuilder()
-        .WithImage(AzuriteImage)
+    private readonly AzuriteContainer container = new AzuriteBuilder(AzuriteImage)
         .Build();
 
     public string ConnectionString => container.GetConnectionString();

--- a/test/WopiHost.AzureStorageProvider.Tests/AzuriteFixture.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/AzuriteFixture.cs
@@ -22,8 +22,7 @@ public sealed class AzuriteFixture : IAsyncLifetime
     /// </summary>
     public const BlobClientOptions.ServiceVersion AzuriteSupportedVersion = BlobClientOptions.ServiceVersion.V2025_11_05;
 
-    private readonly AzuriteContainer container = new AzuriteBuilder()
-        .WithImage(AzuriteImage)
+    private readonly AzuriteContainer container = new AzuriteBuilder(AzuriteImage)
         .Build();
 
     public string ConnectionString => container.GetConnectionString();

--- a/test/WopiHost.IntegrationTests/Fixtures/MockOidcServerFixture.cs
+++ b/test/WopiHost.IntegrationTests/Fixtures/MockOidcServerFixture.cs
@@ -38,8 +38,7 @@ public sealed class MockOidcServerFixture : IAsyncLifetime
     {
         try
         {
-            _container = new ContainerBuilder()
-                .WithImage(Image)
+            _container = new ContainerBuilder(Image)
                 .WithPortBinding(ContainerPort, true)
                 .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(r =>
                     r.ForPort(ContainerPort).ForPath($"/{Issuer}/.well-known/openid-configuration")))


### PR DESCRIPTION
## Summary

Combines Dependabot's separate bumps ([#348](https://github.com/petrsvihlik/WopiHost/pull/348), [#349](https://github.com/petrsvihlik/WopiHost/pull/349)) into a single PR so the 4.10.0 breaking-change adaptation lands atomically with the version bump.

Closes #348
Closes #349

## API change

**Breaking change in [4.10.0 #1584](https://github.com/testcontainers/testcontainers-dotnet/pull/1584):** the parameterless `new ContainerBuilder()` / `new AzuriteBuilder()` constructor is deprecated in favor of an image-string constructor.

```diff
-new XxxBuilder().WithImage(image).Build()
+new XxxBuilder(image).Build()
```

Three call sites:
- `test/WopiHost.AzureLockProvider.Tests/AzuriteFixture.cs`
- `test/WopiHost.AzureStorageProvider.Tests/AzuriteFixture.cs`
- `test/WopiHost.IntegrationTests/Fixtures/MockOidcServerFixture.cs`

The image strings are unchanged. The `WithImage(...)` extension call collapses into the constructor, so behavior is identical.

## Other 4.8 → 4.11 changes considered (no action needed)

| Change | Impact |
|---|---|
| CosmosDb base image switch to `vnext-preview` (4.11) | not used |
| KurrentDb / Mosquitto / Toxiproxy / Grafana / Playwright / Seq / Temporal modules added | not used |
| Docker Engine v29 API pin to 1.44 (4.10) | works as-is for Azurite + mock-oauth2 |
| `WithResourceMapping` / `CopyAsync` UID/GID overloads (4.8) | we don't use the affected APIs |
| `IContainerBuilder<…>` third generic param (4.8) | we don't implement that interface |
| Wait strategies default to `Running` mode (4.8) | our explicit `UntilHttpRequestIsSucceeded` still applies; default change just makes startup-failures more diagnosable |

## Test plan

- [x] Build clean across net8.0 / net9.0 / net10.0 (0 warnings, 0 errors)
- [x] Non-Docker tests pass locally:
  - `WopiHost.Core.Tests` — 335 ✅
  - `WopiHost.MemoryLockProvider.Tests` — 9 ✅
- [ ] Docker-dependent test suites verified by CI:
  - `WopiHost.AzureLockProvider.Tests` (Azurite)
  - `WopiHost.AzureStorageProvider.Tests` (Azurite)
  - `WopiHost.IntegrationTests` (mock-oauth2-server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)