### PR TITLE
issue #331: TODOs, suppressed warnings, drive-by audit

### DIFF
--- a/sample/WopiHost.Validator/Pages/Index.cshtml.cs
+++ b/sample/WopiHost.Validator/Pages/Index.cshtml.cs
@@ -44,11 +44,11 @@ public class IndexModel(
                         : null;
                     var part = new ChildContainer(
                         ancestor.Name,
-                        Url.Page(pageName: null, values: new 
-                        { 
+                        new Uri(Url.Page(pageName: null, values: new
+                        {
                             ContainerId = ancestor.Identifier,
                             ParentContainerId = parentId
-                        })!
+                        })!, UriKind.RelativeOrAbsolute)
                     );
                     BreadcrumbParts.Add(part);
                 }

--- a/src/WopiHost.Abstractions/ICobaltProcessor.cs
+++ b/src/WopiHost.Abstractions/ICobaltProcessor.cs
@@ -10,9 +10,10 @@ public interface ICobaltProcessor
     /// <summary>
     /// Gets content of a MS-FSSHTTP update action.
     /// </summary>
-    /// <param name="file">File to process</param>
-    /// <param name="principal">User editing the file</param>
-    /// <param name="newContent">Partitions with new content (diffs)</param>
+    /// <param name="file">File to process.</param>
+    /// <param name="principal">User editing the file.</param>
+    /// <param name="newContent">Partitions with new content (diffs).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>An octet stream.</returns>
-    Task<byte[]> ProcessCobalt(IWopiFile file, ClaimsPrincipal principal, byte[] newContent);
+    Task<byte[]> ProcessCobalt(IWopiFile file, ClaimsPrincipal principal, byte[] newContent, CancellationToken cancellationToken = default);
 }

--- a/src/WopiHost.Abstractions/IWopiFile.cs
+++ b/src/WopiHost.Abstractions/IWopiFile.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-
-namespace WopiHost.Abstractions;
+﻿namespace WopiHost.Abstractions;
 
 /// <summary>
 /// Representation of a file.
@@ -38,11 +36,12 @@ public interface IWopiFile : IWopiResource
     string? Version { get; }
 
     /// <summary>
-    /// SHA256 checksum
+    /// SHA-256 checksum of the file contents, or <see langword="null"/> when the provider doesn't
+    /// compute one. <see cref="ReadOnlyMemory{T}"/> hands callers an immutable view; providers
+    /// can wrap their existing <c>byte[]</c> hash output via the implicit conversion from
+    /// <c>byte[]</c> to <see cref="ReadOnlyMemory{T}"/>.
     /// </summary>
-    [SuppressMessage("Performance", "CA1819:Properties should not return arrays",
-        Justification = "SHA-256 hash bytes; byte[] is the natural shape and matches SHA256.ComputeHash output.")]
-    byte[]? Checksum { get; }
+    ReadOnlyMemory<byte>? Checksum { get; }
 
     /// <summary>
     /// Size of the file.

--- a/src/WopiHost.AzureStorageProvider/WopiBlobFile.cs
+++ b/src/WopiHost.AzureStorageProvider/WopiBlobFile.cs
@@ -98,9 +98,7 @@ public class WopiBlobFile : IWopiFile
     }
 
     /// <inheritdoc/>
-#pragma warning disable CA1819 // Properties should not return arrays — interface contract
-    public byte[]? Checksum
-#pragma warning restore CA1819
+    public ReadOnlyMemory<byte>? Checksum
     {
         get
         {

--- a/src/WopiHost.Cobalt/CobaltSession.cs
+++ b/src/WopiHost.Cobalt/CobaltSession.cs
@@ -47,13 +47,13 @@ public sealed partial class CobaltProcessor : ICobaltProcessor, IDisposable
     }
 
     /// <inheritdoc/>
-    public async Task<byte[]> ProcessCobalt(IWopiFile file, ClaimsPrincipal principal, byte[] newContent)
+    public async Task<byte[]> ProcessCobalt(IWopiFile file, ClaimsPrincipal principal, byte[] newContent, CancellationToken cancellationToken = default)
     {
         ThrowIfDisposed();
         ArgumentNullException.ThrowIfNull(file);
         ArgumentNullException.ThrowIfNull(newContent);
 
-        var entry = await GetOrCreateSession(file).ConfigureAwait(false);
+        var entry = await GetOrCreateSession(file, cancellationToken).ConfigureAwait(false);
 
         // Wrap the request bytes as a CobaltStream (16.x replaced the Atom-taking
         // overload of DeserializeInputFromProtocol with one that takes CobaltStream).
@@ -79,10 +79,13 @@ public sealed partial class CobaltProcessor : ICobaltProcessor, IDisposable
                 // Serialize concurrent saves for the same file. WOPI itself uses
                 // protocol-level locks but those don't necessarily cover the
                 // window between ExecuteRequestBatch and the disk flush.
-                await entry.WriteLock.WaitAsync().ConfigureAwait(false);
+                await entry.WriteLock.WaitAsync(cancellationToken).ConfigureAwait(false);
                 try
                 {
-                    using var stream = await file.GetWriteStream().ConfigureAwait(false);
+                    using var stream = await file.GetWriteStream(cancellationToken).ConfigureAwait(false);
+                    // GenericFdaStream is sync-only (CobaltCore exposes no async copy). The
+                    // surrounding awaits already honor cancellation; the sync copy itself runs
+                    // against an in-memory buffer so it's not network-bound.
                     new GenericFda(entry.File.CobaltEndpoint).GetContentStream().CopyTo(stream);
                     LogContentFlushed(_logger, file.Identifier);
                 }
@@ -104,7 +107,7 @@ public sealed partial class CobaltProcessor : ICobaltProcessor, IDisposable
         return response;
     }
 
-    private async Task<CobaltSessionEntry> GetOrCreateSession(IWopiFile file)
+    private async Task<CobaltSessionEntry> GetOrCreateSession(IWopiFile file, CancellationToken cancellationToken)
     {
         var freshEntry = false;
         var lazy = _sessions.GetOrAdd(
@@ -112,7 +115,7 @@ public sealed partial class CobaltProcessor : ICobaltProcessor, IDisposable
             _ =>
             {
                 freshEntry = true;
-                return new Lazy<Task<CobaltSessionEntry>>(() => CreateSessionEntry(file), LazyThreadSafetyMode.ExecutionAndPublication);
+                return new Lazy<Task<CobaltSessionEntry>>(() => CreateSessionEntry(file, cancellationToken), LazyThreadSafetyMode.ExecutionAndPublication);
             });
         try
         {
@@ -135,7 +138,7 @@ public sealed partial class CobaltProcessor : ICobaltProcessor, IDisposable
         }
     }
 
-    private async Task<CobaltSessionEntry> CreateSessionEntry(IWopiFile file)
+    private async Task<CobaltSessionEntry> CreateSessionEntry(IWopiFile file, CancellationToken cancellationToken)
     {
         var disposal = new DisposalEscrow(file.Owner);
 
@@ -170,12 +173,12 @@ public sealed partial class CobaltProcessor : ICobaltProcessor, IDisposable
 
         if (file.Exists)
         {
-            using var stream = await file.GetReadStream().ConfigureAwait(false);
+            using var stream = await file.GetReadStream(cancellationToken).ConfigureAwait(false);
             // 16.x made `AtomFromStream` an internal sealed type; `Atom.CreateFromArray`
             // is the public byte[] factory. Buffer the stream so we can hand a byte[]
             // to it.
             using var ms = new MemoryStream();
-            await stream.CopyToAsync(ms).ConfigureAwait(false);
+            await stream.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
             var srcAtom = Atom.CreateFromArray(ms.ToArray());
             cobaltFile.GetCobaltFilePartition(FilePartitionId.Content).SetStream(RootId.Default.Value, srcAtom, out _);
             cobaltFile.GetCobaltFilePartition(FilePartitionId.Content).GetStream(RootId.Default.Value).Flush();

--- a/src/WopiHost.Core/Controllers/FilesController.cs
+++ b/src/WopiHost.Core/Controllers/FilesController.cs
@@ -589,7 +589,7 @@ public class FilesController(
         var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken)
             ?? throw new InvalidOperationException("File not found");
 
-        var responseBytes = await cobaltProcessor.ProcessCobalt(file, User, await HttpContext.Request.Body.ReadBytesAsync());
+        var responseBytes = await cobaltProcessor.ProcessCobalt(file, User, await HttpContext.Request.Body.ReadBytesAsync(cancellationToken), cancellationToken);
         if (!string.IsNullOrEmpty(correlationId))
         {
             HttpContext.Response.Headers.Append(WopiHeaders.CORRELATION_ID, correlationId);

--- a/src/WopiHost.Core/Extensions/Extensions.cs
+++ b/src/WopiHost.Core/Extensions/Extensions.cs
@@ -11,12 +11,13 @@ internal static class Extensions
     /// <summary>
     /// Copies the stream to a byte array.
     /// </summary>
-    /// <param name="input">Stream to read from</param>
-    /// <returns>Byte array copy of a stream</returns>
-    public static async Task<byte[]> ReadBytesAsync(this Stream input)
+    /// <param name="input">Stream to read from.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Byte array copy of a stream.</returns>
+    public static async Task<byte[]> ReadBytesAsync(this Stream input, CancellationToken cancellationToken = default)
     {
         using var ms = new MemoryStream();
-        await input.CopyToAsync(ms);
+        await input.CopyToAsync(ms, cancellationToken);
         return ms.ToArray();
     }
 

--- a/src/WopiHost.Core/Extensions/Extensions.cs
+++ b/src/WopiHost.Core/Extensions/Extensions.cs
@@ -73,7 +73,7 @@ internal static class Extensions
     /// <param name="identifier">Identifier of an object associated to the controller.</param>
     /// <param name="accessToken">Access token to use for authentication for the given controller.</param>
     /// <returns>https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/concepts#wopisrc</returns>
-    public static string GetWopiSrc(this IUrlHelper url, string routeName, string? identifier = null, string? accessToken = null)
+    public static Uri GetWopiSrc(this IUrlHelper url, string routeName, string? identifier = null, string? accessToken = null)
     {
         ArgumentNullException.ThrowIfNull(url);
         ArgumentException.ThrowIfNullOrWhiteSpace(routeName);
@@ -86,8 +86,12 @@ internal static class Extensions
             accessToken = string.IsNullOrEmpty(requestToken) ? null : requestToken;
         }
 
-        return url.ProxyAwareRouteUrl(routeName, new { id = identifier ?? string.Empty, access_token = accessToken })
+        var built = url.ProxyAwareRouteUrl(routeName, new { id = identifier ?? string.Empty, access_token = accessToken })
                ?? throw new InvalidOperationException(routeName + " route not found");
+        // RelativeOrAbsolute so the helper still works in test contexts (DefaultHttpContext with
+        // empty Host) and behind proxies that strip the path-base. In production the result is
+        // always absolute because Request.Scheme and Request.Host are populated by the host server.
+        return new Uri(built, UriKind.RelativeOrAbsolute);
     }
 
     /// <summary>
@@ -98,7 +102,7 @@ internal static class Extensions
     /// <param name="identifier">resource unique identifier</param>
     /// <param name="accessToken">Access token to use for authentication for the given controller.</param>
     /// <returns>https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/concepts#wopisrc</returns>
-    public static string GetWopiSrc(this IUrlHelper url, WopiResourceType resourceType, string? identifier = null, string? accessToken = null)
+    public static Uri GetWopiSrc(this IUrlHelper url, WopiResourceType resourceType, string? identifier = null, string? accessToken = null)
     {
         ArgumentNullException.ThrowIfNull(url);
         return url.GetWopiSrc(

--- a/src/WopiHost.Core/Extensions/WopiExtensions.cs
+++ b/src/WopiHost.Core/Extensions/WopiExtensions.cs
@@ -33,7 +33,7 @@ public static class WopiExtensions
             using var stream = await file.GetReadStream(cancellationToken);
             result = await Sha.ComputeHashAsync(stream, cancellationToken);
         }
-        return Convert.ToBase64String(result);
+        return Convert.ToBase64String(result.Value.Span);
     }
 
     /// <summary>

--- a/src/WopiHost.Core/Infrastructure/UtfString.cs
+++ b/src/WopiHost.Core/Infrastructure/UtfString.cs
@@ -102,10 +102,15 @@ public class UtfString : IParsable<UtfString>
         }
         byte[] utf7Bytes = Encoding.Default.GetBytes(encodedValue);
 
-        // Decode the byte array using UTF-7
-#pragma warning disable SYSLIB0001 // Type or member is obsolete
+        // SYSLIB0001 is suppressed here because the WOPI specification mandates UTF-7 for the
+        // X-WOPI-SuggestedTarget and X-WOPI-RelativeTarget headers — see
+        // https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/putrelativefile#request-headers
+        // and the MS-WOPI protocol spec section 2.2.5.1.5. The framework deprecation is unrelated
+        // to the protocol requirement; we cannot change to a different encoding without breaking
+        // interop with Office Online / Microsoft 365 for the Web.
+#pragma warning disable SYSLIB0001 // Type or member is obsolete — required by WOPI spec
         Encoding utf7 = Encoding.UTF7;
-#pragma warning restore SYSLIB0001 // Type or member is obsolete
+#pragma warning restore SYSLIB0001
         return utf7.GetString(utf7Bytes);
     }
 
@@ -120,10 +125,10 @@ public class UtfString : IParsable<UtfString>
         {
             return decodedValue;
         }
-        // Encode the byte array using UTF-7
-#pragma warning disable SYSLIB0001 // Type or member is obsolete
+        // SYSLIB0001 suppressed — see DecodeString for rationale (WOPI spec mandates UTF-7).
+#pragma warning disable SYSLIB0001 // Type or member is obsolete — required by WOPI spec
         Encoding utf7 = Encoding.UTF7;
-#pragma warning restore SYSLIB0001 // Type or member is obsolete
+#pragma warning restore SYSLIB0001
 
         byte[] bytes = utf7.GetBytes(decodedValue);
 

--- a/src/WopiHost.Core/Infrastructure/WopiTelemetry.cs
+++ b/src/WopiHost.Core/Infrastructure/WopiTelemetry.cs
@@ -57,6 +57,10 @@ public static class WopiTelemetry
         public const string PreconditionFailed = "precondition_failed";
         public const string NotImplemented = "not_implemented";
         public const string ProofValidationFailed = "proof_validation_failed";
+
+        /// <summary>Client disconnected / request aborted before completion. Not a server error.</summary>
+        public const string Cancelled = "cancelled";
+
         public const string Error = "error";
     }
 
@@ -84,7 +88,9 @@ public static class WopiTelemetry
     public static void RecordOutcome(Activity? activity, string operation, string outcome)
     {
         activity?.SetTag(Tags.Outcome, outcome);
-        if (outcome != Outcomes.Success)
+        // Success and Cancelled are non-Error from a tracing perspective — Cancelled means the
+        // client closed the connection, which isn't a server-side fault.
+        if (outcome != Outcomes.Success && outcome != Outcomes.Cancelled)
         {
             activity?.SetStatus(ActivityStatusCode.Error, outcome);
         }

--- a/src/WopiHost.Core/Infrastructure/WopiTelemetryActionFilter.Logging.cs
+++ b/src/WopiHost.Core/Infrastructure/WopiTelemetryActionFilter.Logging.cs
@@ -27,4 +27,12 @@ public sealed partial class WopiTelemetryActionFilter
         Exception exception,
         string operation,
         string resourceId);
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "WOPI {operation} on {resourceId} cancelled (client disconnected)")]
+    private static partial void LogActionCancelled(
+        ILogger logger,
+        string operation,
+        string resourceId);
 }

--- a/src/WopiHost.Core/Infrastructure/WopiTelemetryActionFilter.cs
+++ b/src/WopiHost.Core/Infrastructure/WopiTelemetryActionFilter.cs
@@ -45,8 +45,18 @@ public sealed partial class WopiTelemetryActionFilter(ILogger<WopiTelemetryActio
             var executed = await next().ConfigureAwait(false);
             if (executed.Exception is { } ex)
             {
-                outcome = WopiTelemetry.Outcomes.Error;
-                LogActionFailed(logger, ex, operation, resourceId ?? string.Empty);
+                // Client disconnect / aborted request shouldn't surface as an Error in metrics
+                // or logs — the WOPI client closed the socket and there's nothing wrong with us.
+                if (IsCancellation(ex, context.HttpContext.RequestAborted))
+                {
+                    outcome = WopiTelemetry.Outcomes.Cancelled;
+                    LogActionCancelled(logger, operation, resourceId ?? string.Empty);
+                }
+                else
+                {
+                    outcome = WopiTelemetry.Outcomes.Error;
+                    LogActionFailed(logger, ex, operation, resourceId ?? string.Empty);
+                }
             }
             else
             {
@@ -59,6 +69,11 @@ public sealed partial class WopiTelemetryActionFilter(ILogger<WopiTelemetryActio
             WopiTelemetry.RecordOutcome(activity, operation, outcome);
         }
     }
+
+    private static bool IsCancellation(Exception ex, CancellationToken requestAborted) =>
+        (ex is OperationCanceledException && requestAborted.IsCancellationRequested)
+        // AggregateException can wrap an OCE when a Task.WhenAll observes one of several faults.
+        || (ex is AggregateException agg && agg.InnerExceptions.All(e => e is OperationCanceledException) && requestAborted.IsCancellationRequested);
 
     private static string? NullIfEmpty(string? value) => string.IsNullOrEmpty(value) ? null : value;
 

--- a/src/WopiHost.Core/Models/AbstractChildBase.cs
+++ b/src/WopiHost.Core/Models/AbstractChildBase.cs
@@ -1,10 +1,8 @@
-﻿namespace WopiHost.Core.Models;
+namespace WopiHost.Core.Models;
 
 /// <summary>
 /// Represents a child object of an arbitrary type.
 /// </summary>
 /// <param name="Name">Name of the object.</param>
 /// <param name="Url">URL pointing to the object.</param>
-#pragma warning disable CA1056 // URI-like properties should not be strings
-public abstract record AbstractChildBase(string Name, string Url);
-#pragma warning restore CA1056 // URI-like properties should not be strings
+public abstract record AbstractChildBase(string Name, Uri Url);

--- a/src/WopiHost.Core/Models/BootstrapInfo.cs
+++ b/src/WopiHost.Core/Models/BootstrapInfo.cs
@@ -8,11 +8,10 @@ namespace WopiHost.Core.Models;
 public class BootstrapInfo
 {
     /// <summary>
-    /// A string URI for the WOPI server’s 🔧 Ecosystem endpoint, with a WOPI access token appended. A GET request to this URL will invoke the CheckEcosystem operation.
+    /// URI for the WOPI server's 🔧 Ecosystem endpoint, with a WOPI access token appended.
+    /// A GET request to this URL will invoke the CheckEcosystem operation.
     /// </summary>
-#pragma warning disable CA1056 // URI-like properties should not be strings
-    public string? EcosystemUrl { get; set; }
-#pragma warning restore CA1056 // URI-like properties should not be strings
+    public Uri? EcosystemUrl { get; set; }
 
     /// <summary>
     /// A string value uniquely identifying the user making the request. This value should match the UserId value provided in <see cref="WopiCheckFileInfo"/>. 

--- a/src/WopiHost.Core/Models/ChildContainer.cs
+++ b/src/WopiHost.Core/Models/ChildContainer.cs
@@ -1,8 +1,8 @@
-﻿namespace WopiHost.Core.Models;
+namespace WopiHost.Core.Models;
 
 /// <summary>
 /// Object containing information pointing to a container.
 /// </summary>
 /// <param name="Name">Name of the object.</param>
 /// <param name="Url">URL pointing to the object.</param>
-public record ChildContainer(string Name, string Url) : AbstractChildBase(Name, Url);
+public record ChildContainer(string Name, Uri Url) : AbstractChildBase(Name, Url);

--- a/src/WopiHost.Core/Models/ChildFile.cs
+++ b/src/WopiHost.Core/Models/ChildFile.cs
@@ -5,7 +5,7 @@
 /// </summary>
 /// <param name="Name">Name of the object.</param>
 /// <param name="Url">URL pointing to the object.</param>
-public record ChildFile(string Name, string Url) : AbstractChildBase(Name, Url)
+public record ChildFile(string Name, Uri Url) : AbstractChildBase(Name, Url)
 {
 	/// <summary>
 	/// Version of the file.

--- a/src/WopiHost.Core/Models/UrlResponse.cs
+++ b/src/WopiHost.Core/Models/UrlResponse.cs
@@ -1,9 +1,7 @@
-﻿namespace WopiHost.Core.Models;
+namespace WopiHost.Core.Models;
 
 /// <summary>
 /// Response object containing an Url.
 /// </summary>
 /// <param name="Url">the absolute Url to return.</param>
-#pragma warning disable CA1056 // URI-like properties should not be strings
-public record UrlResponse(string Url);
-#pragma warning restore CA1056 // URI-like properties should not be strings
+public record UrlResponse(Uri Url);

--- a/src/WopiHost.Core/Results/FileResult.cs
+++ b/src/WopiHost.Core/Results/FileResult.cs
@@ -50,12 +50,14 @@ public class FileResult : ActionResult
     /// <inheritdoc/>
     public override async Task ExecuteResultAsync(ActionContext context)
     {
+        ArgumentNullException.ThrowIfNull(context);
         var response = context.HttpContext.Response;
+        var ct = context.HttpContext.RequestAborted;
         response.ContentType = ContentType;
         var targetStream = response.Body;
         if (Content is not null)
         {
-            await targetStream.WriteAsync(Content.AsMemory(0, Content.Length));
+            await targetStream.WriteAsync(Content.AsMemory(0, Content.Length), ct);
         }
         else
         {
@@ -66,7 +68,7 @@ public class FileResult : ActionResult
                 {
                     SourceStream.Seek(0, SeekOrigin.Begin);
                 }
-                await SourceStream.CopyToAsync(targetStream);
+                await SourceStream.CopyToAsync(targetStream, ct);
             }
         }
     }

--- a/src/WopiHost.Discovery/IDiscoverer.cs
+++ b/src/WopiHost.Discovery/IDiscoverer.cs
@@ -40,14 +40,6 @@ public interface IDiscoverer
 		Task<IEnumerable<string>> GetActionRequirementsAsync(string extension, WopiActionEnum action);
 
 		/// <summary>
-		/// Determines if files with the given extension require MS-FSSHTTP (Cobalt) to be implemented in order to support the given action.
-		/// </summary>
-		/// <param name="extension">File extension to consider (without the leading dot).</param>
-		/// <param name="action">WOPI action to consider.</param>
-		/// <returns>True if MS-FSSHTTP (Cobalt) is required for the combination of action and file extension.</returns>
-		Task<bool> RequiresCobaltAsync(string extension, WopiActionEnum action); //TODO: convert to an extension method (remove from interface)
-
-		/// <summary>
 		/// Gets the name of the application that handles files with the given extension.
 		/// </summary>
 		/// <param name="extension">File extension to get the app name for (without the leading dot).</param>

--- a/src/WopiHost.Discovery/IDiscovererExtensions.cs
+++ b/src/WopiHost.Discovery/IDiscovererExtensions.cs
@@ -1,0 +1,27 @@
+using WopiHost.Discovery.Enumerations;
+
+namespace WopiHost.Discovery;
+
+/// <summary>
+/// Convenience extension methods over <see cref="IDiscoverer"/> that derive from primitives
+/// already exposed by the interface.
+/// </summary>
+public static class IDiscovererExtensions
+{
+    private const string CobaltRequirement = "cobalt";
+
+    /// <summary>
+    /// Determines whether files with the given extension require MS-FSSHTTP (Cobalt) for the
+    /// specified action — i.e. whether the discovery file lists <c>cobalt</c> in the action's
+    /// <c>requires</c> attribute.
+    /// </summary>
+    /// <param name="discoverer">Discoverer instance.</param>
+    /// <param name="extension">File extension to consider (without the leading dot).</param>
+    /// <param name="action">WOPI action to consider.</param>
+    public static async Task<bool> RequiresCobaltAsync(this IDiscoverer discoverer, string extension, WopiActionEnum action)
+    {
+        ArgumentNullException.ThrowIfNull(discoverer);
+        var requirements = await discoverer.GetActionRequirementsAsync(extension, action).ConfigureAwait(false);
+        return requirements is not null && requirements.Contains(CobaltRequirement);
+    }
+}

--- a/src/WopiHost.Discovery/WopiDiscoverer.cs
+++ b/src/WopiHost.Discovery/WopiDiscoverer.cs
@@ -127,18 +127,11 @@ public partial class WopiDiscoverer : IDiscoverer, IDisposable
         var actionString = action.ToString().ToUpperInvariant();
 
         var query = (await GetAppsAsync()).Elements()
-            .Where(e => string.Equals(e.Attribute(AttrActionExtension)?.Value, extension, StringComparison.OrdinalIgnoreCase) && 
+            .Where(e => string.Equals(e.Attribute(AttrActionExtension)?.Value, extension, StringComparison.OrdinalIgnoreCase) &&
                 e.Attribute(AttrActionName)?.Value.Equals(actionString, StringComparison.InvariantCultureIgnoreCase) == true)
             .Select(e => e.Attribute(AttrActionRequires)?.Value.Split(','));
 
         return query?.FirstOrDefault() ?? [];
-    }
-
-    ///<inheritdoc />
-    public async Task<bool> RequiresCobaltAsync(string extension, WopiActionEnum action)
-    {
-        var requirements = await GetActionRequirementsAsync(extension, action);
-        return requirements is not null && requirements.Contains(AttrValCobalt);
     }
 
     ///<inheritdoc />

--- a/src/WopiHost.FileSystemProvider/LinuxFileOwner.cs
+++ b/src/WopiHost.FileSystemProvider/LinuxFileOwner.cs
@@ -94,7 +94,12 @@ internal static partial class LinuxFileOwner
         public IntPtr pw_shell;
     }
 
-#pragma warning disable CA5392 // Use DefaultDllImportSearchPaths attribute for P/Invokes
+    // CA5392 wants explicit DLL search paths to limit the loader's search to safe directories
+    // and prevent DLL hijacking. The attribute is honored on Windows only — on Linux the dynamic
+    // loader uses LD_LIBRARY_PATH + system paths and ignores the attribute entirely. This whole
+    // class is [SupportedOSPlatform("linux")] so the attribute is effectively a no-op for us, but
+    // it satisfies the analyzer and documents intent.
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
     [LibraryImport("libc", EntryPoint = "statx", SetLastError = true, StringMarshalling = StringMarshalling.Utf8)]
     private static partial int Statx(
         int dirfd,
@@ -103,6 +108,7 @@ internal static partial class LinuxFileOwner
         uint mask,
         out StatxBuf statxbuf);
 
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
     [LibraryImport("libc", EntryPoint = "getpwuid_r", SetLastError = false)]
     private static partial int GetPwUid_R(
         uint uid,
@@ -110,5 +116,4 @@ internal static partial class LinuxFileOwner
         IntPtr buf,
         nuint buflen,
         out IntPtr result);
-#pragma warning restore CA5392
 }

--- a/src/WopiHost.FileSystemProvider/WopiFile.cs
+++ b/src/WopiHost.FileSystemProvider/WopiFile.cs
@@ -30,9 +30,7 @@ public class WopiFile(string filePath, string fileIdentifier) : IWopiFile
     public string? Version => fileVersionInfo.FileVersion ?? fileInfo.LastWriteTimeUtc.Ticks.ToString(CultureInfo.InvariantCulture);
 
     /// <inheritdoc/>
-#pragma warning disable CA1819 // Properties should not return arrays
-    public byte[]? Checksum { get; } = null;
-#pragma warning restore CA1819 // Properties should not return arrays
+    public ReadOnlyMemory<byte>? Checksum => null;
 
     /// <inheritdoc/>
     public long Size => fileInfo.Length;

--- a/src/WopiHost.Url/WopiUrlBuilder.cs
+++ b/src/WopiHost.Url/WopiUrlBuilder.cs
@@ -42,23 +42,43 @@ public partial class WopiUrlBuilder(
     /// <returns></returns>
     public async Task<string?> GetFileUrlAsync(string extension, Uri wopiFileUrl, WopiActionEnum action, WopiUrlSettings? urlSettings = null)
     {
+        ArgumentNullException.ThrowIfNull(wopiFileUrl);
         var combinedUrlSettings = new WopiUrlSettings((urlSettings ?? []).Merge(UrlSettings ?? []));
+
+        // Single source of truth for the WopiSrc value: the wopiFileUrl parameter. The
+        // WOPI_SOURCE placeholder, when present in a template, gets substituted with this
+        // value (URL-escaped by ResolveOptionalParameter). Any caller-provided WOPI_SOURCE
+        // value in urlSettings is overwritten so we never produce two different WopiSrc
+        // values in the same URL.
+        combinedUrlSettings[WopiSourcePlaceholder] = wopiFileUrl.ToString();
+
         var template = await _wopiDiscoverer.GetUrlTemplateAsync(extension, action);
-        if (!string.IsNullOrEmpty(template))
+        if (string.IsNullOrEmpty(template))
         {
-            // Resolve optional parameters
-            var url = UrlParamRegex().Replace(template, m => ResolveOptionalParameter(m.Groups["name"].Value, m.Groups["value"].Value, combinedUrlSettings) ?? string.Empty);
-            url = url.TrimEnd('&');
-
-            // Append mandatory parameters
-            url += "&WOPISrc=" + Uri.EscapeDataString(wopiFileUrl.ToString());
-
-            LogFileUrlGenerated(_logger, extension, action);
-            return url;
+            LogTemplateNotFound(_logger, extension, action);
+            return null;
         }
-        LogTemplateNotFound(_logger, extension, action);
-        return null;
+
+        var templateHasWopiSourcePlaceholder = template.Contains(WopiSourcePlaceholder, StringComparison.Ordinal);
+
+        // Resolve optional parameters
+        var url = UrlParamRegex().Replace(template, m => ResolveOptionalParameter(m.Groups["name"].Value, m.Groups["value"].Value, combinedUrlSettings) ?? string.Empty);
+        url = url.TrimEnd('&');
+
+        // Only append &WOPISrc= when the template did not already carry the WOPI_SOURCE
+        // placeholder. Modern Office Online / M365 templates include `<wopisrc=WOPI_SOURCE&>`
+        // and would otherwise produce two WopiSrc params (lowercase from the substitution,
+        // uppercase from this append) with potentially different values.
+        if (!templateHasWopiSourcePlaceholder)
+        {
+            url += "&WOPISrc=" + Uri.EscapeDataString(wopiFileUrl.ToString());
+        }
+
+        LogFileUrlGenerated(_logger, extension, action);
+        return url;
     }
+
+    private const string WopiSourcePlaceholder = "WOPI_SOURCE";
 
     private static string? ResolveOptionalParameter(string name, string value, WopiUrlSettings urlSettings)
     {

--- a/src/WopiHost.Url/WopiUrlBuilder.cs
+++ b/src/WopiHost.Url/WopiUrlBuilder.cs
@@ -43,7 +43,17 @@ public partial class WopiUrlBuilder(
     public async Task<string?> GetFileUrlAsync(string extension, Uri wopiFileUrl, WopiActionEnum action, WopiUrlSettings? urlSettings = null)
     {
         ArgumentNullException.ThrowIfNull(wopiFileUrl);
-        var combinedUrlSettings = new WopiUrlSettings((urlSettings ?? []).Merge(UrlSettings ?? []));
+
+        // Combine settings with method-arg precedence over constructor-arg.
+        WopiUrlSettings combinedUrlSettings = [];
+        if (UrlSettings is not null)
+        {
+            foreach (var kvp in UrlSettings) combinedUrlSettings[kvp.Key] = kvp.Value;
+        }
+        if (urlSettings is not null)
+        {
+            foreach (var kvp in urlSettings) combinedUrlSettings[kvp.Key] = kvp.Value; // overrides
+        }
 
         // Single source of truth for the WopiSrc value: the wopiFileUrl parameter. The
         // WOPI_SOURCE placeholder, when present in a template, gets substituted with this

--- a/src/WopiHost.Url/WopiUrlSettings.cs
+++ b/src/WopiHost.Url/WopiUrlSettings.cs
@@ -139,17 +139,6 @@ public class WopiUrlSettings : Dictionary<string, string>
     }
 
     /// <summary>
-    /// This placeholder must be replaced by a WopiSrc value. Unlike other placeholders, replacing this placeholder is required.
-    /// New in version 2018.12.15: Prior to this version, hosts were required to add the WopiSrc to the action URL for most (but not all) actions. This placeholder enables hosts to handle the WopiSrc in the same way as other URL parameters.
-    /// </summary>
-    public string WopiSource
-    {
-        //TODO: unify with WopiSrc
-        get => this["WOPI_SOURCE"];
-        set => this["WOPI_SOURCE"] = value;
-    }
-
-    /// <summary>
     /// This value is used to run the WOPI Validation application in different modes.
     /// This value can be set to All, OfficeOnline or OfficeNativeClient to activate tests specific to Office Online and Office for iOS.If omitted, the default value is All.
     /// All: activates all WOPI Validation application tests.

--- a/test/WopiHost.AzureStorageProvider.Tests/WopiAzureStorageProviderTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/WopiAzureStorageProviderTests.cs
@@ -94,7 +94,7 @@ public class WopiAzureStorageProviderTests(AzuriteFixture azurite)
         var refreshed = (await provider.GetWopiResource<IWopiFile>(created.Identifier))!;
         Assert.Equal(payload.Length, refreshed.Length);
         Assert.NotNull(refreshed.Checksum);
-        Assert.Equal(expectedHash, Convert.ToHexString(refreshed.Checksum!).ToLowerInvariant());
+        Assert.Equal(expectedHash, Convert.ToHexString(refreshed.Checksum.Value.Span).ToLowerInvariant());
     }
 
     [Fact]

--- a/test/WopiHost.AzureStorageProvider.Tests/WopiBlobFileTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/WopiBlobFileTests.cs
@@ -81,7 +81,7 @@ public class WopiBlobFileTests(AzuriteFixture azurite)
         var file = await WopiBlobFile.CreateAsync(blob, "with-hash.bin", "id", CancellationToken.None);
 
         Assert.NotNull(file.Checksum);
-        Assert.Equal(Convert.FromHexString(hex), file.Checksum);
+        Assert.Equal(Convert.FromHexString(hex), file.Checksum.Value.ToArray());
     }
 
     [Fact]

--- a/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
@@ -318,6 +318,9 @@ public class ContainersControllerTests
         fileMock.SetupGet(f => f.Extension).Returns("txt");
         fileMock.SetupGet(f => f.LastWriteTimeUtc).Returns(DateTime.UtcNow);
         fileMock.SetupGet(f => f.Length).Returns(1024);
+        // Stub Checksum so GetEncodedSha256 takes the early-return path; avoids the unmocked
+        // GetReadStream call inside CheckFileInfo composition.
+        fileMock.SetupGet(f => f.Checksum).Returns(new ReadOnlyMemory<byte>([0]));
         storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Mock<IWopiFolder>().Object);
         writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()))

--- a/test/WopiHost.Core.Tests/Extensions/WopiExtensionsTests.cs
+++ b/test/WopiHost.Core.Tests/Extensions/WopiExtensionsTests.cs
@@ -43,6 +43,9 @@ public class WopiExtensionsTests
     public async Task GetWopiCheckFileInfo_ReturnsCorrectInfo()
     {
         var mockFile = new Mock<IWopiFile>();
+        // Stub Checksum so GetEncodedSha256 takes the early-return path; otherwise it would
+        // call GetReadStream (also unmocked), and ComputeHashAsync(null) throws.
+        mockFile.Setup(f => f.Checksum).Returns(new ReadOnlyMemory<byte>([0]));
         mockFile.Setup(f => f.Name).Returns("test");
         mockFile.Setup(f => f.Owner).Returns("owner");
         mockFile.Setup(f => f.Extension).Returns("txt");
@@ -105,6 +108,9 @@ public class WopiExtensionsTests
     public async Task GetWopiCheckFileInfo_WithWritableStorageProvider_ReturnsCorrectInfo()
     {
         var mockFile = new Mock<IWopiFile>();
+        // Stub Checksum so GetEncodedSha256 takes the early-return path; otherwise it would
+        // call GetReadStream (also unmocked), and ComputeHashAsync(null) throws.
+        mockFile.Setup(f => f.Checksum).Returns(new ReadOnlyMemory<byte>([0]));
         mockFile.Setup(f => f.Name).Returns("test");
         mockFile.Setup(f => f.Owner).Returns("owner");
         mockFile.Setup(f => f.Extension).Returns("txt");
@@ -136,6 +142,9 @@ public class WopiExtensionsTests
     public async Task GetWopiCheckFileInfo_PopulatesFileUrl_WhenLinkGeneratorIsRegistered()
     {
         var mockFile = new Mock<IWopiFile>();
+        // Stub Checksum so GetEncodedSha256 takes the early-return path; otherwise it would
+        // call GetReadStream (also unmocked), and ComputeHashAsync(null) throws.
+        mockFile.Setup(f => f.Checksum).Returns(new ReadOnlyMemory<byte>([0]));
         mockFile.Setup(f => f.Name).Returns("test");
         mockFile.Setup(f => f.Owner).Returns("owner");
         mockFile.Setup(f => f.Extension).Returns("txt");
@@ -162,6 +171,9 @@ public class WopiExtensionsTests
     public async Task GetWopiCheckFileInfo_OverridesFileUrl_WhenOnCheckFileInfoSetsIt()
     {
         var mockFile = new Mock<IWopiFile>();
+        // Stub Checksum so GetEncodedSha256 takes the early-return path; otherwise it would
+        // call GetReadStream (also unmocked), and ComputeHashAsync(null) throws.
+        mockFile.Setup(f => f.Checksum).Returns(new ReadOnlyMemory<byte>([0]));
         mockFile.Setup(f => f.Name).Returns("test");
         mockFile.Setup(f => f.Owner).Returns("owner");
         mockFile.Setup(f => f.Extension).Returns("txt");
@@ -194,6 +206,9 @@ public class WopiExtensionsTests
     public async Task GetWopiCheckFileInfo_LeavesFileUrlNull_WhenLinkGeneratorIsMissing()
     {
         var mockFile = new Mock<IWopiFile>();
+        // Stub Checksum so GetEncodedSha256 takes the early-return path; otherwise it would
+        // call GetReadStream (also unmocked), and ComputeHashAsync(null) throws.
+        mockFile.Setup(f => f.Checksum).Returns(new ReadOnlyMemory<byte>([0]));
         mockFile.Setup(f => f.Name).Returns("test");
         mockFile.Setup(f => f.Owner).Returns("owner");
         mockFile.Setup(f => f.Extension).Returns("txt");
@@ -214,6 +229,9 @@ public class WopiExtensionsTests
     public async Task GetWopiCheckFileInfo_CallsOnCheckFileInfoEvent()
     {
         var mockFile = new Mock<IWopiFile>();
+        // Stub Checksum so GetEncodedSha256 takes the early-return path; otherwise it would
+        // call GetReadStream (also unmocked), and ComputeHashAsync(null) throws.
+        mockFile.Setup(f => f.Checksum).Returns(new ReadOnlyMemory<byte>([0]));
         mockFile.Setup(f => f.Name).Returns("test");
         mockFile.Setup(f => f.Owner).Returns("owner");
         mockFile.Setup(f => f.Extension).Returns("txt");
@@ -241,6 +259,9 @@ public class WopiExtensionsTests
     public async Task GetWopiCheckFileInfo_WithAuthenticatedUser()
     {
         var mockFile = new Mock<IWopiFile>();
+        // Stub Checksum so GetEncodedSha256 takes the early-return path; otherwise it would
+        // call GetReadStream (also unmocked), and ComputeHashAsync(null) throws.
+        mockFile.Setup(f => f.Checksum).Returns(new ReadOnlyMemory<byte>([0]));
         mockFile.Setup(f => f.Name).Returns("test");
         mockFile.Setup(f => f.Owner).Returns("owner");
         mockFile.Setup(f => f.Extension).Returns("txt");
@@ -484,6 +505,9 @@ public class WopiExtensionsTests
     public async Task GetWopiCheckFileInfo_WithAllPermissions_ReturnsAllTrue()
     {
         var mockFile = new Mock<IWopiFile>();
+        // Stub Checksum so GetEncodedSha256 takes the early-return path; otherwise it would
+        // call GetReadStream (also unmocked), and ComputeHashAsync(null) throws.
+        mockFile.Setup(f => f.Checksum).Returns(new ReadOnlyMemory<byte>([0]));
         mockFile.Setup(f => f.Name).Returns("test");
         mockFile.Setup(f => f.Owner).Returns("owner");
         mockFile.Setup(f => f.Extension).Returns("txt");

--- a/test/WopiHost.Core.Tests/Extensions/WopiExtensionsTests.cs
+++ b/test/WopiHost.Core.Tests/Extensions/WopiExtensionsTests.cs
@@ -17,7 +17,7 @@ public class WopiExtensionsTests
     {
         var mockFile = new Mock<IWopiFile>();
         var checksum = new byte[] { 1, 2, 3, 4, 5 };
-        mockFile.Setup(f => f.Checksum).Returns(checksum);
+        mockFile.Setup(f => f.Checksum).Returns(new ReadOnlyMemory<byte>(checksum));
 
         var result = await mockFile.Object.GetEncodedSha256();
 
@@ -28,7 +28,7 @@ public class WopiExtensionsTests
     public async Task GetEncodedSha256_CalculatesChecksum_WhenChecksumIsNotProvided()
     {
         var mockFile = new Mock<IWopiFile>();
-        mockFile.Setup(f => f.Checksum).Returns((byte[]?)null);
+        mockFile.Setup(f => f.Checksum).Returns((ReadOnlyMemory<byte>?)null);
         var stream = new MemoryStream([1, 2, 3, 4, 5]);
         mockFile.Setup(f => f.GetReadStream(It.IsAny<CancellationToken>())).ReturnsAsync(stream);
 

--- a/test/WopiHost.Core.Tests/Models/RootContainerInfoTests.cs
+++ b/test/WopiHost.Core.Tests/Models/RootContainerInfoTests.cs
@@ -11,7 +11,7 @@ public class RootContainerInfoTests
         var info = new WopiCheckContainerInfo { Name = "Root" };
         var sut = new RootContainerInfo
         {
-            ContainerPointer = new ChildContainer("Root", "https://wopi/root"),
+            ContainerPointer = new ChildContainer("Root", new Uri("https://wopi/root")),
             ContainerInfo = info,
         };
 

--- a/test/WopiHost.IntegrationTests/Fixtures/FakeDiscoverer.cs
+++ b/test/WopiHost.IntegrationTests/Fixtures/FakeDiscoverer.cs
@@ -21,8 +21,6 @@ internal sealed class FakeDiscoverer : IDiscoverer
     public Task<IEnumerable<string>> GetActionRequirementsAsync(string extension, WopiActionEnum action) =>
         Task.FromResult(Enumerable.Empty<string>());
 
-    public Task<bool> RequiresCobaltAsync(string extension, WopiActionEnum action) => Task.FromResult(false);
-
     public Task<string?> GetApplicationNameAsync(string extension) => Task.FromResult<string?>("FakeOffice");
 
     public Task<Uri?> GetApplicationFavIconAsync(string extension) =>

--- a/test/WopiHost.Url.Tests/WopiUrlGeneratorTests.cs
+++ b/test/WopiHost.Url.Tests/WopiUrlGeneratorTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Text.RegularExpressions;
 using FakeItEasy;
 using Microsoft.Extensions.Logging.Abstractions;
 using WopiHost.Discovery;
@@ -6,8 +7,12 @@ using WopiHost.Discovery.Enumerations;
 
 namespace WopiHost.Url.Tests;
 
-public class WopiUrlGeneratorTests
+public partial class WopiUrlGeneratorTests
 {
+    /// <summary>Counts WopiSrc occurrences in the generated URL (case-insensitive).</summary>
+    [GeneratedRegex("wopisrc=", RegexOptions.IgnoreCase)]
+    private static partial Regex WopiSrcParamRegex();
+
     private readonly IDiscoverer _discoverer;
 
     public WopiUrlGeneratorTests()
@@ -72,7 +77,7 @@ public class WopiUrlGeneratorTests
         // The substitution is URL-escaped and lowercase per the template.
         Assert.Contains("wopisrc=" + Uri.EscapeDataString(fileUrl.ToString()), result, StringComparison.Ordinal);
         // No second copy of the param — case-insensitive count of "wopisrc=" must be exactly 1.
-        Assert.Single(System.Text.RegularExpressions.Regex.Matches(result, "wopisrc=", System.Text.RegularExpressions.RegexOptions.IgnoreCase));
+        Assert.Single(WopiSrcParamRegex().Matches(result));
     }
 
     [Fact]
@@ -86,7 +91,7 @@ public class WopiUrlGeneratorTests
         var result = await urlGenerator.GetFileUrlAsync("xlsx", fileUrl, WopiActionEnum.Edit);
 
         Assert.NotNull(result);
-        Assert.Single(System.Text.RegularExpressions.Regex.Matches(result, "wopisrc=", System.Text.RegularExpressions.RegexOptions.IgnoreCase));
+        Assert.Single(WopiSrcParamRegex().Matches(result));
         Assert.Contains("WOPISrc=" + Uri.EscapeDataString(fileUrl.ToString()), result, StringComparison.Ordinal);
     }
 

--- a/test/WopiHost.Url.Tests/WopiUrlGeneratorTests.cs
+++ b/test/WopiHost.Url.Tests/WopiUrlGeneratorTests.cs
@@ -54,6 +54,62 @@ public class WopiUrlGeneratorTests
     }
 
     [Fact]
+    public async Task GetFileUrlAsync_TemplateContainsWopiSourcePlaceholder_SubstitutesAndDoesNotAppendDuplicate()
+    {
+        // Modern OOS / M365 templates carry `<wopisrc=WOPI_SOURCE&>`. Prior to the WOPI_SOURCE fix
+        // the builder would unconditionally append `&WOPISrc=...`, producing two WopiSrc params
+        // (lowercase from the substitution + uppercase from the append). The placeholder must now
+        // be auto-populated from the wopiFileUrl parameter and the unconditional append skipped.
+        const string template = "https://office.example.com/x/_vti_bin/excelserviceinternal.asmx?<ui=UI_LLCC&><wopisrc=WOPI_SOURCE&>";
+        A.CallTo(() => _discoverer.GetUrlTemplateAsync("xlsm", WopiActionEnum.LegacyWebService)).ReturnsLazily(() => template);
+
+        var urlGenerator = new WopiUrlBuilder(_discoverer, NullLogger<WopiUrlBuilder>.Instance);
+        var fileUrl = new Uri("http://wopihost:5000/wopi/files/test.xlsm");
+
+        var result = await urlGenerator.GetFileUrlAsync("xlsm", fileUrl, WopiActionEnum.LegacyWebService);
+
+        Assert.NotNull(result);
+        // The substitution is URL-escaped and lowercase per the template.
+        Assert.Contains("wopisrc=" + Uri.EscapeDataString(fileUrl.ToString()), result, StringComparison.Ordinal);
+        // No second copy of the param — case-insensitive count of "wopisrc=" must be exactly 1.
+        Assert.Single(System.Text.RegularExpressions.Regex.Matches(result, "wopisrc=", System.Text.RegularExpressions.RegexOptions.IgnoreCase));
+    }
+
+    [Fact]
+    public async Task GetFileUrlAsync_TemplateWithoutWopiSourcePlaceholder_AppendsWopiSrcExactlyOnce()
+    {
+        // Backward-compat path: templates that don't include the WOPI_SOURCE placeholder still
+        // get the unconditional `&WOPISrc=` append.
+        var urlGenerator = new WopiUrlBuilder(_discoverer, NullLogger<WopiUrlBuilder>.Instance);
+        var fileUrl = new Uri("http://wopihost:5000/wopi/files/test.xlsx");
+
+        var result = await urlGenerator.GetFileUrlAsync("xlsx", fileUrl, WopiActionEnum.Edit);
+
+        Assert.NotNull(result);
+        Assert.Single(System.Text.RegularExpressions.Regex.Matches(result, "wopisrc=", System.Text.RegularExpressions.RegexOptions.IgnoreCase));
+        Assert.Contains("WOPISrc=" + Uri.EscapeDataString(fileUrl.ToString()), result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetFileUrlAsync_CallerProvidedWopiSourceSetting_IsOverriddenByFileUrlParameter()
+    {
+        // Defensive: even if a caller leaks WOPI_SOURCE into urlSettings, the wopiFileUrl
+        // parameter wins. The builder owns the single source of truth for the WopiSrc value.
+        const string template = "https://office.example.com/x/_layouts/foo.aspx?<wopisrc=WOPI_SOURCE&>";
+        A.CallTo(() => _discoverer.GetUrlTemplateAsync("xlsm", WopiActionEnum.LegacyWebService)).ReturnsLazily(() => template);
+
+        var settings = new WopiUrlSettings { ["WOPI_SOURCE"] = "http://impostor/file/999" };
+        var urlGenerator = new WopiUrlBuilder(_discoverer, NullLogger<WopiUrlBuilder>.Instance, settings);
+        var fileUrl = new Uri("http://wopihost:5000/wopi/files/real.xlsm");
+
+        var result = await urlGenerator.GetFileUrlAsync("xlsm", fileUrl, WopiActionEnum.LegacyWebService);
+
+        Assert.NotNull(result);
+        Assert.Contains("wopisrc=" + Uri.EscapeDataString(fileUrl.ToString()), result, StringComparison.Ordinal);
+        Assert.DoesNotContain("impostor", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void WopiUrlSettings_AssignedProperties_ExposeSameValues()
     {
         var businessUser = new Random(DateTime.Now.Millisecond).Next();
@@ -69,7 +125,6 @@ public class WopiUrlGeneratorTests
         var perfstats = new Random(DateTime.Now.Millisecond).Next();
         var hostSessionId = Guid.NewGuid().ToString();
         var sessionContext = Guid.NewGuid().ToString();
-        var wopiSource = "c:\\doc.docx";
         var validatorTestCategory = ValidatorTestCategoryEnum.All;
 
         var settings = new WopiUrlSettings()
@@ -87,11 +142,10 @@ public class WopiUrlGeneratorTests
             Perfstats = perfstats,
             HostSessionId = hostSessionId,
             SessionContext = sessionContext,
-            WopiSource = wopiSource,
             ValidatorTestCategory = validatorTestCategory
         };
 
-        Assert.Equal(15, settings.Count);
+        Assert.Equal(14, settings.Count);
         Assert.Equal(businessUser, settings.BusinessUser);
         Assert.Equal(uiLlcc, settings.UiLlcc);
         Assert.Equal(dcLlcc, settings.DcLlcc);
@@ -105,7 +159,6 @@ public class WopiUrlGeneratorTests
         Assert.Equal(perfstats, settings.Perfstats);
         Assert.Equal(hostSessionId, settings.HostSessionId);
         Assert.Equal(sessionContext, settings.SessionContext);
-        Assert.Equal(wopiSource, settings.WopiSource);
         Assert.Equal(validatorTestCategory, settings.ValidatorTestCategory);
     }
 }


### PR DESCRIPTION
Closes the remaining open items on issue [#331](https://github.com/petrsvihlik/WopiHost/issues/331) (item 1 already shipped in #338). Six logical commits, all on master.

## Summary

| # | Commit | What |
|---|---|---|
| `b4347b5` | `fix(analyzers): CA5392 + SYSLIB0001` | Replace `#pragma` suppressions with attributes / explanatory comments. **Item 3a + 3b.** |
| `0ef2899` | `fix(url): unify WOPI_SOURCE placeholder with wopiFileUrl parameter` | The `WopiUrlSettings.WopiSource` property + the unconditional `&WOPISrc=` append could produce two different WopiSrc params in the same URL when modern M365/OOS templates carried the placeholder. Single source of truth = the `wopiFileUrl` parameter. **Item 2a.** |
| `6e6ded4` | `refactor(discovery): RequiresCobaltAsync → extension method` | Pure function over `GetActionRequirementsAsync`; no instance state. Move out of the interface. **Item 2b.** |
| `0fd1517` | `refactor(api): IWopiFile.Checksum byte[]? → ReadOnlyMemory<byte>?` | Modern, immutable view; no allocation per access. `WopiSecurityOptions.SigningKey` intentionally stays `byte[]` (config binder + HMAC API both want it). **Item 3c.** |
| `4fbb9b2` | `refactor(api): URL-bearing response models string → System.Uri` | `UrlResponse`, `BootstrapInfo.EcosystemUrl`, `AbstractChildBase`, `ChildContainer`, `ChildFile`, `IUrlHelper.GetWopiSrc(...)`. JSON wire format unchanged. **Item 3d.** |
| `3d2d194` | `fix(audit): CT propagation + OCE handling` | `ICobaltProcessor.ProcessCobalt`, `Stream.ReadBytesAsync`, `FileResult.ExecuteResultAsync` now thread `CancellationToken`. Action filter detects client-disconnect OCE and tags it as new `cancelled` outcome instead of `error`. **Item 4.** |

## Breaking changes

`SigningKey` and lock-release-on-exception are explicitly *not* in this PR — see commit messages for rationale on each. Everything else listed in #331's open items is here.

| API | Before | After |
|---|---|---|
| `WopiUrlSettings.WopiSource` | `string` property | **removed** — pass via `wopiFileUrl` |
| `IDiscoverer.RequiresCobaltAsync` | interface method | **removed**, available as extension |
| `IWopiFile.Checksum` | `byte[]?` | `ReadOnlyMemory<byte>?` |
| `UrlResponse(Url)` | `string` | `Uri` |
| `BootstrapInfo.EcosystemUrl` | `string?` | `Uri?` |
| `AbstractChildBase(Name, Url)` | `(string, string)` | `(string, Uri)` |
| `ChildContainer(Name, Url)` | `(string, string)` | `(string, Uri)` |
| `ChildFile(Name, Url)` | `(string, string)` | `(string, Uri)` |
| `IUrlHelper.GetWopiSrc(...)` × 2 overloads | returns `string` | returns `Uri` |
| `ICobaltProcessor.ProcessCobalt` | `(file, principal, newContent)` | `(file, principal, newContent, CancellationToken = default)` |

System.Text.Json's `UriConverter` keeps the wire format identical for JSON consumers. Implementors of the affected interfaces / overriders need to follow.

## Verification

- Build: 0 warnings, 0 errors across net8.0 / net9.0 / net10.0.
- Non-Docker tests:
  - `WopiHost.Core.Tests` — 335 ✅
  - `WopiHost.Url.Tests` — 11 ✅ (includes 3 new regression tests for the WOPI_SOURCE fix)
  - `WopiHost.Discovery.Tests` — 80 ✅
  - `WopiHost.MemoryLockProvider.Tests` — 9 ✅
  - `WopiHost.FileSystemProvider.Tests` — 94 ✅
- Docker-dependent (Azure*Tests, IntegrationTests) — left for CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)