### PR TITLE
fix(azure-lock): close AddLockAsync race (#331 item 4b)

### DIFF
--- a/src/WopiHost.AzureLockProvider/WopiAzureLockProvider.cs
+++ b/src/WopiHost.AzureLockProvider/WopiAzureLockProvider.cs
@@ -68,58 +68,80 @@ public partial class WopiAzureLockProvider(BlobContainerClient containerClient, 
         await EnsureContainerAsync(cancellationToken).ConfigureAwait(false);
         var blobClient = GetLockBlob(fileId);
 
-        // Honour WOPI expiry: a stale (>30 min old) lock can be taken over.
+        // Step 1: probe existing state.
         var existing = await TryGetPropertiesAsync(blobClient, cancellationToken).ConfigureAwait(false);
-        if (existing is not null && TryReadLock(fileId, existing, out var existingInfo) && !existingInfo.Expired)
-        {
-            LogLockAddRejected(logger, fileId, lockId, existingInfo.LockId);
-            return null;
-        }
         if (existing is not null)
         {
-            // Either no valid metadata or expired. Break the lease and delete so we can start fresh.
-            await TryBreakLeaseAsync(blobClient, cancellationToken).ConfigureAwait(false);
-            await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (TryReadLock(fileId, existing, out var existingInfo))
+            {
+                if (!existingInfo.Expired)
+                {
+                    LogLockAddRejected(logger, fileId, lockId, existingInfo.LockId);
+                    return null;
+                }
+                // Stale (>30 min old) — clean up so we can take over.
+                await TryBreakLeaseAsync(blobClient, cancellationToken).ConfigureAwait(false);
+                await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                // Blob exists but metadata is missing/malformed. With the atomic upload-with-
+                // metadata flow below, healthy peers never observe this state — it can only mean
+                // a peer is mid-acquire RIGHT NOW (we lost the race) or a previous attempt
+                // crashed between Upload and lease acquisition. Either way, treat it as
+                // "lock-attempt in progress" and yield. (Aggressive cleanup here was the prior
+                // bug that broke healthy peers via lease-break + delete in their acquire window.)
+                LogLockAddRaceLost(logger, fileId, lockId);
+                return null;
+            }
         }
 
-        // Upload the placeholder. If two callers race here, exactly one wins (overwrite=false).
-        try
-        {
-            using var empty = new MemoryStream([], writable: false);
-            await blobClient.UploadAsync(empty, overwrite: false, cancellationToken: cancellationToken).ConfigureAwait(false);
-        }
-        catch (RequestFailedException ex) when (ex.Status == 409)
-        {
-            // Raced with another caller that just created the blob.
-            LogLockAddRaceLost(logger, fileId, lockId);
-            return null;
-        }
-
+        // Step 2: atomic upload-with-metadata. The blob is never observable in a "no metadata"
+        // state, so any peer's TryReadLock either gets a complete WopiLockInfo (we won) or the
+        // blob doesn't yet exist (their probe hits before our upload lands). IfNoneMatch=*
+        // serves as the create-if-not-exists conditional: a 412 means a sibling acquire raced
+        // ahead and we lost. Some Azure SDK paths surface 409 instead — we treat both as the
+        // race-lost outcome.
         var leaseId = Guid.NewGuid().ToString();
         var now = DateTimeOffset.UtcNow;
-        var leaseClient = blobClient.GetBlobLeaseClient(leaseId);
-
-        try
-        {
-            await leaseClient.AcquireAsync(TimeSpan.FromSeconds(-1), cancellationToken: cancellationToken).ConfigureAwait(false);
-        }
-        catch (RequestFailedException ex)
-        {
-            // Couldn't lease — clean up the placeholder so we don't leave a no-op blob behind.
-            LogLeaseAcquireFailed(logger, ex, fileId);
-            await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-            return null;
-        }
-
         var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
         {
             [LockIdKey] = lockId,
             [LeaseIdKey] = leaseId,
             [CreatedKey] = now.ToString("O", CultureInfo.InvariantCulture),
         };
-        await blobClient.SetMetadataAsync(metadata,
-            conditions: new BlobRequestConditions { LeaseId = leaseId },
-            cancellationToken: cancellationToken).ConfigureAwait(false);
+        try
+        {
+            using var empty = new MemoryStream([], writable: false);
+            await blobClient.UploadAsync(
+                empty,
+                new BlobUploadOptions
+                {
+                    Metadata = metadata,
+                    Conditions = new BlobRequestConditions { IfNoneMatch = ETag.All },
+                },
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (RequestFailedException ex) when (ex.Status == 409 || ex.Status == 412)
+        {
+            LogLockAddRaceLost(logger, fileId, lockId);
+            return null;
+        }
+
+        // Step 3: acquire the infinite lease whose id is already announced via metadata. If
+        // this fails, delete the placeholder so we don't leave a no-op blob behind that claims
+        // a lease we don't actually hold.
+        var leaseClient = blobClient.GetBlobLeaseClient(leaseId);
+        try
+        {
+            await leaseClient.AcquireAsync(TimeSpan.FromSeconds(-1), cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (RequestFailedException ex)
+        {
+            LogLeaseAcquireFailed(logger, ex, fileId);
+            await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            return null;
+        }
 
         LogLockAcquired(logger, fileId, lockId);
         return new WopiLockInfo { FileId = fileId, LockId = lockId, DateCreated = now };

--- a/test/WopiHost.AzureLockProvider.Tests/WopiAzureLockProviderEdgeCaseTests.cs
+++ b/test/WopiHost.AzureLockProvider.Tests/WopiAzureLockProviderEdgeCaseTests.cs
@@ -201,6 +201,30 @@ public class WopiAzureLockProviderEdgeCaseTests(AzuriteFixture azurite)
     }
 
     [Fact]
+    public async Task AddLockAsync_ConcurrentRace_OneWinsOthersReturnNull()
+    {
+        // Regression test for the race that prompted #331 item 4b. With the atomic upload-with-
+        // metadata fix in place, six concurrent AddLockAsync calls converge on:
+        //   - exactly one winner (whose UploadAsync IfNoneMatch=* succeeds first)
+        //   - five losers that see either 412/409 from UploadAsync or, if their TryGetProperties
+        //     fired after the winner's upload, a fully-formed metadata blob → return null.
+        // Prior to the fix, peers' TryGetProperties hitting the brief Upload→SetMetadata window
+        // would observe an empty-metadata blob, enter the cleanup path, break the winner's
+        // lease, and clobber the acquire — surfacing as LeaseNotPresentWithBlobOperation on the
+        // winner's pending SetMetadata.
+        var (provider, _) = await CreateProviderAsync();
+        var fileId = $"file-race-{Guid.NewGuid():N}";
+
+        var tasks = Enumerable.Range(0, 6)
+            .Select(i => provider.AddLockAsync(fileId, $"lock-{i}"))
+            .ToArray();
+        var results = await Task.WhenAll(tasks);
+
+        Assert.Single(results, r => r is not null);
+        Assert.Equal(results.Length - 1, results.Count(r => r is null));
+    }
+
+    [Fact]
     public async Task Constructor_NullArgs_Throws()
     {
         Assert.Throws<ArgumentNullException>(

--- a/test/WopiHost.AzureLockProvider.Tests/WopiAzureLockProviderEdgeCaseTests.cs
+++ b/test/WopiHost.AzureLockProvider.Tests/WopiAzureLockProviderEdgeCaseTests.cs
@@ -182,10 +182,15 @@ public class WopiAzureLockProviderEdgeCaseTests(AzuriteFixture azurite)
     }
 
     [Fact]
-    public async Task AddLockAsync_BlobExistsButNoMetadata_TakesOver()
+    public async Task AddLockAsync_BlobExistsButNoMetadata_ReturnsNull_ToProtectInFlightAcquires()
     {
-        // Hits the "existing blob with no readable lock metadata" → break-lease + delete path,
-        // then proceeds to upload + acquire.
+        // After the #353 race fix the "no readable metadata" branch yields rather than cleaning
+        // up — that aggressive cleanup was the bug it was clobbering healthy peers mid-acquire.
+        // A bare metadata-less blob can mean either (a) a sibling acquire happening right now,
+        // whose UploadAsync has landed but whose AcquireAsync hasn't returned yet, or (b) an
+        // unlikely operator-created stub or a pre-fix crashed acquire. Either way, the safe
+        // answer is to return null; case (b) requires manual cleanup, which is documented and
+        // very rare since the new flow uploads metadata atomically.
         var (provider, _) = await CreateProviderAsync();
         var lockBlob = GetLockBlob(provider, "file-stale-blob");
         using (var empty = new MemoryStream([]))
@@ -196,8 +201,7 @@ public class WopiAzureLockProviderEdgeCaseTests(AzuriteFixture azurite)
 
         var info = await provider.AddLockAsync("file-stale-blob", "fresh");
 
-        Assert.NotNull(info);
-        Assert.Equal("fresh", info.LockId);
+        Assert.Null(info);
     }
 
     [Fact]


### PR DESCRIPTION
Closes [issue #331](https://github.com/petrsvihlik/WopiHost/issues/331) item 4b — the pre-existing race in `WopiAzureLockProvider.AddLockAsync` surfaced by #338's tests but not fixed there.

## The race

Old flow:

```
1. probe blob (TryGetProperties)
2. if exists with valid metadata + !Expired → return null
   if exists otherwise → break lease + delete
3. UploadAsync(empty)               ← blob now exists with NO metadata
4. AcquireAsync(lease)
5. SetMetadataAsync(LockId, LeaseId, Created)
```

Between steps 3 and 5, peer's `TryGetProperties` sees the metadata-less blob and falls into the step-2 cleanup branch — breaks the winner's lease, deletes the blob — and the winner's pending `SetMetadata` fails with `LeaseNotPresentWithBlobOperation`.

## Fix

```
1. probe blob → branch on TryReadLock outcome
     - valid + !Expired       → return null (lock held)
     - valid + Expired        → break lease + delete (take over)
     - present but unreadable → return null  ← key change
2. UploadAsync(empty, Metadata=…, IfNoneMatch=*)  — atomic create-with-metadata
   on 412/409 → return null (race lost)
3. AcquireAsync(lease)
   on failure → delete placeholder + return null
```

The blob is now never observable in a "no metadata" state. Peers' `TryReadLock` either gets the full `WopiLockInfo` (we won) or 404 (their probe hit before our upload landed). The aggressive cleanup branch can no longer fire on a healthy peer's in-flight acquire — the lone case it can fire on is genuinely stale `Expired` metadata, where the takeover is correct.

The "present but unreadable" branch returning `null` instead of cleaning up is the other half of the fix. Pre-fix, this was the cleanup that clobbered healthy peers. Post-fix, healthy peers always observe full metadata from atomic upload, so this branch only triggers for:
- a sibling acquire **right now** — yield, correct
- a crashed acquire from a pre-fix version — operator can clean up manually; rare migration concern

## Test

Re-added the `AddLockAsync_ConcurrentRace_OneWinsOthersReturnNull` regression test that was dropped from #338. Six concurrent `AddLockAsync` calls; expect exactly one winner and five clean `null`s. Couldn't run locally (no Docker for Azurite); CI will validate.

## Test plan

- [x] Build clean across net8.0 / net9.0 / net10.0
- [ ] CI verifies `WopiAzureLockProvider.Tests` passes (Azurite via Testcontainers), including the re-added race test
- [ ] No regression in the existing `RefreshLockAsync` / `RemoveLockAsync` / `GetLockAsync` flows — they read the same metadata shape we now write atomically

🤖 Generated with [Claude Code](https://claude.com/claude-code)