### PR TITLE
chore: enable IDE0005 + IDE0161 and clean up unused usings (#331 item 6)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,12 @@ dotnet_diagnostic.CA1056.severity = suggestion
 
 # CA1819: Properties should not return arrays
 dotnet_diagnostic.CA1819.severity = suggestion
+
+# IDE0005: Remove unnecessary using directives
+# Note: IDE0005 only fires at build-time when GenerateDocumentationFile is true.
+# It is enabled here for the IDE; the build-time guarantee is in Directory.Build.props.
+dotnet_diagnostic.IDE0005.severity = warning
+
+# IDE0161: Convert to file-scoped namespace
+csharp_style_namespace_declarations = file_scoped:warning
+dotnet_diagnostic.IDE0161.severity = warning

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,16 @@
 		     own Directory.Build.props) don't end up with a separate test/artifacts/. -->
 		<UseArtifactsOutput>true</UseArtifactsOutput>
 		<ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
+		<!-- IDE0005 (remove unnecessary usings) only fires at build-time when XML docs
+		     are generated, so enable doc generation everywhere. Non-packable projects
+		     silence CS1591 below to avoid missing-doc warning floods. -->
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+	</PropertyGroup>
+
+	<!-- Non-packable projects (samples, infra, tests): silence CS1591 since they don't
+	     ship to consumers and don't need XML docs on every public member. -->
+	<PropertyGroup Condition="$(IsPackable) != 'true' OR $(PackageId) == ''">
+		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
 
 	<!-- Package Validation Configuration for NuGet packages -->
@@ -22,9 +32,6 @@
 		<!-- Baseline used to detect public-API breaks against the last released version.
 		     Bump this in lockstep with releases. -->
 		<PackageValidationBaselineVersion>6.0.0</PackageValidationBaselineVersion>
-		<!-- Generate XML doc files alongside the assembly. Letting the SDK pick the
-		     path keeps it in sync with UseArtifactsOutput. -->
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
 	
 	<ItemGroup Condition="!$(MSBuildProjectName.EndsWith('Tests'))">

--- a/sample/WopiHost.Validator/Infrastructure/NoOpProofValidator.cs
+++ b/sample/WopiHost.Validator/Infrastructure/NoOpProofValidator.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.Http;
 using WopiHost.Core.Security.Authentication;
 
 namespace WopiHost.Validator.Infrastructure;

--- a/sample/WopiHost.Validator/Pages/HostPage.cshtml.cs
+++ b/sample/WopiHost.Validator/Pages/HostPage.cshtml.cs
@@ -2,8 +2,6 @@ using System.Globalization;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using WopiHost.Abstractions;
 using WopiHost.Core.Infrastructure;

--- a/sample/WopiHost.Web.Oidc/Controllers/HomeController.cs
+++ b/sample/WopiHost.Web.Oidc/Controllers/HomeController.cs
@@ -2,7 +2,6 @@ using System.Globalization;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using WopiHost.Abstractions;
 using WopiHost.Discovery;

--- a/sample/WopiHost.Web/Controllers/HomeController.cs
+++ b/sample/WopiHost.Web/Controllers/HomeController.cs
@@ -3,7 +3,6 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using WopiHost.Abstractions;

--- a/sample/WopiHost/Program.cs
+++ b/sample/WopiHost/Program.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection.Extensions;
+﻿using Microsoft.Extensions.DependencyInjection.Extensions;
 using Serilog;
 using Serilog.Events;
 using WopiHost.Abstractions;

--- a/sample/WopiHost/ServiceCollectionExtensions.cs
+++ b/sample/WopiHost/ServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 using System.Runtime.Loader;
-using Microsoft.Extensions.Configuration;
 using WopiHost.Abstractions;
 using WopiHost.AzureLockProvider;
 using WopiHost.AzureStorageProvider;

--- a/src/WopiHost.Abstractions/IWopiAuthorizationRequirement.cs
+++ b/src/WopiHost.Abstractions/IWopiAuthorizationRequirement.cs
@@ -15,7 +15,6 @@ public enum WopiResourceType
     Container
 }
 
-
 /// <summary>
 /// Represents an authorization requirement for a given combination of resource, user, and action.
 /// </summary>

--- a/src/WopiHost.AzureStorageProvider/WopiBlobFile.cs
+++ b/src/WopiHost.AzureStorageProvider/WopiBlobFile.cs
@@ -1,4 +1,3 @@
-using System.Security.Cryptography;
 using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;

--- a/src/WopiHost.Cobalt/CobaltSession.cs
+++ b/src/WopiHost.Cobalt/CobaltSession.cs
@@ -21,7 +21,7 @@ namespace WopiHost.Cobalt;
 /// </para>
 /// <para>
 /// Sessions are cached in a <see cref="ConcurrentDictionary{TKey,TValue}"/>
-/// keyed by <see cref="IWopiFile.Identifier"/>. A periodic timer evicts idle
+/// keyed by <see cref="IWopiResource.Identifier"/>. A periodic timer evicts idle
 /// sessions after <see cref="SessionIdleTimeout"/> to keep memory bounded —
 /// the <see cref="LocalHostBlobStore"/> backing each session is in-memory.
 /// </para>

--- a/src/WopiHost.Core/Controllers/FilesController.cs
+++ b/src/WopiHost.Core/Controllers/FilesController.cs
@@ -3,7 +3,6 @@ using System.Security.Claims;
 using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
 using WopiHost.Abstractions;

--- a/src/WopiHost.Core/Controllers/WopiBootstrapperController.cs
+++ b/src/WopiHost.Core/Controllers/WopiBootstrapperController.cs
@@ -1,7 +1,6 @@
 using System.Net.Mime;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using WopiHost.Abstractions;
 using WopiHost.Core.Extensions;

--- a/src/WopiHost.Core/Security/WopiSecurityOptions.cs
+++ b/src/WopiHost.Core/Security/WopiSecurityOptions.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.IdentityModel.Tokens;
 

--- a/test/WopiHost.AzureLockProvider.Tests/WopiAzureLockProviderEdgeCaseTests.cs
+++ b/test/WopiHost.AzureLockProvider.Tests/WopiAzureLockProviderEdgeCaseTests.cs
@@ -1,6 +1,5 @@
 using System.Reflection;
 using Azure.Storage.Blobs;
-using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;

--- a/test/WopiHost.AzureLockProvider.Tests/WopiAzureLockProviderTests.cs
+++ b/test/WopiHost.AzureLockProvider.Tests/WopiAzureLockProviderTests.cs
@@ -3,7 +3,6 @@ using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Microsoft.Extensions.Logging.Abstractions;
-using WopiHost.Abstractions;
 using Xunit;
 
 namespace WopiHost.AzureLockProvider.Tests;

--- a/test/WopiHost.Core.Tests/Controllers/FoldersControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/FoldersControllerTests.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Mvc.Routing;
 using Moq;
 using WopiHost.Abstractions;
 using WopiHost.Core.Controllers;
-using WopiHost.Core.Infrastructure;
 using WopiHost.Core.Models;
 using WopiHost.Core.Results;
 

--- a/test/WopiHost.Core.Tests/Controllers/WopiBootstrapperControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/WopiBootstrapperControllerTests.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Routing;
-using Microsoft.AspNetCore.Routing;
 using Moq;
 using WopiHost.Abstractions;
 using WopiHost.Core.Controllers;

--- a/test/WopiHost.Core.Tests/Extensions/ExtensionsTests.cs
+++ b/test/WopiHost.Core.Tests/Extensions/ExtensionsTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Text;
-using WopiHost.Core.Extensions;
+﻿using WopiHost.Core.Extensions;
 
 namespace WopiHost.Core.Tests.Extensions;
 

--- a/test/WopiHost.Core.Tests/Extensions/HttpRequestExtensionsTests.cs
+++ b/test/WopiHost.Core.Tests/Extensions/HttpRequestExtensionsTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Primitives;
 using Moq;
 using WopiHost.Core.Extensions;
 

--- a/test/WopiHost.Core.Tests/Infrastructure/WopiTelemetryActionFilterTests.cs
+++ b/test/WopiHost.Core.Tests/Infrastructure/WopiTelemetryActionFilterTests.cs
@@ -1,8 +1,6 @@
 using System.Diagnostics;
-using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Routing;

--- a/test/WopiHost.Core.Tests/Security/Authentication/WopiOriginValidationActionFilterTests.cs
+++ b/test/WopiHost.Core.Tests/Security/Authentication/WopiOriginValidationActionFilterTests.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
-using WopiHost.Abstractions;
 using WopiHost.Core.Security.Authentication;
 
 namespace WopiHost.Core.Tests.Security.Authentication;

--- a/test/WopiHost.Discovery.Tests/FileSystemDiscoveryFileProviderTests.cs
+++ b/test/WopiHost.Discovery.Tests/FileSystemDiscoveryFileProviderTests.cs
@@ -1,6 +1,5 @@
 using System.Xml;
 using Microsoft.Extensions.Logging.Abstractions;
-using WopiHost.Discovery;
 
 namespace WopiHost.Discovery.Tests;
 

--- a/test/WopiHost.Discovery.Tests/HttpDiscoveryFileProviderTests.cs
+++ b/test/WopiHost.Discovery.Tests/HttpDiscoveryFileProviderTests.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using System.Xml.Linq;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace WopiHost.Discovery.Tests;

--- a/test/WopiHost.Discovery.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/WopiHost.Discovery.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using WopiHost.Discovery.Enumerations;
 
 namespace WopiHost.Discovery.Tests;
 

--- a/test/WopiHost.IntegrationTests/Fixtures/OidcWebAppFactory.cs
+++ b/test/WopiHost.IntegrationTests/Fixtures/OidcWebAppFactory.cs
@@ -1,8 +1,5 @@
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using WopiHost.Web.Oidc;
 
 namespace WopiHost.IntegrationTests.Fixtures;

--- a/test/WopiHost.IntegrationTests/Fixtures/TestAuthHandler.cs
+++ b/test/WopiHost.IntegrationTests/Fixtures/TestAuthHandler.cs
@@ -1,7 +1,6 @@
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace WopiHost.IntegrationTests.Fixtures;

--- a/test/WopiHost.IntegrationTests/Fixtures/TestAuthOidcWebAppFactory.cs
+++ b/test/WopiHost.IntegrationTests/Fixtures/TestAuthOidcWebAppFactory.cs
@@ -1,8 +1,5 @@
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using WopiHost.Discovery;
 using WopiHost.Web.Oidc;
 

--- a/test/WopiHost.IntegrationTests/Fixtures/WopiBackendFactory.cs
+++ b/test/WopiHost.IntegrationTests/Fixtures/WopiBackendFactory.cs
@@ -1,7 +1,4 @@
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using WopiHost.Core.Security.Authentication;
 
 namespace WopiHost.IntegrationTests.Fixtures;


### PR DESCRIPTION
## Summary

Resolves item 6 of #331 — simplify usings and file-scoped namespaces sweep.

- Promotes **IDE0005** (remove unnecessary usings) and **IDE0161** (file-scoped namespaces) to `warning` in `.editorconfig`. Combined with `TreatWarningsAsErrors=true`, future drift is caught at build time.
- IDE0005 only fires at build-time when XML docs are generated, so `GenerateDocumentationFile` is now enabled solution-wide. Non-packable projects (samples, infra, tests) silence `CS1591` to avoid missing-doc warning floods on internals they don't ship.
- Removes 30+ unused using directives across `src/`, `sample/`, and `test/` — mostly things already imported via the Web SDK's implicit usings.
- All namespaces are already file-scoped except `sample/WopiHost.Web.Oidc/Program.cs`, which can't be converted because it follows top-level statements (and so any namespace declaration must be block-scoped at the bottom).

## Test plan

- [ ] CI build passes with `TreatWarningsAsErrors=true` (i.e. no IDE0005/IDE0161 escapes).
- [ ] Full test suite still passes (the one flake on `WopiTelemetryTests.StartActivity_NoListener_ReturnsNull` is pre-existing parallel-test global-Activity-state contamination, unrelated to these changes — passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)