### PR TITLE
refactor: extract spec-mandated constants and placeholder strings (#331 item 5)

### DIFF
--- a/src/WopiHost.Abstractions/IWopiLockProvider.cs
+++ b/src/WopiHost.Abstractions/IWopiLockProvider.cs
@@ -51,6 +51,16 @@ public interface IWopiLockProvider
 public record WopiLockInfo
 {
     /// <summary>
+    /// Lock auto-expiration window mandated by the WOPI specification.
+    /// </summary>
+    /// <remarks>
+    /// Per <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/lock"/>,
+    /// WOPI locks MUST automatically expire after 30 minutes if not renewed by the WOPI client.
+    /// This is fixed by the spec and not a tunable.
+    /// </remarks>
+    public const int ExpirationMinutes = 30;
+
+    /// <summary>
     /// The lock identifier
     /// </summary>
     public required string LockId { get; init; }
@@ -68,6 +78,6 @@ public record WopiLockInfo
     /// <summary>
     /// Is this lock expired
     /// </summary>
-    /// <remarks>WOPI locks must automatically expire after 30 minutes if not renewed by the WOPI client</remarks>
-    public bool Expired => DateCreated.AddMinutes(30) < DateTime.UtcNow;
+    /// <remarks>See <see cref="ExpirationMinutes"/> for the spec-mandated 30-minute window.</remarks>
+    public bool Expired => DateCreated.AddMinutes(ExpirationMinutes) < DateTime.UtcNow;
 }

--- a/src/WopiHost.Core/Security/Authentication/WopiProofValidator.cs
+++ b/src/WopiHost.Core/Security/Authentication/WopiProofValidator.cs
@@ -20,6 +20,18 @@ namespace WopiHost.Core.Security.Authentication;
 /// <param name="timeProvider">Provider for time operations (defaults to system time if not provided).</param>
 public partial class WopiProofValidator(IDiscoverer discoverer, ILogger<WopiProofValidator> logger, TimeProvider? timeProvider = null) : IWopiProofValidator
 {
+    /// <summary>
+    /// Maximum age of a request timestamp before it is rejected as stale, in minutes.
+    /// Per WOPI spec: <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/concepts/proof-keys"/>.
+    /// </summary>
+    private const int MaxTimestampAgeMinutes = 20;
+
+    /// <summary>
+    /// Maximum allowed clock skew where a request's timestamp is in the future, in minutes.
+    /// Tolerates small drift between the WOPI client's clock and the host's clock.
+    /// </summary>
+    private const int MaxFutureSkewMinutes = 5;
+
     private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
 
     /// <summary>
@@ -46,12 +58,12 @@ public partial class WopiProofValidator(IDiscoverer discoverer, ILogger<WopiProo
             var sourceProofKeys = await discoverer.GetProofKeysAsync();
 
             // Per WOPI spec: X-WOPI-TimeStamp is .NET DateTime.Ticks (UTC).
-            // Reject timestamps older than 20 minutes; allow a small future skew.
+            // Reject stale timestamps; allow a small future skew.
             var age = _timeProvider.GetUtcNow().UtcDateTime - new DateTime(ticks, DateTimeKind.Utc);
             if (sourceProofKeys.Value is null
                 || sourceProofKeys.OldValue is null
-                || age > TimeSpan.FromMinutes(20)
-                || age < TimeSpan.FromMinutes(-5))
+                || age > TimeSpan.FromMinutes(MaxTimestampAgeMinutes)
+                || age < TimeSpan.FromMinutes(-MaxFutureSkewMinutes))
             {
                 var reason = sourceProofKeys.Value is null || sourceProofKeys.OldValue is null
                     ? "missing_discovery_keys"

--- a/src/WopiHost.Discovery/DiscoveryOptions.cs
+++ b/src/WopiHost.Discovery/DiscoveryOptions.cs
@@ -6,13 +6,19 @@
 public class DiscoveryOptions
 {
     /// <summary>
+    /// Default discovery refresh cadence (24 hours). Office Online publishes a new discovery
+    /// XML at most once a day, so refreshing more often produces no useful change.
+    /// </summary>
+    public const int DefaultRefreshIntervalHours = 24;
+
+    /// <summary>
     /// A network zone to retrieve the configuration from.
     /// </summary>
     public NetZoneEnum NetZone { get; set; }
 
     /// <summary>
     /// Determines how often should the discovery file be fetched again.
-    /// The default value is 24 hours.
+    /// Defaults to <see cref="DefaultRefreshIntervalHours"/> hours.
     /// </summary>
-    public TimeSpan RefreshInterval { get; set; } = TimeSpan.FromHours(24);
+    public TimeSpan RefreshInterval { get; set; } = TimeSpan.FromHours(DefaultRefreshIntervalHours);
 }

--- a/src/WopiHost.Url/WopiUrlBuilder.cs
+++ b/src/WopiHost.Url/WopiUrlBuilder.cs
@@ -60,7 +60,7 @@ public partial class WopiUrlBuilder(
         // value (URL-escaped by ResolveOptionalParameter). Any caller-provided WOPI_SOURCE
         // value in urlSettings is overwritten so we never produce two different WopiSrc
         // values in the same URL.
-        combinedUrlSettings[WopiSourcePlaceholder] = wopiFileUrl.ToString();
+        combinedUrlSettings[WopiUrlSettings.Placeholders.WopiSource] = wopiFileUrl.ToString();
 
         var template = await _wopiDiscoverer.GetUrlTemplateAsync(extension, action);
         if (string.IsNullOrEmpty(template))
@@ -69,7 +69,7 @@ public partial class WopiUrlBuilder(
             return null;
         }
 
-        var templateHasWopiSourcePlaceholder = template.Contains(WopiSourcePlaceholder, StringComparison.Ordinal);
+        var templateHasWopiSourcePlaceholder = template.Contains(WopiUrlSettings.Placeholders.WopiSource, StringComparison.Ordinal);
 
         // Resolve optional parameters
         var url = UrlParamRegex().Replace(template, m => ResolveOptionalParameter(m.Groups["name"].Value, m.Groups["value"].Value, combinedUrlSettings) ?? string.Empty);
@@ -87,8 +87,6 @@ public partial class WopiUrlBuilder(
         LogFileUrlGenerated(_logger, extension, action);
         return url;
     }
-
-    private const string WopiSourcePlaceholder = "WOPI_SOURCE";
 
     private static string? ResolveOptionalParameter(string name, string value, WopiUrlSettings urlSettings)
     {

--- a/src/WopiHost.Url/WopiUrlSettings.cs
+++ b/src/WopiHost.Url/WopiUrlSettings.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 
 namespace WopiHost.Url;
 
@@ -9,16 +9,68 @@ namespace WopiHost.Url;
 public class WopiUrlSettings : Dictionary<string, string>
 {
     /// <summary>
+    /// Names of the placeholder tokens that appear in WOPI discovery URL templates.
+    /// Defined by the WOPI specification: see <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/online/discovery#placeholder-values"/>.
+    /// </summary>
+    public static class Placeholders
+    {
+        /// <summary>The URL of the WOPI host's file endpoint, URL-escaped.</summary>
+        public const string WopiSource = "WOPI_SOURCE";
+
+        /// <summary>UI language tag (RFC 1766).</summary>
+        public const string UiLlcc = "UI_LLCC";
+
+        /// <summary>Data-calculation language tag (RFC 1766).</summary>
+        public const string DcLlcc = "DC_LLCC";
+
+        /// <summary>"true" to render the action embedded in another web page.</summary>
+        public const string Embedded = "EMBEDDED";
+
+        /// <summary>"true" to prevent attendees from navigating a file (broadcast attendee mode).</summary>
+        public const string DisableAsync = "DISABLE_ASYNC";
+
+        /// <summary>"true" to load a view that does not create or join a broadcast session.</summary>
+        public const string DisableBroadcast = "DISABLE_BROADCAST";
+
+        /// <summary>"true" to load the file type in full-screen mode.</summary>
+        public const string Fullscreen = "FULLSCREEN";
+
+        /// <summary>"true" to load the file type with a minimal user interface.</summary>
+        public const string Recording = "RECORDING";
+
+        /// <summary>"1" for light theme, "2" for dark theme.</summary>
+        public const string ThemeId = "THEME_ID";
+
+        /// <summary>"1" to indicate that the user is a business user.</summary>
+        public const string BusinessUser = "BUSINESS_USER";
+
+        /// <summary>"1" to disable chat in the editor session.</summary>
+        public const string DisableChat = "DISABLE_CHAT";
+
+        /// <summary>Set to "1" to display a Perfstats overlay (debugging aid).</summary>
+        public const string Perfstats = "PERFSTATS";
+
+        /// <summary>Host-supplied session identifier echoed in Office for the web logs.</summary>
+        public const string HostSessionId = "HOST_SESSION_ID";
+
+        /// <summary>Host-supplied opaque value echoed back via X-WOPI-SessionContext.</summary>
+        public const string SessionContext = "SESSION_CONTEXT";
+
+        /// <summary>Selects which WOPI Validator test suite to run (All, OfficeOnline, OfficeNativeClient).</summary>
+        public const string ValidatorTestCategory = "VALIDATOR_TEST_CATEGORY";
+    }
+
+    /// <summary>
     /// Indicates that the WOPI server MAY include the preferred UI language in the format described in [RFC1766].
     /// </summary>
     public CultureInfo UiLlcc
     {
-        get => new(this["UI_LLCC"]);
+        get => new(this[Placeholders.UiLlcc]);
         set
         {
             if (value != null)
             {
-                this["UI_LLCC"] = value.Name;
+                this[Placeholders.UiLlcc] = value.Name;
             }
         }
     }
@@ -28,12 +80,12 @@ public class WopiUrlSettings : Dictionary<string, string>
     /// </summary>
     public CultureInfo DcLlcc
     {
-        get => new(this["DC_LLCC"]);
+        get => new(this[Placeholders.DcLlcc]);
         set
         {
             if (value != null)
             {
-                this["DC_LLCC"] = value.Name;
+                this[Placeholders.DcLlcc] = value.Name;
             }
         }
     }
@@ -43,8 +95,8 @@ public class WopiUrlSettings : Dictionary<string, string>
     /// </summary>
     public bool Embedded
     {
-        get => Convert.ToBoolean(this["EMBEDDED"], CultureInfo.InvariantCulture);
-        set => this["EMBEDDED"] = value.ToString(CultureInfo.InvariantCulture);
+        get => Convert.ToBoolean(this[Placeholders.Embedded], CultureInfo.InvariantCulture);
+        set => this[Placeholders.Embedded] = value.ToString(CultureInfo.InvariantCulture);
     }
 
     /// <summary>
@@ -52,8 +104,8 @@ public class WopiUrlSettings : Dictionary<string, string>
     /// </summary>
     public bool DisableAsync
     {
-        get => Convert.ToBoolean(this["DISABLE_ASYNC"], CultureInfo.InvariantCulture);
-        set => this["DISABLE_ASYNC"] = value.ToString(CultureInfo.InvariantCulture);
+        get => Convert.ToBoolean(this[Placeholders.DisableAsync], CultureInfo.InvariantCulture);
+        set => this[Placeholders.DisableAsync] = value.ToString(CultureInfo.InvariantCulture);
     }
 
     /// <summary>
@@ -61,8 +113,8 @@ public class WopiUrlSettings : Dictionary<string, string>
     /// </summary>
     public bool DisableBroadcast
     {
-        get => Convert.ToBoolean(this["DISABLE_BROADCAST"], CultureInfo.InvariantCulture);
-        set => this["DISABLE_BROADCAST"] = value.ToString(CultureInfo.InvariantCulture);
+        get => Convert.ToBoolean(this[Placeholders.DisableBroadcast], CultureInfo.InvariantCulture);
+        set => this[Placeholders.DisableBroadcast] = value.ToString(CultureInfo.InvariantCulture);
     }
 
     /// <summary>
@@ -70,8 +122,8 @@ public class WopiUrlSettings : Dictionary<string, string>
     /// </summary>
     public bool Fullscreen
     {
-        get => Convert.ToBoolean(this["FULLSCREEN"], CultureInfo.InvariantCulture);
-        set => this["FULLSCREEN"] = value.ToString(CultureInfo.InvariantCulture);
+        get => Convert.ToBoolean(this[Placeholders.Fullscreen], CultureInfo.InvariantCulture);
+        set => this[Placeholders.Fullscreen] = value.ToString(CultureInfo.InvariantCulture);
     }
 
     /// <summary>
@@ -79,8 +131,8 @@ public class WopiUrlSettings : Dictionary<string, string>
     /// </summary>
     public bool Recording
     {
-        get => Convert.ToBoolean(this["RECORDING"], CultureInfo.InvariantCulture);
-        set => this["RECORDING"] = value.ToString(CultureInfo.InvariantCulture);
+        get => Convert.ToBoolean(this[Placeholders.Recording], CultureInfo.InvariantCulture);
+        set => this[Placeholders.Recording] = value.ToString(CultureInfo.InvariantCulture);
     }
 
     /// <summary>
@@ -88,8 +140,8 @@ public class WopiUrlSettings : Dictionary<string, string>
     /// </summary>
     public int ThemeId
     {
-        get => Convert.ToInt32(this["THEME_ID"], CultureInfo.InvariantCulture);
-        set => this["THEME_ID"] = value.ToString(CultureInfo.InvariantCulture);
+        get => Convert.ToInt32(this[Placeholders.ThemeId], CultureInfo.InvariantCulture);
+        set => this[Placeholders.ThemeId] = value.ToString(CultureInfo.InvariantCulture);
     }
 
     /// <summary>
@@ -97,8 +149,8 @@ public class WopiUrlSettings : Dictionary<string, string>
     /// </summary>
     public int BusinessUser
     {
-        get => Convert.ToInt32(this["BUSINESS_USER"], CultureInfo.InvariantCulture);
-        set => this["BUSINESS_USER"] = value.ToString(CultureInfo.InvariantCulture);
+        get => Convert.ToInt32(this[Placeholders.BusinessUser], CultureInfo.InvariantCulture);
+        set => this[Placeholders.BusinessUser] = value.ToString(CultureInfo.InvariantCulture);
     }
 
     /// <summary>
@@ -106,8 +158,8 @@ public class WopiUrlSettings : Dictionary<string, string>
     /// </summary>
     public int DisableChat
     {
-        get => Convert.ToInt32(this["DISABLE_CHAT"], CultureInfo.InvariantCulture);
-        set => this["DISABLE_CHAT"] = value.ToString(CultureInfo.InvariantCulture);
+        get => Convert.ToInt32(this[Placeholders.DisableChat], CultureInfo.InvariantCulture);
+        set => this[Placeholders.DisableChat] = value.ToString(CultureInfo.InvariantCulture);
     }
 
     /// <summary>
@@ -116,8 +168,8 @@ public class WopiUrlSettings : Dictionary<string, string>
     /// </summary>
     public int Perfstats
     {
-        get => Convert.ToInt32(this["PERFSTATS"], CultureInfo.InvariantCulture);
-        set => this["PERFSTATS"] = value.ToString(CultureInfo.InvariantCulture);
+        get => Convert.ToInt32(this[Placeholders.Perfstats], CultureInfo.InvariantCulture);
+        set => this[Placeholders.Perfstats] = value.ToString(CultureInfo.InvariantCulture);
     }
 
     /// <summary>
@@ -125,8 +177,8 @@ public class WopiUrlSettings : Dictionary<string, string>
     /// </summary>
     public string HostSessionId
     {
-        get => this["HOST_SESSION_ID"];
-        set => this["HOST_SESSION_ID"] = value;
+        get => this[Placeholders.HostSessionId];
+        set => this[Placeholders.HostSessionId] = value;
     }
 
     /// <summary>
@@ -134,8 +186,8 @@ public class WopiUrlSettings : Dictionary<string, string>
     /// </summary>
     public string SessionContext
     {
-        get => this["SESSION_CONTEXT"];
-        set => this["SESSION_CONTEXT"] = value;
+        get => this[Placeholders.SessionContext];
+        set => this[Placeholders.SessionContext] = value;
     }
 
     /// <summary>
@@ -149,10 +201,10 @@ public class WopiUrlSettings : Dictionary<string, string>
     {
         get
         {
-            _ = Enum.TryParse(this["VALIDATOR_TEST_CATEGORY"], out ValidatorTestCategoryEnum validator);
+            _ = Enum.TryParse(this[Placeholders.ValidatorTestCategory], out ValidatorTestCategoryEnum validator);
             return validator;
         }
-        set => this["VALIDATOR_TEST_CATEGORY"] = value.ToString();
+        set => this[Placeholders.ValidatorTestCategory] = value.ToString();
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Resolves item 5 of #331 — extract hardcoded constants, document them, decide each as either a fixed spec value or a tunable.

Promotes a handful of unnamed literals to named, documented constants so they advertise their meaning at the point of declaration:

- **\`WopiLockInfo.ExpirationMinutes\` (30)** — spec-mandated lock auto-expiry. Used by the \`Expired\` predicate. Was previously a magic number in \`AddMinutes(30)\`.
- **\`WopiProofValidator.MaxTimestampAgeMinutes\` (20)** and **\`MaxFutureSkewMinutes\` (5)** — replaces the inline \`TimeSpan.FromMinutes(20)\` / \`FromMinutes(-5)\` in the proof-validation window check.
- **\`DiscoveryOptions.DefaultRefreshIntervalHours\` (24)** — replaces the inline \`TimeSpan.FromHours(24)\` default; the named const is referenced in the property's XML doc.
- **\`WopiUrlSettings.Placeholders\` nested static class** — collects every discovery-template placeholder name (\`WOPI_SOURCE\`, \`UI_LLCC\`, \`DC_LLCC\`, \`EMBEDDED\`, \`DISABLE_ASYNC\`, \`THEME_ID\`, …). The settings property accessors and \`WopiUrlBuilder\` now reference these constants instead of duplicating the literals across getter/setter pairs and call sites.

These values are all dictated by the WOPI specification and are not tunables, so they're \`const\` rather than \`IOptions\`-bound config. Each carries an XML doc comment with a spec link or rationale.

## Out of scope (deliberately left alone)

- Cobalt's \`SessionTimeout = TimeSpan.FromMinutes(30)\` — already a well-named field.
- Azure lock blob metadata keys (\`wopi_lock_id\`, \`wopi_lease_id\`, \`wopi_created\`) — already \`public const string\` on \`WopiAzureLockProvider\`.
- Route prefix \`"wopi/[controller]"\` on each controller — that's the conventional ASP.NET pattern, breaking it adds noise without payoff.
- Telemetry tag/outcome strings — already organized in the \`WopiTelemetry.Tags\` and \`WopiTelemetry.Outcomes\` static classes.

## Test plan

- [ ] CI build is clean.
- [ ] Existing test suite passes (the \`WopiTelemetryTests.StartActivity_NoListener_ReturnsNull\` flake is pre-existing parallel-Activity-state contamination, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)