### PR TITLE
ci(qlty): exclude sample/** and infra/** to match codecov

### DIFF
--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -2,7 +2,9 @@ config_version = "0"
 
 exclude_patterns = [
   "**/node_modules/**",
-  "**/wwwroot/**"
+  "**/wwwroot/**",
+  "sample/**",
+  "infra/**",
 ]
 
 test_patterns = [


### PR DESCRIPTION
## Summary

- Mirrors `codecov.yml`'s ignore list in `.qlty/qlty.toml` so both coverage reporters score the same set of files.
- Resolves the ~96% vs ~74% disparity tracked in #360. The gap was caused by Qlty including the demo apps under `sample/**` (`WopiHost`, `WopiHost.Web`, `WopiHost.Web.Oidc`, `WopiHost.Validator`) and Aspire orchestration under `infra/**` (`WopiHost.AppHost`, `WopiHost.ServiceDefaults`), neither of which is exercised by the unit-test suite that produces the lcov file both services consume.

## Test plan

- [ ] After merge, confirm Qlty's reported coverage on `master` jumps to within a few percent of Codecov's number.
- [ ] Spot-check that `sample/*` and `infra/*` files no longer appear in the Qlty file list for the next build.
- [ ] Walk through the remaining checklist on #360 (branch-vs-line coverage defaults, badge canonicalization).

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)