### PR TITLE
ci(infersharp): allowlist mechanism for known false positives

### DIFF
--- a/.github/infer-allowlist.txt
+++ b/.github/infer-allowlist.txt
@@ -1,0 +1,25 @@
+# Infer# false-positive allowlist
+#
+# One pattern per line. Each pattern is matched as a fixed substring against
+# `infer-out/report.txt` lines; any matching error line is dropped before the
+# fail-on-finding gate. Empty lines and lines starting with `#` are ignored.
+#
+# Add a comment above each entry naming the issue tracking it. Don't add new
+# entries without a matching issue — every allowlist entry is technical debt.
+
+# Issue: https://github.com/petrsvihlik/WopiHost/issues/363
+# Three sites where Infer# reports `Null Dereference` on `await SomeAsyncCall()`
+# because it can't see through the call to confirm the returned Task is
+# non-null. The C# compiler guarantees that async Task methods always return
+# a non-null Task. Master ran clean on the same code; this PR's broader
+# binary surface (new types in WopiHost.Abstractions and WopiHost.Core)
+# pushes Infer#'s cross-file analysis depth past a threshold and surfaces
+# these FPs.
+#
+# Long-term fixes to consider when the issue is picked up:
+#   - Inline the helper method bodies so the await is on an interface call.
+#   - Drop `async`, return Task directly via ContinueWith / a local function.
+#   - Investigate Infer# annotation support (.infersharp.json or similar).
+src/WopiHost.Core/Controllers/FoldersController.cs:51: error: Null Dereference
+src/WopiHost.Core/Controllers/WopiBootstrapperController.cs:55: error: Null Dereference
+src/WopiHost.Core/Controllers/WopiBootstrapperController.cs:79: error: Null Dereference

--- a/.github/workflows/infersharp.yml
+++ b/.github/workflows/infersharp.yml
@@ -105,11 +105,41 @@ jobs:
             infer-out/report.sarif
             infer-out/logs
 
-      - name: Fail on any finding
+      - name: Fail on any unlisted finding
         run: |
-          if [ -s infer-out/report.txt ]; then
-            echo "::error::Infer# reported findings — see report.txt artifact and the Security tab."
-            cat infer-out/report.txt
+          if [ ! -s infer-out/report.txt ]; then
+            echo "Infer# clean — no issues found."
+            exit 0
+          fi
+
+          # Filter known false positives via .github/infer-allowlist.txt. Each
+          # active line in the allowlist is a fixed-string substring matched
+          # against the report; any matching report line is dropped before the
+          # fail gate. See the allowlist itself for the policy on adding entries.
+          allowlist=".github/infer-allowlist.txt"
+          if [ -f "$allowlist" ]; then
+            grep -v -E '^(#|$)' "$allowlist" > /tmp/infer-allowlist-active || true
+            if [ -s /tmp/infer-allowlist-active ]; then
+              grep -v -F -f /tmp/infer-allowlist-active infer-out/report.txt > /tmp/infer-filtered.txt || true
+            else
+              cp infer-out/report.txt /tmp/infer-filtered.txt
+            fi
+          else
+            cp infer-out/report.txt /tmp/infer-filtered.txt
+          fi
+
+          # Count remaining error lines (not summary or context lines).
+          remaining=$(grep -cE ': error:' /tmp/infer-filtered.txt || true)
+          if [ "${remaining:-0}" -gt 0 ]; then
+            echo "::error::Infer# reported $remaining unlisted finding(s) — see report.txt artifact and the Security tab."
+            grep -E ': error:' /tmp/infer-filtered.txt
+            echo ""
+            echo "If these are true positives, fix the code. If they are false positives, add an entry to .github/infer-allowlist.txt with a tracking issue link."
             exit 1
           fi
-          echo "Infer# clean — no issues found."
+
+          echo "Infer# clean — all reported findings are in the allowlist."
+          if [ -s /tmp/infer-allowlist-active ]; then
+            echo "Allowlisted entries (these still need long-term fixes — see .github/infer-allowlist.txt):"
+            cat /tmp/infer-allowlist-active
+          fi


### PR DESCRIPTION
Adds an allowlist gate to the Infer# workflow so we can suppress documented false positives without making invasive code changes that exist solely to placate the analyzer.

## Why now

Surfaced while landing PR #362 (the WOPI spec-correctness audit). Three Infer# findings — all of the same shape, `await SomeAsyncMethod()` where the analyzer can't see through to confirm the returned Task is non-null — appeared on that PR despite the same code running clean on \`master\`. Workarounds explored on #362:

- Inlining the helper method bodies — worked for one of the five findings (in code added by the PR), but the remaining three are in pre-existing methods large enough that inlining is worse than the FP it suppresses.
- Null-forgiving \`!\` on the call — Infer# ignores it.
- Reverting individual commits in #362 — didn't isolate a single trigger.

The findings are objectively false positives (the C# compiler guarantees \`async Task\` methods return non-null Tasks). Tracked separately in #363 with a list of long-term fixes to consider.

## What this PR does

- Adds \`.github/infer-allowlist.txt\` listing the three lines and a comment linking #363.
- Updates \`.github/workflows/infersharp.yml\` to filter the report against the allowlist before the fail gate. The job still fails on any **unlisted** finding; on a green run, it prints the active allowlist so reviewers see what's currently being suppressed.
- Falls through gracefully when the allowlist file is missing.

## Why a separate PR

\`infersharp.yml\` uses \`pull_request_target\`, which means the workflow YAML for any PR's CI run comes from \`master\` — not from the PR. So the gate logic on PR #362 doesn't take effect there until this lands first. After merge, #362's next Infer# run picks up the new logic and goes green via the allowlisted entries.

## Test plan

- [ ] After merge, re-trigger Infer# on PR #362; expect green with three allowlisted entries printed in the workflow log.
- [ ] Future PR that introduces a *new* Infer# finding still fails CI (allowlist only matches its three documented entries).

Refs #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)