### PR TITLE
fix(controllers): restructure to clear Infer# null-deref FPs (closes #363)

### DIFF
--- a/.github/infer-allowlist.txt
+++ b/.github/infer-allowlist.txt
@@ -6,20 +6,9 @@
 #
 # Add a comment above each entry naming the issue tracking it. Don't add new
 # entries without a matching issue — every allowlist entry is technical debt.
-
-# Issue: https://github.com/petrsvihlik/WopiHost/issues/363
-# Three sites where Infer# reports `Null Dereference` on `await SomeAsyncCall()`
-# because it can't see through the call to confirm the returned Task is
-# non-null. The C# compiler guarantees that async Task methods always return
-# a non-null Task. Master ran clean on the same code; this PR's broader
-# binary surface (new types in WopiHost.Abstractions and WopiHost.Core)
-# pushes Infer#'s cross-file analysis depth past a threshold and surfaces
-# these FPs.
 #
-# Long-term fixes to consider when the issue is picked up:
-#   - Inline the helper method bodies so the await is on an interface call.
-#   - Drop `async`, return Task directly via ContinueWith / a local function.
-#   - Investigate Infer# annotation support (.infersharp.json or similar).
-src/WopiHost.Core/Controllers/FoldersController.cs:51: error: Null Dereference
-src/WopiHost.Core/Controllers/WopiBootstrapperController.cs:55: error: Null Dereference
-src/WopiHost.Core/Controllers/WopiBootstrapperController.cs:79: error: Null Dereference
+# (No active entries — the three originally tracked by #363 were resolved by
+# restructuring `WopiBootstrapperController.BuildBootstrapInfoAsync` and
+# `GetWopiCheckFolderInfo` so the `await` lands on an injected dependency
+# directly, which Infer# can see through. The mechanism stays in place for
+# the next FP we run into.)

--- a/src/WopiHost.Core/Controllers/FoldersController.cs
+++ b/src/WopiHost.Core/Controllers/FoldersController.cs
@@ -2,6 +2,8 @@ using System.Globalization;
 using System.Net.Mime;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using WopiHost.Abstractions;
 using WopiHost.Core.Extensions;
 using WopiHost.Core.Infrastructure;
@@ -48,7 +50,17 @@ public class FoldersController(IWopiStorageProvider storageProvider) : Controlle
         {
             return NotFound();
         }
-        var checkFolderInfo = await folder.GetWopiCheckFolderInfo(HttpContext);
+
+        // Build the default response synchronously, then fire the host-supplied callback
+        // (when configured) here — keeps the only `await` on a direct interface/delegate call,
+        // avoiding the Infer# false positive tracked by #363.
+        var checkFolderInfo = folder.BuildCheckFolderInfo(HttpContext);
+        var options = HttpContext.RequestServices.GetService<IOptions<WopiHostOptions>>();
+        if (options is not null)
+        {
+            checkFolderInfo = await options.Value.OnCheckFolderInfo(
+                new WopiCheckFolderInfoContext(HttpContext.User, folder, checkFolderInfo));
+        }
         return new JsonResult<WopiCheckFolderInfo>(checkFolderInfo);
     }
 

--- a/src/WopiHost.Core/Controllers/WopiBootstrapperController.cs
+++ b/src/WopiHost.Core/Controllers/WopiBootstrapperController.cs
@@ -52,7 +52,12 @@ public class WopiBootstrapperController(
     [Produces(MediaTypeNames.Application.Json)]
     public async Task<IActionResult> Bootstrap(CancellationToken cancellationToken = default)
     {
-        var bootstrap = await BuildBootstrapInfoAsync(cancellationToken);
+        var userId = GetUserIdOrThrow();
+        // Direct interface await keeps Infer# happy — see #363; the previous private async
+        // helper (BuildBootstrapInfoAsync) became an Infer null-deref FP that no analyzer
+        // annotation could suppress. Sync helpers do the request-shape and result-shape work.
+        var ecosystemToken = await accessTokenService.IssueAsync(BuildEcosystemTokenRequest(userId), cancellationToken);
+        var bootstrap = BuildBootstrapInfo(userId, ecosystemToken);
         return new JsonResult(new BootstrapRootContainerInfo { Bootstrap = bootstrap });
     }
 
@@ -76,7 +81,9 @@ public class WopiBootstrapperController(
 
     private async Task<IActionResult> GetRootContainerAsync(CancellationToken cancellationToken)
     {
-        var bootstrap = await BuildBootstrapInfoAsync(cancellationToken);
+        var userId = GetUserIdOrThrow();
+        var ecosystemToken = await accessTokenService.IssueAsync(BuildEcosystemTokenRequest(userId), cancellationToken);
+        var bootstrap = BuildBootstrapInfo(userId, ecosystemToken);
 
         var rootPointer = storageProvider.RootContainerPointer;
         var rootContainer = await storageProvider.GetWopiResource<IWopiFolder>(rootPointer.Identifier, cancellationToken);
@@ -108,7 +115,9 @@ public class WopiBootstrapperController(
             return NotFound();
         }
 
-        var bootstrap = await BuildBootstrapInfoAsync(cancellationToken);
+        var userId = GetUserIdOrThrow();
+        var ecosystemToken = await accessTokenService.IssueAsync(BuildEcosystemTokenRequest(userId), cancellationToken);
+        var bootstrap = BuildBootstrapInfo(userId, ecosystemToken);
         WopiAccessToken token;
 
         if (resourceType == WopiResourceType.File)
@@ -143,32 +152,40 @@ public class WopiBootstrapperController(
         });
     }
 
-    private async Task<BootstrapInfo> BuildBootstrapInfoAsync(CancellationToken cancellationToken)
+    /// <summary>
+    /// Builds the access-token request for the bootstrap ecosystem token. Per WOPI
+    /// "preventing token trading" guidance, this token must be fresh and minimum-privilege:
+    /// CheckEcosystem has no resource gate, so we bind it to the root container with no
+    /// permissions.
+    /// </summary>
+    /// <remarks>
+    /// Sync on purpose — see #363. Splitting the request-building (sync) from the IssueAsync
+    /// await (interface call) lets the caller `await accessTokenService.IssueAsync(...)`
+    /// directly, which Infer# can see through; an intermediate `private async Task` helper
+    /// trips a null-deref FP that no annotation suppresses.
+    /// </remarks>
+    private WopiAccessTokenRequest BuildEcosystemTokenRequest(string userId) => new()
     {
-        var userId = GetUserIdOrThrow();
-        var root = storageProvider.RootContainerPointer;
+        UserId = userId,
+        UserDisplayName = User.FindFirstValue(ClaimTypes.Name),
+        UserEmail = User.FindFirstValue(ClaimTypes.Email),
+        ResourceId = storageProvider.RootContainerPointer.Identifier,
+        ResourceType = WopiResourceType.Container,
+        ContainerPermissions = WopiContainerPermissions.None,
+    };
 
-        // Per WOPI "preventing token trading" guidance, the access token embedded in
-        // EcosystemUrl must be a fresh, minimum-privilege token. CheckEcosystem has no
-        // resource gate, so we bind the token to the root container with no permissions.
-        var ecosystemToken = await accessTokenService.IssueAsync(new WopiAccessTokenRequest
-        {
-            UserId = userId,
-            UserDisplayName = User.FindFirstValue(ClaimTypes.Name),
-            UserEmail = User.FindFirstValue(ClaimTypes.Email),
-            ResourceId = root.Identifier,
-            ResourceType = WopiResourceType.Container,
-            ContainerPermissions = WopiContainerPermissions.None,
-        }, cancellationToken);
-
-        return new BootstrapInfo
-        {
-            EcosystemUrl = Url.GetWopiSrc(WopiRouteNames.CheckEcosystem, identifier: null, accessToken: ecosystemToken.Token),
-            UserId = userId,
-            SignInName = User.FindFirstValue(ClaimTypes.Email) ?? string.Empty,
-            UserFriendlyName = User.FindFirstValue(ClaimTypes.Name) ?? string.Empty,
-        };
-    }
+    /// <summary>
+    /// Synchronous shaping helper that turns a freshly-issued ecosystem token into the
+    /// <see cref="BootstrapInfo"/> the WOPI client expects. Paired with
+    /// <see cref="BuildEcosystemTokenRequest"/>; see its remarks for the rationale.
+    /// </summary>
+    private BootstrapInfo BuildBootstrapInfo(string userId, WopiAccessToken ecosystemToken) => new()
+    {
+        EcosystemUrl = Url.GetWopiSrc(WopiRouteNames.CheckEcosystem, identifier: null, accessToken: ecosystemToken.Token),
+        UserId = userId,
+        SignInName = User.FindFirstValue(ClaimTypes.Email) ?? string.Empty,
+        UserFriendlyName = User.FindFirstValue(ClaimTypes.Name) ?? string.Empty,
+    };
 
     private async Task<WopiAccessToken> IssueFileTokenAsync(IWopiFile file, CancellationToken cancellationToken)
     {

--- a/src/WopiHost.Core/Extensions/WopiExtensions.cs
+++ b/src/WopiHost.Core/Extensions/WopiExtensions.cs
@@ -206,13 +206,20 @@ public static class WopiExtensions
     }
 
     /// <summary>
-    /// Creates a new instance of the <see cref="WopiCheckFolderInfo"/> based on the provided <see cref="IWopiFolder"/>.
-    /// This is used by the OneNote for the web Folders endpoint.
+    /// Builds a default <see cref="WopiCheckFolderInfo"/> for the given <see cref="IWopiFolder"/>
+    /// — folder name, plus user identity slots populated from <see cref="HttpContext.User"/>.
+    /// Used by the OneNote-for-the-web Folders endpoint.
     /// </summary>
-    /// <param name="folder"><see cref="IWopiFolder"/> to return info</param>
-    /// <param name="httpContext">current HttpContext</param>
-    /// <returns>WopiCheckFolderInfo</returns>
-    public static async Task<WopiCheckFolderInfo> GetWopiCheckFolderInfo(
+    /// <remarks>
+    /// Synchronous on purpose — see #363. The <see cref="WopiHostOptions.OnCheckFolderInfo"/>
+    /// callback is fired by the <c>FoldersController</c> after this returns, so the controller's
+    /// only <c>await</c> in this path is the direct delegate invocation. An async extension
+    /// method here would re-introduce the Infer# null-deref FP that the issue tracks.
+    /// </remarks>
+    /// <param name="folder"><see cref="IWopiFolder"/> to return info for.</param>
+    /// <param name="httpContext">current <see cref="HttpContext"/>.</param>
+    /// <returns>The default <see cref="WopiCheckFolderInfo"/> before any host-supplied callback.</returns>
+    public static WopiCheckFolderInfo BuildCheckFolderInfo(
         this IWopiFolder folder,
         HttpContext httpContext)
     {
@@ -232,13 +239,6 @@ public static class WopiExtensions
         else
         {
             checkFolderInfo.IsAnonymousUser = true;
-        }
-
-        // allow changes and/or extensions before returning
-        var wopiHostOptions = httpContext.RequestServices.GetService<IOptions<WopiHostOptions>>();
-        if (wopiHostOptions is not null)
-        {
-            checkFolderInfo = await wopiHostOptions.Value.OnCheckFolderInfo(new WopiCheckFolderInfoContext(httpContext.User, folder, checkFolderInfo));
         }
 
         return checkFolderInfo;

--- a/test/WopiHost.Core.Tests/Controllers/FoldersControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/FoldersControllerTests.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.Extensions.Options;
 using Moq;
 using WopiHost.Abstractions;
 using WopiHost.Core.Controllers;
@@ -70,6 +71,77 @@ public class FoldersControllerTests
         var jsonResult = Assert.IsType<JsonResult<WopiCheckFolderInfo>>(result);
         var checkFolderInfo = Assert.IsType<WopiCheckFolderInfo>(jsonResult.Value);
         Assert.Equal("TestFolder", checkFolderInfo.FolderName);
+    }
+
+    [Fact]
+    public async Task CheckFolderInfo_CallsOnCheckFolderInfoEvent()
+    {
+        // Moved here from WopiExtensionsTests.GetWopiCheckFolderInfo_CallsOnCheckFolderInfoEvent
+        // when the OnCheckFolderInfo callback firing moved from the extension method to the
+        // controller as part of resolving #363.
+        var folder = new Mock<IWopiFolder>();
+        folder.Setup(f => f.Name).Returns("MyFolder");
+        storageProviderMock
+            .Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => folder.Object);
+
+        var eventFired = false;
+        var hostViewUrl = new Uri("https://host/view");
+        var hostEditUrl = new Uri("https://host/edit");
+        var closeUrl = new Uri("https://host/close");
+        var fileSharingUrl = new Uri("https://host/share");
+        var brandUrl = new Uri("https://brand.example.com");
+        var folderUrl = new Uri("https://host/parent");
+        var wopiHostOptions = Options.Create(new WopiHostOptions
+        {
+            StorageProviderAssemblyName = "test",
+            ClientUrl = new Uri("http://localhost:5000"),
+            OnCheckFolderInfo = context =>
+            {
+                eventFired = true;
+                Assert.Equal("MyFolder", context.CheckFolderInfo.FolderName);
+                Assert.NotNull(context.Folder);
+                context.CheckFolderInfo.OwnerId = "owner1";
+                context.CheckFolderInfo.UserCanWrite = true;
+                context.CheckFolderInfo.HostViewUrl = hostViewUrl;
+                context.CheckFolderInfo.HostEditUrl = hostEditUrl;
+                context.CheckFolderInfo.CloseUrl = closeUrl;
+                context.CheckFolderInfo.FileSharingUrl = fileSharingUrl;
+                context.CheckFolderInfo.BreadcrumbBrandName = "Contoso";
+                context.CheckFolderInfo.BreadcrumbBrandUrl = brandUrl;
+                context.CheckFolderInfo.BreadcrumbFolderName = "ParentFolder";
+                context.CheckFolderInfo.BreadcrumbFolderUrl = folderUrl;
+                context.CheckFolderInfo.DisablePrint = true;
+                context.CheckFolderInfo.CloseButtonClosesWindow = true;
+                return Task.FromResult(context.CheckFolderInfo);
+            }
+        });
+
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                ServiceScopeFactory = TestUtils.CreateServiceScope<IOptions<WopiHostOptions>>(wopiHostOptions),
+            }
+        };
+
+        var result = await _controller.CheckFolderInfo("folder");
+
+        Assert.True(eventFired);
+        var jsonResult = Assert.IsType<JsonResult<WopiCheckFolderInfo>>(result);
+        var checkFolderInfo = Assert.IsType<WopiCheckFolderInfo>(jsonResult.Value);
+        Assert.Equal("owner1", checkFolderInfo.OwnerId);
+        Assert.True(checkFolderInfo.UserCanWrite);
+        Assert.Equal(hostViewUrl, checkFolderInfo.HostViewUrl);
+        Assert.Equal(hostEditUrl, checkFolderInfo.HostEditUrl);
+        Assert.Equal(closeUrl, checkFolderInfo.CloseUrl);
+        Assert.Equal(fileSharingUrl, checkFolderInfo.FileSharingUrl);
+        Assert.Equal("Contoso", checkFolderInfo.BreadcrumbBrandName);
+        Assert.Equal(brandUrl, checkFolderInfo.BreadcrumbBrandUrl);
+        Assert.Equal("ParentFolder", checkFolderInfo.BreadcrumbFolderName);
+        Assert.Equal(folderUrl, checkFolderInfo.BreadcrumbFolderUrl);
+        Assert.True(checkFolderInfo.DisablePrint);
+        Assert.True(checkFolderInfo.CloseButtonClosesWindow);
     }
 
     [Fact]

--- a/test/WopiHost.Core.Tests/Extensions/WopiExtensionsTests.cs
+++ b/test/WopiHost.Core.Tests/Extensions/WopiExtensionsTests.cs
@@ -301,16 +301,13 @@ public class WopiExtensionsTests
     }
 
     [Fact]
-    public async Task GetWopiCheckFolderInfo_ReturnsAnonymousUser_WhenNotAuthenticated()
+    public void BuildCheckFolderInfo_ReturnsAnonymousUser_WhenNotAuthenticated()
     {
         var mockFolder = new Mock<IWopiFolder>();
         mockFolder.Setup(f => f.Name).Returns("MyFolder");
-        var httpContext = new DefaultHttpContext()
-        {
-            ServiceScopeFactory = TestUtils.CreateServiceScope(),
-        };
+        var httpContext = new DefaultHttpContext();
 
-        var result = await mockFolder.Object.GetWopiCheckFolderInfo(httpContext);
+        var result = mockFolder.Object.BuildCheckFolderInfo(httpContext);
 
         Assert.Equal("MyFolder", result.FolderName);
         Assert.True(result.IsAnonymousUser);
@@ -319,13 +316,12 @@ public class WopiExtensionsTests
     }
 
     [Fact]
-    public async Task GetWopiCheckFolderInfo_WithAuthenticatedUser()
+    public void BuildCheckFolderInfo_WithAuthenticatedUser()
     {
         var mockFolder = new Mock<IWopiFolder>();
         mockFolder.Setup(f => f.Name).Returns("MyFolder");
         var httpContext = new DefaultHttpContext()
         {
-            ServiceScopeFactory = TestUtils.CreateServiceScope(),
             User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                 [
@@ -334,72 +330,16 @@ public class WopiExtensionsTests
                 ], "test auth scheme")),
         };
 
-        var result = await mockFolder.Object.GetWopiCheckFolderInfo(httpContext);
+        var result = mockFolder.Object.BuildCheckFolderInfo(httpContext);
 
         Assert.Equal("userId42", result.UserId);
         Assert.Equal("Jane Doe", result.UserFriendlyName);
         Assert.False(result.IsAnonymousUser);
     }
 
-    [Fact]
-    public async Task GetWopiCheckFolderInfo_CallsOnCheckFolderInfoEvent()
-    {
-        var mockFolder = new Mock<IWopiFolder>();
-        mockFolder.Setup(f => f.Name).Returns("MyFolder");
-        var eventFired = false;
-        var hostViewUrl = new Uri("https://host/view");
-        var hostEditUrl = new Uri("https://host/edit");
-        var closeUrl = new Uri("https://host/close");
-        var fileSharingUrl = new Uri("https://host/share");
-        var brandUrl = new Uri("https://brand.example.com");
-        var folderUrl = new Uri("https://host/parent");
-        var wopiHostOptions = Options.Create(new WopiHostOptions
-        {
-            StorageProviderAssemblyName = "test",
-            ClientUrl = new Uri("http://localhost:5000"),
-            OnCheckFolderInfo = context =>
-            {
-                eventFired = true;
-                // Verify context record is properly constructed
-                Assert.Equal("MyFolder", context.CheckFolderInfo.FolderName);
-                Assert.NotNull(context.Folder);
-                // Set all optional properties to verify they round-trip
-                context.CheckFolderInfo.OwnerId = "owner1";
-                context.CheckFolderInfo.UserCanWrite = true;
-                context.CheckFolderInfo.HostViewUrl = hostViewUrl;
-                context.CheckFolderInfo.HostEditUrl = hostEditUrl;
-                context.CheckFolderInfo.CloseUrl = closeUrl;
-                context.CheckFolderInfo.FileSharingUrl = fileSharingUrl;
-                context.CheckFolderInfo.BreadcrumbBrandName = "Contoso";
-                context.CheckFolderInfo.BreadcrumbBrandUrl = brandUrl;
-                context.CheckFolderInfo.BreadcrumbFolderName = "ParentFolder";
-                context.CheckFolderInfo.BreadcrumbFolderUrl = folderUrl;
-                context.CheckFolderInfo.DisablePrint = true;
-                context.CheckFolderInfo.CloseButtonClosesWindow = true;
-                return Task.FromResult(context.CheckFolderInfo);
-            }
-        });
-        var httpContext = new DefaultHttpContext()
-        {
-            ServiceScopeFactory = TestUtils.CreateServiceScope<IOptions<WopiHostOptions>>(wopiHostOptions),
-        };
-
-        var result = await mockFolder.Object.GetWopiCheckFolderInfo(httpContext);
-
-        Assert.True(eventFired);
-        Assert.Equal("owner1", result.OwnerId);
-        Assert.True(result.UserCanWrite);
-        Assert.Equal(hostViewUrl, result.HostViewUrl);
-        Assert.Equal(hostEditUrl, result.HostEditUrl);
-        Assert.Equal(closeUrl, result.CloseUrl);
-        Assert.Equal(fileSharingUrl, result.FileSharingUrl);
-        Assert.Equal("Contoso", result.BreadcrumbBrandName);
-        Assert.Equal(brandUrl, result.BreadcrumbBrandUrl);
-        Assert.Equal("ParentFolder", result.BreadcrumbFolderName);
-        Assert.Equal(folderUrl, result.BreadcrumbFolderUrl);
-        Assert.True(result.DisablePrint);
-        Assert.True(result.CloseButtonClosesWindow);
-    }
+    // Note: OnCheckFolderInfo callback firing is no longer the extension's responsibility — it
+    // moved to FoldersController.CheckFolderInfo as part of #363's resolution. The callback
+    // round-trip is covered by FoldersControllerTests.CheckFolderInfo_CallsOnCheckFolderInfoEvent.
 
     [Fact]
     public async Task GetWopiCheckContainerInfo_CallsOnCheckContainerInfoEvent()


### PR DESCRIPTION
Closes #363.

The three Infer# null-deref findings tracked by [#363](https://github.com/petrsvihlik/WopiHost/issues/363) — currently suppressed by `.github/infer-allowlist.txt` since [#364](https://github.com/petrsvihlik/WopiHost/pull/364) — are false positives on `await SomeAsyncCall()` patterns where Infer# can't see through the call into our own async helpers. None of the lighter-touch workarounds we tried earlier moved the analyzer (revert A1, null-forgiving `!`, `var task = ...; await task`).

The pattern Infer# *does* accept is `await someInjectedDependency.SomeMethod()` — direct `await` on an interface or constructor-injected dependency. This commit restructures the two offending paths so that's exactly the shape the controller body emits.

## Changes

### `WopiBootstrapperController.BuildBootstrapInfoAsync` is gone
Replaced with two synchronous helpers:
- `BuildEcosystemTokenRequest(userId)` — shapes the access-token request (sync, returns the request DTO).
- `BuildBootstrapInfo(userId, token)` — shapes the response from a freshly-issued token (sync, returns `BootstrapInfo`).

The three call sites (`Bootstrap`, `GetRootContainerAsync`, `GetNewAccessTokenAsync`) now do:
```csharp
var userId = GetUserIdOrThrow();
var ecosystemToken = await accessTokenService.IssueAsync(BuildEcosystemTokenRequest(userId), cancellationToken);
var bootstrap = BuildBootstrapInfo(userId, ecosystemToken);
```
The `await` lands directly on the injected `accessTokenService`'s interface method — Infer# can see through.

### `WopiExtensions.GetWopiCheckFolderInfo` becomes `BuildCheckFolderInfo`, sync
The default-building part stays in the extension but is now synchronous — no `await` inside.

The `OnCheckFolderInfo` callback firing moves to `FoldersController.CheckFolderInfo`, where the controller's only `await` in this path is the direct delegate invocation. Same Infer#-friendly shape.

### Allowlist cleanup
The three entries in `.github/infer-allowlist.txt` are removed. The file stays in place (with a comment noting the original entries were resolved here) so the gate mechanism is ready for the next FP we run into.

### Tests
- `WopiExtensionsTests.GetWopiCheckFolderInfo_*` — three tests rewritten to test the new sync `BuildCheckFolderInfo` (drop the async + ServiceScopeFactory plumbing they no longer need).
- `WopiExtensionsTests.GetWopiCheckFolderInfo_CallsOnCheckFolderInfoEvent` — moved to `FoldersControllerTests.CheckFolderInfo_CallsOnCheckFolderInfoEvent` since the callback now fires at the controller, not the extension.

## Test plan

- [x] `WopiHost.Core.Tests` — 367/367 pass on net10.0 (callback-firing test moved, all assertions preserved).
- [ ] After merge, Infer# Static Analysis on the next PR / push to master is green with zero allowlist hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)