### PR TITLE
ci(qlty): skip missing source-generated files (74% → ~93%)

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -46,6 +46,11 @@ jobs:
       with:
         oidc: true
         files: "**/coverage.*.info"
+        # Coverlet's lcov references source-generated files (LoggerMessage.g.cs,
+        # LibraryImports.g.cs, etc.) under artifacts/obj/, which don't exist at
+        # publish time. Without this flag Qlty counts them as 0% covered, hence
+        # the ~74% vs Codecov's ~93% disparity. See also .qlty/qlty.toml.
+        skip-missing-files: true
     - name: Codecov
       uses: codecov/codecov-action@v6
       with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -59,6 +59,8 @@ jobs:
       with:
         oidc: true
         files: "**/coverage.*.info"
+        # See integrate.yml for the rationale.
+        skip-missing-files: true
     - name: Codecov
       uses: codecov/codecov-action@v6
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,8 @@ jobs:
       with:
         oidc: true
         files: "**/coverage.*.info"
+        # See integrate.yml for the rationale.
+        skip-missing-files: true
     - name: Codecov
       uses: codecov/codecov-action@v6
       with:

--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -5,6 +5,15 @@ exclude_patterns = [
   "**/wwwroot/**",
   "sample/**",
   "infra/**",
+  # Source-generated output. Coverlet emits lcov entries for these (Logger source
+  # generator, LibraryImport source generator, etc.) but the files don't exist on
+  # disk at coverage-publish time — they're build outputs under artifacts/obj/.
+  # Without this exclusion, Qlty counts them as 0%-covered and tanks the
+  # percentage. (Codecov auto-skips files missing from the repo, which is why
+  # the same lcov yields ~93% there.)
+  "**/artifacts/**",
+  "**/obj/**",
+  "**/*.g.cs",
 ]
 
 test_patterns = [


### PR DESCRIPTION
Closes the long-running ~20-point gap between Qlty (~74%) and Codecov (~93%) reporting on the same lcov files.

## Diagnosis

The qlty step's CI log spells it out:

```
 COVERAGE DATA

    Auto-path fixing: Enabled
    122 unique code file paths
    27 paths are missing on disk (22.1%)

    Missing code files:
      /_/artifacts/obj/WopiHost.AzureLockProvider/debug_net10.0/.../LoggerMessage.g.cs
      /_/artifacts/obj/WopiHost.Core/debug_net10.0/.../LoggerMessage.g.cs
      ...

    Covered Lines:      4,328
    Uncovered Lines:    1,444
    Omitted Lines:      7,079

    Line Coverage:       74.98%
```

Coverlet emits lcov entries for source-generated files (Logger source generator, LibraryImport source generator) that live under `artifacts/obj/` and don't exist at coverage-publish time. Qlty's default is to count them as 0%-covered, which tanks the percentage. Codecov silently skips files missing from the repo — that's the entire delta between the two tools' numbers.

## Fix

Two complementary changes:

- `skip-missing-files: true` on the qlty-action invocation in all three workflows (`integrate.yml`, `pull_request.yml`, `release.yml`). Same heuristic Codecov uses.
- `**/artifacts/**`, `**/obj/**`, `**/*.g.cs` added to `.qlty/qlty.toml` `exclude_patterns`. Belt-and-suspenders so the exclusion stays explicit even if someone removes `skip-missing-files` later.

## Test plan

- [x] PR's own `pull_request.yml` workflow run picks up the new flag (this PR's `pull_request` workflow uses the PR-side YAML, unlike `pull_request_target`).
- [ ] Verify the qlty step prints `0 paths are missing on disk` (or close to it) on this PR's CI run.
- [ ] After merge, the master Qlty dashboard reports a number within ~1pt of Codecov's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)