### PR TITLE
test(deps): migrate xunit v2 -> v3

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -10,6 +10,15 @@
 		<IsPackable>false</IsPackable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<!-- xUnit v3 requires test projects to be built as console apps so the framework's
+		     Microsoft.Testing.Platform entry point can run them. The vstest path
+		     (Microsoft.NET.Test.Sdk + xunit.runner.visualstudio) continues to work. -->
+		<OutputType>Exe</OutputType>
+		<!-- xUnit1051 (added in v3) suggests routing every CancellationToken through
+		     TestContext.Current.CancellationToken so tests cancel responsively. Adopting that
+		     pattern is a separate follow-up — suppressing here so the v3 migration doesn't
+		     have to rewrite ~1.5k call sites first. -->
+		<NoWarn>$(NoWarn);xUnit1051</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -17,8 +26,7 @@
 		<PackageReference Include="coverlet.msbuild" />
 		<PackageReference Include="FakeItEasy" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk"/>
-		<PackageReference Include="xunit" />
-		<PackageReference Include="xunit.runner.console" />
+		<PackageReference Include="xunit.v3" />
 		<PackageReference Include="xunit.runner.visualstudio" />
 	</ItemGroup>
 </Project>

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -21,12 +21,7 @@
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
     <PackageVersion Include="Testcontainers" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.Azurite" Version="4.11.0" />
-    <PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.console" Version="2.9.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageVersion>
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/test/WopiHost.AzureLockProvider.Tests/AzuriteFixture.cs
+++ b/test/WopiHost.AzureLockProvider.Tests/AzuriteFixture.cs
@@ -22,9 +22,9 @@ public sealed class AzuriteFixture : IAsyncLifetime
     public BlobServiceClient CreateBlobServiceClient()
         => new(ConnectionString, new BlobClientOptions(AzuriteSupportedVersion));
 
-    public Task InitializeAsync() => container.StartAsync();
+    public ValueTask InitializeAsync() => new(container.StartAsync());
 
-    public Task DisposeAsync() => container.DisposeAsync().AsTask();
+    public ValueTask DisposeAsync() => container.DisposeAsync();
 }
 
 [CollectionDefinition(Name)]

--- a/test/WopiHost.AzureLockProvider.Tests/WopiHost.AzureLockProvider.Tests.csproj
+++ b/test/WopiHost.AzureLockProvider.Tests/WopiHost.AzureLockProvider.Tests.csproj
@@ -18,10 +18,6 @@
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Update="xunit.runner.console">
-	    <PrivateAssets>all</PrivateAssets>
-	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
 	  <PackageReference Update="xunit.runner.visualstudio">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/WopiHost.AzureStorageProvider.Tests/AzuriteFixture.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/AzuriteFixture.cs
@@ -30,9 +30,9 @@ public sealed class AzuriteFixture : IAsyncLifetime
     public BlobServiceClient CreateBlobServiceClient()
         => new(ConnectionString, new BlobClientOptions(AzuriteSupportedVersion));
 
-    public Task InitializeAsync() => container.StartAsync();
+    public ValueTask InitializeAsync() => new(container.StartAsync());
 
-    public Task DisposeAsync() => container.DisposeAsync().AsTask();
+    public ValueTask DisposeAsync() => container.DisposeAsync();
 }
 
 [CollectionDefinition(Name)]

--- a/test/WopiHost.AzureStorageProvider.Tests/WopiHost.AzureStorageProvider.Tests.csproj
+++ b/test/WopiHost.AzureStorageProvider.Tests/WopiHost.AzureStorageProvider.Tests.csproj
@@ -18,10 +18,6 @@
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Update="xunit.runner.console">
-	    <PrivateAssets>all</PrivateAssets>
-	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
 	  <PackageReference Update="xunit.runner.visualstudio">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/WopiHost.Cobalt.Tests/WopiHost.Cobalt.Tests.csproj
+++ b/test/WopiHost.Cobalt.Tests/WopiHost.Cobalt.Tests.csproj
@@ -14,10 +14,6 @@
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Update="xunit.runner.console">
-	    <PrivateAssets>all</PrivateAssets>
-	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
 	  <PackageReference Update="xunit.runner.visualstudio">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/WopiHost.Core.Tests/WopiHost.Core.Tests.csproj
+++ b/test/WopiHost.Core.Tests/WopiHost.Core.Tests.csproj
@@ -27,10 +27,6 @@
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Update="xunit.runner.console">
-	    <PrivateAssets>all</PrivateAssets>
-	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
 	  <PackageReference Update="xunit.runner.visualstudio">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/WopiHost.Discovery.Tests/WopiHost.Discovery.Tests.csproj
+++ b/test/WopiHost.Discovery.Tests/WopiHost.Discovery.Tests.csproj
@@ -22,10 +22,6 @@
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Update="xunit.runner.console">
-	    <PrivateAssets>all</PrivateAssets>
-	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
 	  <PackageReference Update="xunit.runner.visualstudio">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/WopiHost.FileSystemProvider.Tests/WopiHost.FileSystemProvider.Tests.csproj
+++ b/test/WopiHost.FileSystemProvider.Tests/WopiHost.FileSystemProvider.Tests.csproj
@@ -18,10 +18,6 @@
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Update="xunit.runner.console">
-	    <PrivateAssets>all</PrivateAssets>
-	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
 	  <PackageReference Update="xunit.runner.visualstudio">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/WopiHost.IntegrationTests/Fixtures/MockOidcServerFixture.cs
+++ b/test/WopiHost.IntegrationTests/Fixtures/MockOidcServerFixture.cs
@@ -34,7 +34,7 @@ public sealed class MockOidcServerFixture : IAsyncLifetime
     /// <summary>Authority URL passed to the OIDC client (issuer). Null when <see cref="IsAvailable"/> is false.</summary>
     public Uri? Authority => BaseUrl is null ? null : new Uri(BaseUrl, Issuer);
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         try
         {
@@ -57,7 +57,7 @@ public sealed class MockOidcServerFixture : IAsyncLifetime
         }
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         if (_container is not null)
         {

--- a/test/WopiHost.IntegrationTests/OidcStartupTests.cs
+++ b/test/WopiHost.IntegrationTests/OidcStartupTests.cs
@@ -21,10 +21,10 @@ public class OidcStartupTests : IClassFixture<OidcStartupTests.AppFactory>
         _factory.MockOidc = mockOidc;
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task AnonymousRequest_RedirectsToOidcAuthority()
     {
-        Skip.IfNot(_mockOidc.IsAvailable, _mockOidc.UnavailableReason ?? "Docker unavailable.");
+        Assert.SkipUnless(_mockOidc.IsAvailable, _mockOidc.UnavailableReason ?? "Docker unavailable.");
 
         using var client = _factory.CreateInstance().CreateClient(new()
         {
@@ -41,10 +41,10 @@ public class OidcStartupTests : IClassFixture<OidcStartupTests.AppFactory>
         Assert.Contains("client_id=" + OidcWebAppFactory.TestClientId, location);
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task DiscoveryDocument_IsReachableFromAppHost()
     {
-        Skip.IfNot(_mockOidc.IsAvailable, _mockOidc.UnavailableReason ?? "Docker unavailable.");
+        Assert.SkipUnless(_mockOidc.IsAvailable, _mockOidc.UnavailableReason ?? "Docker unavailable.");
 
         using var http = new HttpClient { BaseAddress = _mockOidc.Authority };
         var discovery = await http.GetAsync(".well-known/openid-configuration");
@@ -56,10 +56,10 @@ public class OidcStartupTests : IClassFixture<OidcStartupTests.AppFactory>
         Assert.True(doc.RootElement.TryGetProperty("jwks_uri", out _));
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task HealthEndpoint_IsAnonymous()
     {
-        Skip.IfNot(_mockOidc.IsAvailable, _mockOidc.UnavailableReason ?? "Docker unavailable.");
+        Assert.SkipUnless(_mockOidc.IsAvailable, _mockOidc.UnavailableReason ?? "Docker unavailable.");
 
         using var client = _factory.CreateInstance().CreateClient(new()
         {

--- a/test/WopiHost.IntegrationTests/WopiHost.IntegrationTests.csproj
+++ b/test/WopiHost.IntegrationTests/WopiHost.IntegrationTests.csproj
@@ -13,7 +13,6 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
 		<PackageReference Include="Testcontainers" />
-		<PackageReference Include="Xunit.SkippableFact" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -22,10 +21,6 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Update="coverlet.msbuild">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Update="xunit.runner.console">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/test/WopiHost.MemoryLockProvider.Tests/WopiHost.MemoryLockProvider.Tests.csproj
+++ b/test/WopiHost.MemoryLockProvider.Tests/WopiHost.MemoryLockProvider.Tests.csproj
@@ -14,10 +14,6 @@
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Update="xunit.runner.console">
-	    <PrivateAssets>all</PrivateAssets>
-	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
 	  <PackageReference Update="xunit.runner.visualstudio">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/WopiHost.SmokeTests/Fixtures/PlaywrightFixture.cs
+++ b/test/WopiHost.SmokeTests/Fixtures/PlaywrightFixture.cs
@@ -19,7 +19,7 @@ public sealed class PlaywrightFixture : IAsyncLifetime
     public IPlaywright Playwright { get; private set; } = null!;
     public IBrowser Browser { get; private set; } = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         // Returns 0 immediately if browsers are already installed.
         var exitCode = Microsoft.Playwright.Program.Main(["install", "chromium"]);
@@ -34,7 +34,7 @@ public sealed class PlaywrightFixture : IAsyncLifetime
         Browser = await Playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await Browser.DisposeAsync();
         Playwright.Dispose();

--- a/test/WopiHost.SmokeTests/ValidatorSampleSmokeTests.cs
+++ b/test/WopiHost.SmokeTests/ValidatorSampleSmokeTests.cs
@@ -15,12 +15,12 @@ public sealed class ValidatorSampleSmokeTests(PlaywrightFixture playwright) : IA
     private readonly ValidatorSampleFactory _factory = new();
     private IBrowserContext _context = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _context = await playwright.Browser.NewContextAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _context.CloseAsync();
         await _factory.DisposeAsync();

--- a/test/WopiHost.SmokeTests/WebSampleSmokeTests.cs
+++ b/test/WopiHost.SmokeTests/WebSampleSmokeTests.cs
@@ -16,12 +16,12 @@ public sealed class WebSampleSmokeTests(PlaywrightFixture playwright) : IAsyncLi
     private readonly WebSampleFactory _factory = new();
     private IBrowserContext _context = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _context = await playwright.Browser.NewContextAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _context.CloseAsync();
         await _factory.DisposeAsync();

--- a/test/WopiHost.SmokeTests/WopiHost.SmokeTests.csproj
+++ b/test/WopiHost.SmokeTests/WopiHost.SmokeTests.csproj
@@ -27,10 +27,6 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Update="xunit.runner.console">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
 		<PackageReference Update="xunit.runner.visualstudio">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/WopiHost.Url.Tests/WopiHost.Url.Tests.csproj
+++ b/test/WopiHost.Url.Tests/WopiHost.Url.Tests.csproj
@@ -14,10 +14,6 @@
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Update="xunit.runner.console">
-	    <PrivateAssets>all</PrivateAssets>
-	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
 	  <PackageReference Update="xunit.runner.visualstudio">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary

- Swap `xunit 2.9.3` for `xunit.v3 3.2.2`. Drop the now-redundant `xunit.runner.console` (v3 self-runs via Microsoft.Testing.Platform) and `Xunit.SkippableFact` (replaced by v3's built-in `Assert.SkipUnless`). Keep `xunit.runner.visualstudio 3.1.5` since it's already dual-compat.
- Set `<OutputType>Exe</OutputType>` globally in `test/Directory.Build.props` — required by v3.
- Convert all 6 `IAsyncLifetime` fixtures from `Task` to `ValueTask` returns (Azurite ×2, Playwright, two smoke-test classes, MockOidc).
- Replace 3× `[SkippableFact]` / `Skip.IfNot(...)` in `OidcStartupTests.cs` with `[Fact]` / `Assert.SkipUnless(...)`.
- Strip the dead `xunit.runner.console` `<PackageReference Update>` blocks from all 10 test csprojs.
- Suppress `xUnit1051` with a comment — the new v3 stylistic analyzer would force ~1.5k call sites onto `TestContext.Current.CancellationToken`; deferred as a separate mechanical sweep.

Diff is **net -38 lines** across 19 files, all under `test/`. No production code touched.

## Test plan

- [x] `dotnet build WOPI.slnx` — 0 warnings, 0 errors
- [x] `dotnet test test/WopiHost.Url.Tests` — 11 × 3 TFMs pass
- [x] `dotnet test test/WopiHost.Core.Tests` — 367 × 2 TFMs pass (net8 host run aborted locally on missing `Microsoft.AspNetCore.App 8.0.0` x64 runtime; CI is unaffected)
- [x] `dotnet test test/WopiHost.Discovery.Tests` — 80 × 3 TFMs pass
- [x] `dotnet test test/WopiHost.FileSystemProvider.Tests` — 94 × 3 TFMs pass
- [x] `dotnet test test/WopiHost.MemoryLockProvider.Tests` — 15 × 3 TFMs pass
- [ ] CI to validate the Azurite, Playwright, and MockOidc fixtures (need Docker / Playwright browser install — couldn't runtime-verify locally, but build is clean so the `IAsyncLifetime` signature change compiles for every fixture)

## Follow-up

xUnit1051 (suppressed here) recommends routing `CancellationToken` through `TestContext.Current.CancellationToken` so test cancellation propagates responsively. Worth a separate sweep; ~1.5k mechanical call-site edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)