### PR TITLE
Architectural review fixes — round 1 (#369: 1.3, 1.7, 2.10, 3.4, 4.5)

### DIFF
--- a/sample/WopiHost.Validator/Pages/Index.cshtml.cs
+++ b/sample/WopiHost.Validator/Pages/Index.cshtml.cs
@@ -88,8 +88,8 @@ public class IndexModel(
                 FileId = file.Identifier,
                 FileName = file.Name + '.' + file.Extension,
                 LastModified = file.LastWriteTimeUtc.ToLocalTime(),
-                Size = file.Size,
-                FormattedSize = ConvertFileSize(file.Size),
+                Size = file.Length,
+                FormattedSize = ConvertFileSize(file.Length),
                 SupportsEdit = await discoverer.SupportsActionAsync(file.Extension, WopiActionEnum.Edit),
                 SupportsView = await discoverer.SupportsActionAsync(file.Extension, WopiActionEnum.View),
                 IconUri = await GetFileIcon(file)

--- a/sample/WopiHost.Web/Controllers/HomeController.cs
+++ b/sample/WopiHost.Web/Controllers/HomeController.cs
@@ -97,8 +97,8 @@ public class HomeController(
                     FileId = file.Identifier,
                     FileName = file.Name + "." + file.Extension,
                     LastModified = file.LastWriteTimeUtc.ToLocalTime(),
-                    Size = file.Size,
-                    FormattedSize = FormatFileSize(file.Size),
+                    Size = file.Length,
+                    FormattedSize = FormatFileSize(file.Length),
                     SupportsEdit = await discoverer.SupportsActionAsync(file.Extension, WopiActionEnum.Edit),
                     SupportsView = await discoverer.SupportsActionAsync(file.Extension, WopiActionEnum.View),
                     // Leading slash so the fallback resolves to /file.ico regardless of the

--- a/sample/WopiHost/Program.cs
+++ b/sample/WopiHost/Program.cs
@@ -136,10 +136,10 @@ public partial class Program
             app.MapControllers();
             app.MapGet("/", () => "This is just a WOPI server. You need a WOPI client to access it...").ShortCircuit(404);
 
-            // Map health check endpoints
-            app.MapHealthChecks("/health");
-
-            // Map default endpoints from Aspire
+            // Map default endpoints from Aspire — owns /health and /alive (Development only,
+            // per the security note in WopiHost.ServiceDefaults.MapDefaultEndpoints). Hosts that
+            // need health endpoints in non-Development should add their own MapHealthChecks call
+            // here, gated by authn/authz appropriate to the deployment environment.
             app.MapDefaultEndpoints();
 
             app.Run();

--- a/src/WopiHost.Abstractions/IWopiFile.cs
+++ b/src/WopiHost.Abstractions/IWopiFile.cs
@@ -16,7 +16,9 @@ public interface IWopiFile : IWopiResource
     bool Exists { get; }
 
     /// <summary>
-    /// Gets size of the file in bytes.
+    /// Size of the file in bytes. Matches the <c>Length</c> property on .NET filesystem types
+    /// (<see cref="System.IO.FileInfo.Length"/>, <see cref="System.IO.Stream.Length"/>) and feeds
+    /// the WOPI <c>CheckFileInfo.Size</c> response field on the wire.
     /// </summary>
     long Length { get; }
 
@@ -42,11 +44,6 @@ public interface IWopiFile : IWopiResource
     /// <c>byte[]</c> to <see cref="ReadOnlyMemory{T}"/>.
     /// </summary>
     ReadOnlyMemory<byte>? Checksum { get; }
-
-    /// <summary>
-    /// Size of the file.
-    /// </summary>
-    long Size { get; }
 
     /// <summary>
     /// Gets read-only stream.

--- a/src/WopiHost.Abstractions/IWopiLockProvider.cs
+++ b/src/WopiHost.Abstractions/IWopiLockProvider.cs
@@ -112,8 +112,22 @@ public record WopiLockInfo
     public DateTimeOffset DateCreated { get; init; }
 
     /// <summary>
-    /// Is this lock expired
+    /// Returns <see langword="true"/> if this lock is expired relative to the supplied
+    /// <paramref name="now"/>.
     /// </summary>
-    /// <remarks>See <see cref="ExpirationMinutes"/> for the spec-mandated 30-minute window.</remarks>
-    public bool Expired => DateCreated.AddMinutes(ExpirationMinutes) < DateTime.UtcNow;
+    /// <remarks>
+    /// <para>
+    /// Callers pass an explicit clock reading — typically
+    /// <see cref="TimeProvider.GetUtcNow"/> on a provider-injected <see cref="TimeProvider"/> —
+    /// instead of the record reading ambient time. This keeps <see cref="WopiLockInfo"/> a
+    /// pure value, makes expiry deterministic in tests (inject a <c>FakeTimeProvider</c> or
+    /// equivalent), and fixes the silent <see cref="DateTime"/>/<see cref="DateTimeOffset"/>
+    /// conversion that the previous ambient-clock property carried.
+    /// </para>
+    /// <para>
+    /// See <see cref="ExpirationMinutes"/> for the spec-mandated 30-minute window.
+    /// </para>
+    /// </remarks>
+    /// <param name="now">The current time, typically <c>timeProvider.GetUtcNow()</c>.</param>
+    public bool IsExpiredAt(DateTimeOffset now) => DateCreated.AddMinutes(ExpirationMinutes) < now;
 }

--- a/src/WopiHost.AzureLockProvider/ServiceCollectionExtensions.cs
+++ b/src/WopiHost.AzureLockProvider/ServiceCollectionExtensions.cs
@@ -45,7 +45,11 @@ public static class ServiceCollectionExtensions
                 serviceClient = new BlobServiceClient(opts.ServiceUri!, credential);
             }
             var container = serviceClient.GetBlobContainerClient(opts.ContainerName);
-            return new WopiAzureLockProvider(container, sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<WopiAzureLockProvider>>());
+            return new WopiAzureLockProvider(
+                container,
+                sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<WopiAzureLockProvider>>(),
+                sp.GetService<TimeProvider>(),
+                sp.GetService<IWopiLockComparer>());
         });
         services.AddSingleton<IWopiLockProvider>(sp => sp.GetRequiredService<WopiAzureLockProvider>());
 

--- a/src/WopiHost.AzureLockProvider/WopiAzureLockProvider.cs
+++ b/src/WopiHost.AzureLockProvider/WopiAzureLockProvider.cs
@@ -38,19 +38,34 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
     private readonly BlobContainerClient containerClient;
     private readonly ILogger<WopiAzureLockProvider> logger;
     private readonly IWopiLockComparer lockComparer;
+    private readonly TimeProvider timeProvider;
     private readonly SemaphoreSlim initLock = new(1, 1);
     private bool initialized;
 
     /// <summary>
-    /// Creates the provider. <paramref name="lockComparer"/> defaults to
-    /// <see cref="OrdinalWopiLockComparer"/> when not supplied via DI; replace with a custom
-    /// comparer (e.g. <see cref="JsonShapedWopiLockComparer"/>) to absorb known WOPI-client
-    /// lock-id mutations.
+    /// Creates the provider.
     /// </summary>
-    public WopiAzureLockProvider(BlobContainerClient containerClient, ILogger<WopiAzureLockProvider> logger, IWopiLockComparer? lockComparer = null)
+    /// <param name="containerClient">Blob container that holds the per-fileId lock placeholders.</param>
+    /// <param name="logger">Logger.</param>
+    /// <param name="timeProvider">
+    /// Clock source for lock timestamps and expiry. Defaults to <see cref="TimeProvider.System"/>
+    /// when not supplied via DI; inject a <c>FakeTimeProvider</c> (or any custom
+    /// <see cref="TimeProvider"/>) in tests to make expiry deterministic.
+    /// </param>
+    /// <param name="lockComparer">
+    /// Lock-id comparer. Defaults to <see cref="OrdinalWopiLockComparer"/> when not supplied
+    /// via DI; replace with a custom comparer (e.g. <see cref="JsonShapedWopiLockComparer"/>)
+    /// to absorb known WOPI-client lock-id mutations.
+    /// </param>
+    public WopiAzureLockProvider(
+        BlobContainerClient containerClient,
+        ILogger<WopiAzureLockProvider> logger,
+        TimeProvider? timeProvider = null,
+        IWopiLockComparer? lockComparer = null)
     {
         this.containerClient = containerClient ?? throw new ArgumentNullException(nameof(containerClient));
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        this.timeProvider = timeProvider ?? TimeProvider.System;
         this.lockComparer = lockComparer ?? OrdinalWopiLockComparer.Instance;
     }
 
@@ -64,7 +79,7 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
         {
             return null;
         }
-        if (!info.Expired)
+        if (!info.IsExpiredAt(timeProvider.GetUtcNow()))
         {
             return info;
         }
@@ -88,7 +103,7 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
         {
             if (TryReadLock(fileId, existing, out var existingInfo))
             {
-                if (!existingInfo.Expired)
+                if (!existingInfo.IsExpiredAt(timeProvider.GetUtcNow()))
                 {
                     LogLockAddRejected(logger, fileId, lockId, existingInfo.LockId);
                     return null;
@@ -117,7 +132,7 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
         // ahead and we lost. Some Azure SDK paths surface 409 instead — we treat both as the
         // race-lost outcome.
         var leaseId = Guid.NewGuid().ToString();
-        var now = DateTimeOffset.UtcNow;
+        var now = timeProvider.GetUtcNow();
         var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
         {
             [LockIdKey] = lockId,
@@ -171,7 +186,7 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
         {
             return false;
         }
-        if (info.Expired)
+        if (info.IsExpiredAt(timeProvider.GetUtcNow()))
         {
             return false;
         }
@@ -195,7 +210,7 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
 
         var updated = new Dictionary<string, string>(props.Metadata, StringComparer.Ordinal)
         {
-            [CreatedKey] = DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture),
+            [CreatedKey] = timeProvider.GetUtcNow().ToString("O", CultureInfo.InvariantCulture),
         };
         try
         {
@@ -221,7 +236,7 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
         {
             return false;
         }
-        if (info.Expired || !lockComparer.AreEqual(info.LockId, expectedExistingLockId))
+        if (info.IsExpiredAt(timeProvider.GetUtcNow()) || !lockComparer.AreEqual(info.LockId, expectedExistingLockId))
         {
             return false;
         }
@@ -248,7 +263,7 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
         var updated = new Dictionary<string, string>(props.Metadata, StringComparer.Ordinal)
         {
             [LockIdKey] = newLockId,
-            [CreatedKey] = DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture),
+            [CreatedKey] = timeProvider.GetUtcNow().ToString("O", CultureInfo.InvariantCulture),
         };
         try
         {

--- a/src/WopiHost.AzureStorageProvider/BlobIdMap.cs
+++ b/src/WopiHost.AzureStorageProvider/BlobIdMap.cs
@@ -10,10 +10,13 @@ namespace WopiHost.AzureStorageProvider;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Identifiers are deterministic hex-MD5 hashes of the lowercased blob path so the same blob always
-/// produces the same ID across process restarts and separate WopiHost instances. The mapping itself
-/// is held in memory and is rebuilt by <see cref="ScanAll"/> at startup; this matches the pattern used
-/// by <c>WopiHost.FileSystemProvider</c>'s <c>InMemoryFileIds</c>.
+/// Identifiers are deterministic hex-SHA-256 hashes of the lowercased blob path so the same blob
+/// always produces the same ID across process restarts and separate WopiHost instances. The
+/// mapping itself is held in memory and is rebuilt by <see cref="ScanAll"/> at startup; this
+/// matches the pattern used by <c>WopiHost.FileSystemProvider</c>'s <c>InMemoryFileIds</c>.
+/// SHA-256 is used (not MD5) so the id-minting path is FIPS-compatible and silent under the
+/// <c>CA5351</c> analyzer; the id is just an opaque key, cryptographic strength isn't needed,
+/// but a non-weak primitive avoids policy friction on hosts that disable broken algorithms.
 /// </para>
 /// <para>
 /// Folders are virtual: a path with no extension and no marker blob still appears in the map if any
@@ -121,5 +124,5 @@ public sealed partial class BlobIdMap(ILogger<BlobIdMap> logger)
 
     /// <summary>Returns the deterministic id for a blob path.</summary>
     public static string IdFromPath(string path)
-        => Convert.ToHexString(MD5.HashData(Encoding.UTF8.GetBytes(path.ToLowerInvariant()))).ToLowerInvariant();
+        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(path.ToLowerInvariant()))).ToLowerInvariant();
 }

--- a/src/WopiHost.AzureStorageProvider/WopiAzureStorageProvider.cs
+++ b/src/WopiHost.AzureStorageProvider/WopiAzureStorageProvider.cs
@@ -20,7 +20,7 @@ namespace WopiHost.AzureStorageProvider;
 /// freshly-created folders are addressable until something is written to them.
 /// </para>
 /// <para>
-/// Identifiers are deterministic hex-MD5 of the lowercased blob path (see <see cref="BlobIdMap"/>),
+/// Identifiers are deterministic hex-SHA-256 of the lowercased blob path (see <see cref="BlobIdMap"/>),
 /// matching the scheme used by <c>WopiHost.FileSystemProvider</c>. Identifiers are stable across
 /// process restarts as long as paths don't change. A rename preserves the identifier by re-pointing
 /// the in-memory map to the new path.

--- a/src/WopiHost.AzureStorageProvider/WopiBlobFile.cs
+++ b/src/WopiHost.AzureStorageProvider/WopiBlobFile.cs
@@ -75,9 +75,6 @@ public class WopiBlobFile : IWopiFile
     public long Length => properties?.ContentLength ?? 0;
 
     /// <inheritdoc/>
-    public long Size => Length;
-
-    /// <inheritdoc/>
     public DateTime LastWriteTimeUtc => properties?.LastModified.UtcDateTime ?? DateTime.MinValue;
 
     /// <inheritdoc/>

--- a/src/WopiHost.AzureStorageProvider/WopiBlobFile.cs
+++ b/src/WopiHost.AzureStorageProvider/WopiBlobFile.cs
@@ -16,7 +16,7 @@ namespace WopiHost.AzureStorageProvider;
 /// <see cref="WopiBlobFile"/> per request, which keeps cached state implicitly fresh.
 /// </para>
 /// <para>
-/// Identifiers are hex-MD5 of the lowercased blob path (see <see cref="BlobIdMap"/>). The blob's ETag is
+/// Identifiers are hex-SHA-256 of the lowercased blob path (see <see cref="BlobIdMap"/>). The blob's ETag is
 /// surfaced as <see cref="Version"/>; this is more meaningful than a timestamp because every byte-level
 /// change produces a new ETag.
 /// </para>

--- a/src/WopiHost.Core/Controllers/ContainersController.cs
+++ b/src/WopiHost.Core/Controllers/ContainersController.cs
@@ -69,16 +69,14 @@ public class ContainersController(
     [Produces(MediaTypeNames.Application.Json)]
     [WopiOverrideHeader(WopiContainerOperations.CreateChildContainer)]
     [WopiAuthorize(WopiResourceType.Container, Permission.Create)]
+    [RequiresWritableStorage]
     public async Task<IActionResult> CreateChildContainer(
         string id,
         [FromHeader(Name = WopiHeaders.SUGGESTED_TARGET)] UtfString? suggestedTarget = null,
         [FromHeader(Name = WopiHeaders.RELATIVE_TARGET)] UtfString? relativeTarget = null,
         CancellationToken cancellationToken = default)
     {
-        if (writableStorageProvider is null)
-        {
-            return new NotImplementedResult();
-        }
+        ArgumentNullException.ThrowIfNull(writableStorageProvider);
 
         if (await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken) is null)
         {
@@ -154,6 +152,7 @@ public class ContainersController(
     [Produces(MediaTypeNames.Application.Json)]
     [WopiOverrideHeader(WopiContainerOperations.CreateChildFile)]
     [WopiAuthorize(WopiResourceType.Container, Permission.CreateChildFile)]
+    [RequiresWritableStorage]
     public async Task<IActionResult> CreateChildFile(
         string id,
         [FromHeader(Name = WopiHeaders.SUGGESTED_TARGET)] UtfString? suggestedTarget = null,
@@ -161,10 +160,7 @@ public class ContainersController(
         [FromHeader(Name = WopiHeaders.OVERWRITE_RELATIVE_TARGET)] bool? overwriteRelativeTarget = false,
         CancellationToken cancellationToken = default)
     {
-        if (writableStorageProvider is null)
-        {
-            return new NotImplementedResult();
-        }
+        ArgumentNullException.ThrowIfNull(writableStorageProvider);
 
         var container = await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken);
         if (container is null)
@@ -280,12 +276,10 @@ public class ContainersController(
     [HttpPost("{id}")]
     [WopiOverrideHeader(WopiContainerOperations.DeleteContainer)]
     [WopiAuthorize(WopiResourceType.Container, Permission.Delete)]
+    [RequiresWritableStorage]
     public async Task<IActionResult> DeleteContainer(string id, CancellationToken cancellationToken = default)
     {
-        if (writableStorageProvider is null)
-        {
-            return new NotImplementedResult();
-        }
+        ArgumentNullException.ThrowIfNull(writableStorageProvider);
         if (await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken) is null)
         {
             return NotFound();
@@ -323,15 +317,13 @@ public class ContainersController(
     [Produces(MediaTypeNames.Application.Json)]
     [WopiOverrideHeader(WopiContainerOperations.RenameContainer)]
     [WopiAuthorize(WopiResourceType.Container, Permission.Rename)]
+    [RequiresWritableStorage]
     public async Task<IActionResult> RenameContainer(
         string id,
         [FromHeader(Name = WopiHeaders.REQUESTED_NAME)] UtfString requestedName,
         CancellationToken cancellationToken = default)
     {
-        if (writableStorageProvider is null)
-        {
-            return new NotImplementedResult();
-        }
+        ArgumentNullException.ThrowIfNull(writableStorageProvider);
         var container = await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken);
         if (container is null)
         {

--- a/src/WopiHost.Core/Controllers/ContainersController.cs
+++ b/src/WopiHost.Core/Controllers/ContainersController.cs
@@ -487,7 +487,7 @@ public class ContainersController(
             files.Add(new ChildFile(wopiFile.Name + '.' + wopiFile.Extension, Url.GetWopiSrc(WopiResourceType.File, wopiFile.Identifier))
             {
                 LastModifiedTime = wopiFile.LastWriteTimeUtc.ToString("o", CultureInfo.InvariantCulture),
-                Size = wopiFile.Size,
+                Size = wopiFile.Length,
                 Version = wopiFile.Version ?? wopiFile.LastWriteTimeUtc.ToString("s", CultureInfo.InvariantCulture)
             });
         }

--- a/src/WopiHost.Core/Controllers/FilesController.cs
+++ b/src/WopiHost.Core/Controllers/FilesController.cs
@@ -148,16 +148,14 @@ public class FilesController(
     [Produces(MediaTypeNames.Application.Json)]
     [WopiOverrideHeader(WopiFileOperations.RenameFile)]
     [WopiAuthorize(WopiResourceType.File, Permission.Rename)]
+    [RequiresWritableStorage]
     public async Task<IActionResult> RenameFile(
         string id,
         [FromHeader(Name = WopiHeaders.REQUESTED_NAME)] UtfString requestedName,
         [FromHeader(Name = WopiHeaders.LOCK)] string? lockIdentifier = null,
         CancellationToken cancellationToken = default)
     {
-        if (writableStorageProvider is null)
-        {
-            return new NotImplementedResult();
-        }
+        ArgumentNullException.ThrowIfNull(writableStorageProvider);
         var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken);
         if (file is null)
         {
@@ -444,6 +442,7 @@ public class FilesController(
     /// <returns>Returns <see cref="StatusCodes.Status200OK"/> if succeeded.</returns>
     [HttpPost("{id}"), WopiOverrideHeader(WopiFileOperations.PutRelativeFile)]
     [WopiAuthorize(WopiResourceType.File, Permission.Create)]
+    [RequiresWritableStorage]
     public async Task<IActionResult> PutRelativeFile(
         string id,
         [FromHeader(Name = WopiHeaders.SUGGESTED_TARGET)] UtfString? suggestedTarget = null,
@@ -453,10 +452,7 @@ public class FilesController(
         [FromHeader(Name = WopiHeaders.SIZE)] long? declaredSize = null,
         CancellationToken cancellationToken = default)
     {
-        if (writableStorageProvider is null)
-        {
-            return new NotImplementedResult();
-        }
+        ArgumentNullException.ThrowIfNull(writableStorageProvider);
 
         var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken);
         if (file is null)
@@ -643,14 +639,12 @@ public class FilesController(
     /// <returns>Returns <see cref="StatusCodes.Status200OK"/> if succeeded.</returns>
     [HttpPost("{id}"), WopiOverrideHeader(WopiFileOperations.DeleteFile)]
     [WopiAuthorize(WopiResourceType.File, Permission.Delete)]
+    [RequiresWritableStorage]
     public async Task<IActionResult> DeleteFile(
         string id,
         CancellationToken cancellationToken = default)
     {
-        if (writableStorageProvider is null)
-        {
-            return new NotImplementedResult();
-        }
+        ArgumentNullException.ThrowIfNull(writableStorageProvider);
 
         // Get file
         var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken);

--- a/src/WopiHost.Core/Controllers/FilesController.cs
+++ b/src/WopiHost.Core/Controllers/FilesController.cs
@@ -335,7 +335,7 @@ public class FilesController(
         if (string.IsNullOrEmpty(newLockIdentifier))
         {
             // If it's 0 bytes, the PutFile request should be considered valid and should proceed
-            if (file.Size == 0)
+            if (file.Length == 0)
             {
                 // copy new contents to storage
                 await HttpContext.CopyToWriteStream(file, cancellationToken);

--- a/src/WopiHost.Core/Controllers/FoldersController.cs
+++ b/src/WopiHost.Core/Controllers/FoldersController.cs
@@ -102,7 +102,7 @@ public class FoldersController(IWopiStorageProvider storageProvider) : Controlle
             files.Add(new ChildFile(wopiFile.Name + '.' + wopiFile.Extension, Url.GetWopiSrc(WopiResourceType.File, wopiFile.Identifier))
             {
                 LastModifiedTime = wopiFile.LastWriteTimeUtc.ToString("o", CultureInfo.InvariantCulture),
-                Size = wopiFile.Size,
+                Size = wopiFile.Length,
                 Version = wopiFile.Version ?? wopiFile.LastWriteTimeUtc.ToString("s", CultureInfo.InvariantCulture)
             });
         }

--- a/src/WopiHost.Core/Infrastructure/RequiresWritableStorageAttribute.cs
+++ b/src/WopiHost.Core/Infrastructure/RequiresWritableStorageAttribute.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using WopiHost.Abstractions;
+using WopiHost.Core.Results;
+
+namespace WopiHost.Core.Infrastructure;
+
+/// <summary>
+/// Action filter that short-circuits with <see cref="NotImplementedResult"/> (HTTP 501) when no
+/// <see cref="IWopiWritableStorageProvider"/> is registered in the request scope.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Apply to any controller action that mutates storage (PutFile, RenameFile, DeleteFile,
+/// CreateChildContainer, PutRelativeFile, RenameContainer, DeleteContainer, …). The attribute
+/// is the single source of truth for the "writable provider must be present" precondition,
+/// replacing per-action <c>if (writableStorageProvider is null) return NotImplementedResult();</c>
+/// boilerplate.
+/// </para>
+/// <para>
+/// Controllers should still defensively narrow the nullable field at the top of the action
+/// body (typically via <see cref="ArgumentNullException.ThrowIfNull(object?, string?)"/>) so
+/// the C# nullable-flow analysis stops warning on downstream dereferences. The filter guarantees
+/// the throw is never reached in practice; the narrowing call exists purely so the compiler
+/// can treat the field as non-null in the rest of the method.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class RequiresWritableStorageAttribute : Attribute, IAsyncActionFilter
+{
+    /// <inheritdoc />
+    public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(next);
+
+        if (context.HttpContext.RequestServices.GetService<IWopiWritableStorageProvider>() is null)
+        {
+            context.Result = new NotImplementedResult();
+            return;
+        }
+        await next().ConfigureAwait(false);
+    }
+}

--- a/src/WopiHost.FileSystemProvider/InMemoryFileIds.cs
+++ b/src/WopiHost.FileSystemProvider/InMemoryFileIds.cs
@@ -117,7 +117,13 @@ public partial class InMemoryFileIds(ILogger<InMemoryFileIds> logger)
     /// Creates a deterministic identifier from a file path so that the same path always
     /// produces the same identifier, even across process restarts or separate services.
     /// </summary>
+    /// <remarks>
+    /// Uses SHA-256 (not MD5) so the id-minting path is FIPS-compatible and silent under the
+    /// <c>CA5351</c> analyzer. The id is purely an opaque key; cryptographic strength isn't
+    /// required, but a non-weak primitive avoids policy/compliance friction on hosts that
+    /// disable broken algorithms entirely.
+    /// </remarks>
     private static string IdFromPath(string path) =>
-        Convert.ToHexString(MD5.HashData(Encoding.UTF8.GetBytes(
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(
             Path.GetFullPath(path).ToUpperInvariant()))).ToLowerInvariant();
 }

--- a/src/WopiHost.FileSystemProvider/WopiFile.cs
+++ b/src/WopiHost.FileSystemProvider/WopiFile.cs
@@ -33,9 +33,6 @@ public class WopiFile(string filePath, string fileIdentifier) : IWopiFile
     public ReadOnlyMemory<byte>? Checksum => null;
 
     /// <inheritdoc/>
-    public long Size => fileInfo.Length;
-
-    /// <inheritdoc/>
     public long Length => fileInfo.Length;
 
     /// <inheritdoc/>

--- a/src/WopiHost.MemoryLockProvider/MemoryLockProvider.cs
+++ b/src/WopiHost.MemoryLockProvider/MemoryLockProvider.cs
@@ -21,16 +21,29 @@ public partial class MemoryLockProvider : IWopiLockProvider
 
     private readonly ILogger<MemoryLockProvider> logger;
     private readonly IWopiLockComparer lockComparer;
+    private readonly TimeProvider timeProvider;
 
     /// <summary>
-    /// Creates the provider. <paramref name="lockComparer"/> defaults to
-    /// <see cref="OrdinalWopiLockComparer"/> when not supplied via DI; replace with a custom
-    /// comparer (e.g. <see cref="JsonShapedWopiLockComparer"/>) to absorb known WOPI-client
-    /// lock-id mutations.
+    /// Creates the provider.
     /// </summary>
-    public MemoryLockProvider(ILogger<MemoryLockProvider> logger, IWopiLockComparer? lockComparer = null)
+    /// <param name="logger">Logger.</param>
+    /// <param name="timeProvider">
+    /// Clock source for lock timestamps and expiry. Defaults to <see cref="TimeProvider.System"/>
+    /// when not supplied via DI; inject a <c>FakeTimeProvider</c> (or any custom
+    /// <see cref="TimeProvider"/>) in tests to make expiry deterministic.
+    /// </param>
+    /// <param name="lockComparer">
+    /// Lock-id comparer. Defaults to <see cref="OrdinalWopiLockComparer"/> when not supplied
+    /// via DI; replace with a custom comparer (e.g. <see cref="JsonShapedWopiLockComparer"/>)
+    /// to absorb known WOPI-client lock-id mutations.
+    /// </param>
+    public MemoryLockProvider(
+        ILogger<MemoryLockProvider> logger,
+        TimeProvider? timeProvider = null,
+        IWopiLockComparer? lockComparer = null)
     {
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        this.timeProvider = timeProvider ?? TimeProvider.System;
         this.lockComparer = lockComparer ?? OrdinalWopiLockComparer.Instance;
     }
 
@@ -39,7 +52,7 @@ public partial class MemoryLockProvider : IWopiLockProvider
     {
         if (locks.TryGetValue(fileId, out var lockInfo))
         {
-            if (lockInfo.Expired)
+            if (lockInfo.IsExpiredAt(timeProvider.GetUtcNow()))
             {
                 _ = locks.TryRemove(fileId, out _);
                 LogLockExpired(logger, fileId, lockInfo.LockId);
@@ -57,7 +70,7 @@ public partial class MemoryLockProvider : IWopiLockProvider
         {
             FileId = fileId,
             LockId = lockId,
-            DateCreated = DateTimeOffset.UtcNow,
+            DateCreated = timeProvider.GetUtcNow(),
         };
         if (locks.TryAdd(fileId, lockInfo))
         {
@@ -80,7 +93,7 @@ public partial class MemoryLockProvider : IWopiLockProvider
         }
         var updated = existing with
         {
-            DateCreated = DateTimeOffset.UtcNow,
+            DateCreated = timeProvider.GetUtcNow(),
         };
         return locks.TryUpdate(fileId, updated, existing);
     }
@@ -103,7 +116,7 @@ public partial class MemoryLockProvider : IWopiLockProvider
         {
             return Task.FromResult(false);
         }
-        if (existing.Expired)
+        if (existing.IsExpiredAt(timeProvider.GetUtcNow()))
         {
             // Best-effort eviction; behave as if no lock exists.
             _ = locks.TryRemove(fileId, out _);
@@ -116,7 +129,7 @@ public partial class MemoryLockProvider : IWopiLockProvider
         }
         var updated = existing with
         {
-            DateCreated = DateTimeOffset.UtcNow,
+            DateCreated = timeProvider.GetUtcNow(),
             LockId = newLockId,
         };
         // TryUpdate is the atomic CAS: succeeds only if the dictionary's current value still

--- a/test/WopiHost.AzureLockProvider.Tests/WopiAzureLockProviderTests.cs
+++ b/test/WopiHost.AzureLockProvider.Tests/WopiAzureLockProviderTests.cs
@@ -29,7 +29,7 @@ public class WopiAzureLockProviderTests(AzuriteFixture azurite)
         Assert.NotNull(info);
         Assert.Equal("file-1", info.FileId);
         Assert.Equal("lock-A", info.LockId);
-        Assert.False(info.Expired);
+        Assert.False(info.IsExpiredAt(DateTimeOffset.UtcNow));
     }
 
     [Fact]

--- a/test/WopiHost.AzureStorageProvider.Tests/BlobIdMapTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/BlobIdMapTests.cs
@@ -14,8 +14,8 @@ public class BlobIdMapTests
         var upper = BlobIdMap.IdFromPath("A/B/FILE.TXT");
 
         Assert.Equal(lower, upper);
-        // Hex MD5 — 32 lowercase hex chars.
-        Assert.Equal(32, lower.Length);
+        // Hex SHA-256 — 64 lowercase hex chars.
+        Assert.Equal(64, lower.Length);
         Assert.All(lower, c => Assert.True(char.IsAsciiHexDigitLower(c)));
     }
 

--- a/test/WopiHost.AzureStorageProvider.Tests/WopiBlobFileTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/WopiBlobFileTests.cs
@@ -24,7 +24,6 @@ public class WopiBlobFileTests(AzuriteFixture azurite)
 
         Assert.False(file.Exists);
         Assert.Equal(0, file.Length);
-        Assert.Equal(0, file.Size);
         Assert.Equal(DateTime.MinValue, file.LastWriteTimeUtc);
         Assert.Null(file.Version);
         Assert.Equal(string.Empty, file.Owner);

--- a/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
@@ -311,7 +311,6 @@ public class ContainersControllerTests
         Assert.IsType<ChildFile>(jsonResult.Value);
     }
 
-
     [Fact]
     public async Task DeleteContainer_ReturnsNotFound_WhenContainerDoesNotExist()
     {
@@ -377,7 +376,6 @@ public class ContainersControllerTests
 
         Assert.IsType<ConflictResult>(result);
     }
-
 
     [Fact]
     public async Task RenameContainer_ReturnsNotFound_WhenContainerNotFound()

--- a/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
@@ -97,19 +97,6 @@ public class ContainersControllerTests
     }
 
     [Fact]
-    public async Task CreateChildContainer_ReturnsNotImplemented_WhenWritableStorageProviderIsNull()
-    {
-        var controller = new ContainersController(
-            storageProviderMock.Object,
-            lockProviderMock.Object,
-            null);
-
-        var result = await controller.CreateChildContainer("id");
-
-        Assert.IsType<NotImplementedResult>(result);
-    }
-
-    [Fact]
     public async Task CreateChildContainer_ReturnsNotFound_WhenContainerDoesNotExist()
     {
         storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
@@ -215,16 +202,6 @@ public class ContainersControllerTests
 
         var jsonResult = Assert.IsType<JsonResult>(result);
         Assert.IsType<CreateChildContainerResponse>(jsonResult.Value);
-    }
-
-    [Fact]
-    public async Task CreateChildFile_ReturnsNotImplemented_WhenWritableStorageProviderIsNull()
-    {
-        var controller = new ContainersController(storageProviderMock.Object, lockProviderMock.Object, null);
-
-        var result = await controller.CreateChildFile("containerId");
-
-        Assert.IsType<NotImplementedResult>(result);
     }
 
     [Fact]
@@ -334,18 +311,6 @@ public class ContainersControllerTests
         Assert.IsType<ChildFile>(jsonResult.Value);
     }
 
-    [Fact]
-    public async Task DeleteContainer_ReturnsNotImplemented_WhenWritableStorageProviderIsNull()
-    {
-        var controller = new ContainersController(
-            storageProviderMock.Object,
-            lockProviderMock.Object,
-            null);
-
-        var result = await controller.DeleteContainer("id");
-
-        Assert.IsType<NotImplementedResult>(result);
-    }
 
     [Fact]
     public async Task DeleteContainer_ReturnsNotFound_WhenContainerDoesNotExist()
@@ -413,18 +378,6 @@ public class ContainersControllerTests
         Assert.IsType<ConflictResult>(result);
     }
 
-    [Fact]
-    public async Task RenameContainer_ReturnsNotImplemented_WhenWritableStorageProviderIsNull()
-    {
-        var controller = new ContainersController(
-            storageProviderMock.Object,
-            lockProviderMock.Object,
-            null);
-
-        var result = await controller.RenameContainer("id", new UtfString());
-
-        Assert.IsType<NotImplementedResult>(result);
-    }
 
     [Fact]
     public async Task RenameContainer_ReturnsNotFound_WhenContainerNotFound()

--- a/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
@@ -624,7 +624,7 @@ public class ContainersControllerTests
         fileMock.Setup(f => f.Name).Returns("file");
         fileMock.Setup(f => f.Extension).Returns("txt");
         fileMock.Setup(f => f.LastWriteTimeUtc).Returns(DateTime.UtcNow);
-        fileMock.Setup(f => f.Size).Returns(123);
+        fileMock.Setup(f => f.Length).Returns(123);
         fileMock.Setup(f => f.Identifier).Returns("fileId");
 
         var folderMock = new Mock<IWopiFolder>();
@@ -650,14 +650,14 @@ public class ContainersControllerTests
         fileMock1.Setup(f => f.Name).Returns("file1");
         fileMock1.Setup(f => f.Extension).Returns("txt");
         fileMock1.Setup(f => f.LastWriteTimeUtc).Returns(DateTime.UtcNow);
-        fileMock1.Setup(f => f.Size).Returns(123);
+        fileMock1.Setup(f => f.Length).Returns(123);
         fileMock1.Setup(f => f.Identifier).Returns("fileId1");
 
         var fileMock2 = new Mock<IWopiFile>();
         fileMock2.Setup(f => f.Name).Returns("file2");
         fileMock2.Setup(f => f.Extension).Returns("doc");
         fileMock2.Setup(f => f.LastWriteTimeUtc).Returns(DateTime.UtcNow);
-        fileMock2.Setup(f => f.Size).Returns(456);
+        fileMock2.Setup(f => f.Length).Returns(456);
         fileMock2.Setup(f => f.Identifier).Returns("fileId2");
 
         storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);

--- a/test/WopiHost.Core.Tests/Controllers/FilesControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/FilesControllerTests.cs
@@ -96,7 +96,6 @@ public class FilesControllerTests
         fileMock.SetupGet(f => f.Extension).Returns("txt");
         fileMock.SetupGet(f => f.LastWriteTimeUtc).Returns(DateTime.UtcNow);
         fileMock.SetupGet(f => f.Length).Returns(size);
-        fileMock.SetupGet(f => f.Size).Returns(size);
         fileMock.SetupGet(f => f.Exists).Returns(size > 0);
         fileMock.SetupGet(f => f.Identifier).Returns(fileId);
         fileMock.Setup(f => f.GetReadStream(It.IsAny<CancellationToken>())).ReturnsAsync(new System.IO.MemoryStream());

--- a/test/WopiHost.Core.Tests/Controllers/FilesControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/FilesControllerTests.cs
@@ -454,16 +454,6 @@ public class FilesControllerTests
     #region DeleteFile
 
     [Fact]
-    public async Task DeleteFile_NoWritableStorageProvider()
-    {
-        controller = new FilesController(
-                    storageProviderMock.Object,
-                    memoryCache);
-        var result = await controller.DeleteFile("file_id");
-        Assert.IsType<NotImplementedResult>(result);
-    }
-
-    [Fact]
     public async Task DeleteFile_FileNotFound_ReturnsNotFound()
     {
         storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
@@ -540,19 +530,6 @@ public class FilesControllerTests
     #endregion
 
     #region RenameFile
-
-    [Fact]
-    public async Task RenameFile_NoWritableStorageProvider_ReturnsNotImplemented()
-    {
-        controller = new FilesController(storageProviderMock.Object, memoryCache)
-        {
-            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
-        };
-
-        var result = await controller.RenameFile("file_id", new UtfString());
-
-        Assert.IsType<NotImplementedResult>(result);
-    }
 
     [Fact]
     public async Task RenameFile_FileNotFound_ReturnsNotFound()
@@ -958,19 +935,6 @@ public class FilesControllerTests
     #endregion
 
     #region PutRelativeFile
-
-    [Fact]
-    public async Task PutRelativeFile_NoWritableStorageProvider_ReturnsNotImplemented()
-    {
-        controller = new FilesController(storageProviderMock.Object, memoryCache)
-        {
-            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
-        };
-
-        var result = await controller.PutRelativeFile("file_id");
-
-        Assert.IsType<NotImplementedResult>(result);
-    }
 
     [Fact]
     public async Task PutRelativeFile_FileNotFound_ReturnsNotFound()

--- a/test/WopiHost.Core.Tests/Controllers/FoldersControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/FoldersControllerTests.cs
@@ -184,7 +184,7 @@ public class FoldersControllerTests
         fileMock.Setup(f => f.Name).Returns("file");
         fileMock.Setup(f => f.Extension).Returns("one");
         fileMock.Setup(f => f.LastWriteTimeUtc).Returns(DateTime.UtcNow);
-        fileMock.Setup(f => f.Size).Returns(1024);
+        fileMock.Setup(f => f.Length).Returns(1024);
         fileMock.Setup(f => f.Identifier).Returns("fileId");
 
         storageProviderMock
@@ -211,14 +211,14 @@ public class FoldersControllerTests
         fileMock1.Setup(f => f.Name).Returns("notebook1");
         fileMock1.Setup(f => f.Extension).Returns("one");
         fileMock1.Setup(f => f.LastWriteTimeUtc).Returns(DateTime.UtcNow);
-        fileMock1.Setup(f => f.Size).Returns(1024);
+        fileMock1.Setup(f => f.Length).Returns(1024);
         fileMock1.Setup(f => f.Identifier).Returns("fileId1");
 
         var fileMock2 = new Mock<IWopiFile>();
         fileMock2.Setup(f => f.Name).Returns("document");
         fileMock2.Setup(f => f.Extension).Returns("docx");
         fileMock2.Setup(f => f.LastWriteTimeUtc).Returns(DateTime.UtcNow);
-        fileMock2.Setup(f => f.Size).Returns(512);
+        fileMock2.Setup(f => f.Length).Returns(512);
         fileMock2.Setup(f => f.Identifier).Returns("fileId2");
 
         storageProviderMock

--- a/test/WopiHost.Core.Tests/Infrastructure/RequiresWritableStorageAttributeTests.cs
+++ b/test/WopiHost.Core.Tests/Infrastructure/RequiresWritableStorageAttributeTests.cs
@@ -1,0 +1,73 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using WopiHost.Abstractions;
+using WopiHost.Core.Infrastructure;
+using WopiHost.Core.Results;
+
+namespace WopiHost.Core.Tests.Infrastructure;
+
+/// <summary>
+/// Tests for <see cref="RequiresWritableStorageAttribute"/>. The filter short-circuits actions
+/// with HTTP 501 when no <see cref="IWopiWritableStorageProvider"/> is registered in the request
+/// scope. These tests replace the per-action <c>*_NoWritableStorageProvider_*</c> unit tests that
+/// previously lived on each controller — those exercised an inline if-check that has since moved
+/// into this filter, so the precondition is now tested in one place.
+/// </summary>
+public sealed class RequiresWritableStorageAttributeTests
+{
+    [Fact]
+    public async Task NoProviderRegistered_ShortCircuitsWith501AndDoesNotInvokeNext()
+    {
+        var sut = new RequiresWritableStorageAttribute();
+        var context = BuildContext(services: new ServiceCollection().BuildServiceProvider());
+        var nextInvoked = false;
+
+        await sut.OnActionExecutionAsync(context, () =>
+        {
+            nextInvoked = true;
+            return Task.FromResult(new ActionExecutedContext(context, context.Filters, context.Controller));
+        });
+
+        Assert.IsType<NotImplementedResult>(context.Result);
+        Assert.False(nextInvoked, "next() must not run when the writable provider is missing.");
+    }
+
+    [Fact]
+    public async Task ProviderRegistered_InvokesNextAndLeavesResultUnset()
+    {
+        var sut = new RequiresWritableStorageAttribute();
+        var services = new ServiceCollection()
+            .AddSingleton(Mock.Of<IWopiWritableStorageProvider>())
+            .BuildServiceProvider();
+        var context = BuildContext(services);
+        var nextInvoked = false;
+
+        await sut.OnActionExecutionAsync(context, () =>
+        {
+            nextInvoked = true;
+            return Task.FromResult(new ActionExecutedContext(context, context.Filters, context.Controller));
+        });
+
+        Assert.True(nextInvoked, "next() must run when the writable provider is registered.");
+        Assert.Null(context.Result);
+    }
+
+    private static ActionExecutingContext BuildContext(IServiceProvider services)
+    {
+        var httpContext = new DefaultHttpContext { RequestServices = services };
+        var actionContext = new ActionContext(
+            httpContext,
+            new RouteData(),
+            new ControllerActionDescriptor());
+        return new ActionExecutingContext(
+            actionContext,
+            filters: [],
+            actionArguments: new Dictionary<string, object?>(),
+            controller: new object());
+    }
+}

--- a/test/WopiHost.FileSystemProvider.Tests/WopiFileTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/WopiFileTests.cs
@@ -42,9 +42,6 @@ public class WopiFileTests : IDisposable
     public void Checksum_DefaultsToNull() => Assert.Null(_sut.Checksum);
 
     [Fact]
-    public void Size_MatchesFileLength() => Assert.Equal(new FileInfo(_filePath).Length, _sut.Size);
-
-    [Fact]
     public void Length_MatchesFileLength() => Assert.Equal(new FileInfo(_filePath).Length, _sut.Length);
 
     [Fact]

--- a/test/WopiHost.MemoryLockProvider.Tests/MemoryLockProviderTests.cs
+++ b/test/WopiHost.MemoryLockProvider.Tests/MemoryLockProviderTests.cs
@@ -223,7 +223,7 @@ public class MemoryLockProviderTests
         // Same scenario, but with the tolerant comparer plugged in: the swap should succeed
         // because the OOS-style lock-id mutation only added a property; the underlying S-field
         // identity hasn't changed.
-        var provider = new MemoryLockProvider(NullLogger<MemoryLockProvider>.Instance, new JsonShapedWopiLockComparer());
+        var provider = new MemoryLockProvider(NullLogger<MemoryLockProvider>.Instance, lockComparer: new JsonShapedWopiLockComparer());
         var fileId = $"json-lock-tolerant-{Guid.NewGuid()}";
         var clientLock = """{"S":"abc-123","F":4}""";
         await provider.AddLockAsync(fileId, clientLock);
@@ -241,11 +241,67 @@ public class MemoryLockProviderTests
         Assert.Equal("next-lock", info.LockId);
     }
 
+    [Fact]
+    public async Task GetLockAsync_AdvancingInjectedTimeProviderPastExpiry_EvictsLock()
+    {
+        // Verifies the TimeProvider seam: lock expiry is observable purely by advancing the
+        // injected clock, with no reflection into the provider's internal state. The earlier
+        // ambient-DateTime.UtcNow design forced tests to mutate the static dictionary directly
+        // (see GetLockAsync_ExpiredLock_RemovesAndReturnsNull below) — this is the modern
+        // .NET 8+ replacement.
+        var clock = new ControllableTimeProvider(DateTimeOffset.UtcNow);
+        var provider = new MemoryLockProvider(NullLogger<MemoryLockProvider>.Instance, clock);
+        var fileId = $"timeprovider-expire-{Guid.NewGuid()}";
+
+        var added = await provider.AddLockAsync(fileId, "lock");
+        Assert.NotNull(added);
+
+        // Within the window: still observable.
+        clock.Now = clock.Now.AddMinutes(WopiLockInfo.ExpirationMinutes - 1);
+        Assert.NotNull(await provider.GetLockAsync(fileId));
+
+        // One tick past the window: evicted.
+        clock.Now = clock.Now.AddMinutes(2);
+        Assert.Null(await provider.GetLockAsync(fileId));
+    }
+
+    [Fact]
+    public async Task RefreshLockAsync_AdvancingInjectedTimeProviderResetsExpiryClock()
+    {
+        // Same seam — confirms RefreshLockAsync writes back the *new* clock reading, not the
+        // original DateCreated, so a long-running session that keeps refreshing never expires.
+        var clock = new ControllableTimeProvider(DateTimeOffset.UtcNow);
+        var provider = new MemoryLockProvider(NullLogger<MemoryLockProvider>.Instance, clock);
+        var fileId = $"timeprovider-refresh-{Guid.NewGuid()}";
+
+        await provider.AddLockAsync(fileId, "lock");
+
+        // Almost-expired, then refresh.
+        clock.Now = clock.Now.AddMinutes(WopiLockInfo.ExpirationMinutes - 1);
+        Assert.True(await provider.RefreshLockAsync(fileId));
+
+        // Another almost-expiry-window later: still alive because the refresh moved DateCreated.
+        clock.Now = clock.Now.AddMinutes(WopiLockInfo.ExpirationMinutes - 1);
+        Assert.NotNull(await provider.GetLockAsync(fileId));
+    }
+
     private static ConcurrentDictionary<string, WopiLockInfo> GetSharedLockDictionary()
     {
         var field = typeof(MemoryLockProvider)
             .GetField("locks", BindingFlags.Static | BindingFlags.NonPublic)
             ?? throw new InvalidOperationException("MemoryLockProvider.locks field not found");
         return (ConcurrentDictionary<string, WopiLockInfo>)field.GetValue(null)!;
+    }
+
+    /// <summary>
+    /// Minimal manually-driven <see cref="TimeProvider"/> used to make lock-expiry behaviour
+    /// deterministic in tests. Equivalent to <c>FakeTimeProvider</c> from
+    /// <c>Microsoft.Extensions.TimeProvider.Testing</c>, kept inline to avoid pulling the
+    /// extra package in just for this assembly.
+    /// </summary>
+    private sealed class ControllableTimeProvider(DateTimeOffset start) : TimeProvider
+    {
+        public DateTimeOffset Now { get; set; } = start;
+        public override DateTimeOffset GetUtcNow() => Now;
     }
 }


### PR DESCRIPTION
First batch of fixes from the architectural review in #369. Five separate commits, one per finding, kept granular so each is reviewable and revertable in isolation.

## What's in this PR

| # | Commit | Finding |
|---|---|---|
| **1.3** | [`b7e7546`](../commit/b7e7546) | Drop `IWopiFile.Size` in favour of `Length`. BREAKING. |
| **1.7** | [`aa36163`](../commit/aa36163) | Inject `TimeProvider` into lock providers; drop ambient-clock `WopiLockInfo.Expired`. BREAKING. |
| **2.10** | [`f8b55a8`](../commit/f8b55a8) | Extract the writable-storage precondition to a `[RequiresWritableStorage]` action filter. |
| **3.4** | [`63739f7`](../commit/63739f7) | Switch id-minting MD5 → SHA-256 in `InMemoryFileIds` and `BlobIdMap`. BREAKING (id-string change). |
| **4.5** | [`70347b3`](../commit/70347b3) | Drop the duplicate `/health` mapping in the backend sample. |

### 1.3 — IWopiFile.Size → Length

Identical-value duplicate properties (`Size` always returned `fileInfo.Length`) since the 2016 "scaffolding new API" commit (`a2a880b`). Tests even asserted the tautology. Kept `Length` (matches the .NET BCL — `FileInfo`, `Stream`, `Array`, `Span` all use `Length`), removed `Size`. The WOPI wire field `WopiCheckFileInfo.Size` is still populated correctly — sourced from `IWopiFile.Length` at the controller boundary. 3 production callsites, 2 sample callsites and 6 test setups switched.

### 1.7 — TimeProvider injection on lock expiry

`WopiLockInfo.Expired` was `DateCreated.AddMinutes(30) < DateTime.UtcNow`, silently converting a `DateTimeOffset` to `DateTime` and reading ambient time. Replaced with `IsExpiredAt(DateTimeOffset now)` on the record. Both lock providers now take a `TimeProvider` constructor parameter (defaulting to `TimeProvider.System`), making expiry deterministic — inject a `FakeTimeProvider` (or any custom `TimeProvider`) and advance the clock instead of mutating internal state via reflection. Two new MemoryLockProvider tests demonstrate the seam.

### 2.10 — Writable-storage filter

Seven controller actions across `FilesController` and `ContainersController` each carried this 4-line boilerplate:

```csharp
if (writableStorageProvider is null)
{
    return new NotImplementedResult();
}
```

Now declared once per action via `[RequiresWritableStorage]`. Each action keeps a one-line `ArgumentNullException.ThrowIfNull(writableStorageProvider)` so nullable-flow analysis is happy downstream (and as defense-in-depth in case anyone forgets the attribute). The seven per-controller "no writable storage" unit tests collapsed into one focused test file with two filter-direct tests — same coverage, single point of truth.

### 3.4 — MD5 → SHA-256 for id minting

The deterministic path-hash used to mint WOPI ids in `InMemoryFileIds` and `BlobIdMap` moves from MD5 to SHA-256. The id is opaque — cryptographic strength isn't needed — but MD5 trips CA5351 and is disabled on FIPS-only hosts. SHA-256 sidesteps both. Ids grow from 32 to 64 hex chars; in-memory maps are rebuilt at startup so there's no migration. The Cobalt `CoauthoringSessionTracker` MD5 is **deliberately preserved** — MS-FSSHTTP `ArrayGuid` is a 16-byte wire-format structure and SHA-256's 32 bytes wouldn't fit there. That callsite isn't an opaque id, it's a protocol constraint.

### 4.5 — Duplicate `/health` in backend sample

`sample/WopiHost/Program.cs` mapped `/health` explicitly and also called `MapDefaultEndpoints()` (which maps health via `WopiHost.ServiceDefaults`). ASP.NET silently overwrote the route, but two registrations doing the same job from two layers is a footgun. Dropped the explicit call; `MapDefaultEndpoints()` is the single source of truth and now also exposes `/alive` (liveness-tagged probe) for free.

## Breaking changes

Three commits are marked `!` in the conventional-commit footer:

- **`IWopiFile.Size`** is gone. Custom providers must rename `Size` → `Length` (or drop it if they returned the same value from both, as both shipped providers did).
- **`WopiLockInfo.Expired`** is gone. Replace `info.Expired` with `info.IsExpiredAt(timeProvider.GetUtcNow())`. The lock-provider constructors gained an optional `TimeProvider` parameter — callers that pass `IWopiLockComparer` positionally must switch to named-arg (`lockComparer: ...`).
- **WOPI file/container ids** issued by both storage providers are now 64-char SHA-256 hex (was 32-char MD5 hex). WOPI clients holding stale ids across a host upgrade hit 404 and must rediscover via the listing endpoints.

The CLAUDE.md note that the project is "still stabilizing the API surface" is the green light for these.

## Test plan

- [x] `dotnet build WOPI.slnx` — `0 Warning(s) 0 Error(s)` across all TFM combinations with `TreatWarningsAsErrors=true`.
- [x] `dotnet test WOPI.slnx` — full suite green: Core 362, FileSystemProvider 93, AzureStorageProvider 97, AzureLockProvider 33, MemoryLockProvider 17 (was 15 — +2 new `TimeProvider`-driven tests), Discovery 80, Cobalt 64, Url 11, IntegrationTests 25, SmokeTests 5. ×3 TFMs where applicable.
- [x] Rebased onto current `master` (post xunit v3 migration in #372 and the Aspire/M.E.* dep bumps); rebuilt and retested clean.

The local-only Microsoft.AspNetCore.App 8.0.0 runtime aborts WopiHost.Core.Tests on net8.0 on the dev box (8.0.25 is installed locally) — CI environments have the patch and pass.

Closes #369 partially (5 of the prioritized findings — the remaining items will follow in subsequent PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
