### PR TITLE
Unify root-container addressing — RootContainer + non-nullable identifiers (#369 1.5)

### DIFF
--- a/sample/WopiHost.Validator/Pages/Index.cshtml.cs
+++ b/sample/WopiHost.Validator/Pages/Index.cshtml.cs
@@ -28,11 +28,11 @@ public class IndexModel(
         ViewData["Title"] = "Welcome to WOPI HOST test page";
 
         // setup title
-        ContainerId ??= storageProvider.RootContainerPointer.Identifier;
+        ContainerId ??= storageProvider.RootContainer.Identifier;
         ContainerName = (await storageProvider.GetWopiResource<IWopiFolder>(ContainerId, cancellationToken))?.Name
             ?? throw new InvalidOperationException("Container not found");
         // calc breadcrumb
-        if (ContainerId != storageProvider.RootContainerPointer.Identifier)
+        if (ContainerId != storageProvider.RootContainer.Identifier)
         {
             var ancestors = await storageProvider.GetAncestors<IWopiFolder>(ContainerId, cancellationToken);
             for (var i = 0; i < ancestors.Count; i++)

--- a/sample/WopiHost.Validator/Program.cs
+++ b/sample/WopiHost.Validator/Program.cs
@@ -71,7 +71,7 @@ app.MapGet("/_test/issue-token/{fileId}", async (
     // The Microsoft WOPI validator uses a single token for both file and container ops, so
     // we mint one with both surfaces pre-authorized. Real hosts typically issue narrower
     // tokens per session.
-    var rootContainer = storage.RootContainerPointer;
+    var rootContainer = storage.RootContainer;
     var containerPerms = await permissions.GetContainerPermissionsAsync(anonymous, rootContainer, ct);
     var token = await tokens.IssueAsync(new WopiAccessTokenRequest
     {

--- a/sample/WopiHost.Web.Oidc/Controllers/HomeController.cs
+++ b/sample/WopiHost.Web.Oidc/Controllers/HomeController.cs
@@ -34,7 +34,7 @@ public class HomeController(
         try
         {
             var fileViewModels = new List<FileViewModel>();
-            await foreach (var file in storageProvider.GetWopiFiles(storageProvider.RootContainerPointer.Identifier))
+            await foreach (var file in storageProvider.GetWopiFiles(storageProvider.RootContainer.Identifier))
             {
                 fileViewModels.Add(new FileViewModel
                 {

--- a/sample/WopiHost.Web/Controllers/HomeController.cs
+++ b/sample/WopiHost.Web/Controllers/HomeController.cs
@@ -48,7 +48,7 @@ public class HomeController(
         try
         {
             // Default to the storage provider's root when no container is specified.
-            containerId ??= storageProvider.RootContainerPointer.Identifier;
+            containerId ??= storageProvider.RootContainer.Identifier;
             var current = await storageProvider.GetWopiResource<IWopiFolder>(containerId, cancellationToken)
                 ?? throw new DirectoryNotFoundException($"Container '{containerId}' not found.");
 
@@ -60,7 +60,7 @@ public class HomeController(
 
             // Breadcrumb: if we're below the root, walk ancestors to build clickable trail
             // and recover the parent container id when the URL didn't supply one.
-            if (containerId != storageProvider.RootContainerPointer.Identifier)
+            if (containerId != storageProvider.RootContainer.Identifier)
             {
                 var ancestors = await storageProvider.GetAncestors<IWopiFolder>(containerId, cancellationToken);
                 for (var i = 0; i < ancestors.Count; i++)

--- a/src/WopiHost.Abstractions/IWopiStorageProvider.cs
+++ b/src/WopiHost.Abstractions/IWopiStorageProvider.cs
@@ -17,24 +17,34 @@ public interface IWopiStorageProvider
         where T : class, IWopiResource;
 
     /// <summary>
-    /// Returns all files from the given source.
+    /// Returns all files contained by the container identified by <paramref name="identifier"/>.
+    /// Pass <c><see cref="RootContainer"/>.Identifier</c> to enumerate the root.
     /// </summary>
-    /// <param name="identifier">Container identifier (use null for root)</param>
+    /// <param name="identifier">Container identifier. Required.</param>
     /// <param name="searchPattern">search pattern for files</param>
     /// <param name="cancellationToken">cancellation token</param>
-    IAsyncEnumerable<IWopiFile> GetWopiFiles(string? identifier = null, string? searchPattern = null, CancellationToken cancellationToken = default);
+    IAsyncEnumerable<IWopiFile> GetWopiFiles(string identifier, string? searchPattern = null, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Returns all containers from the given source.
+    /// Returns all containers contained by the container identified by <paramref name="identifier"/>.
+    /// Pass <c><see cref="RootContainer"/>.Identifier</c> to enumerate the root.
     /// </summary>
-    /// <param name="identifier">Container identifier (use null for root)</param>
+    /// <param name="identifier">Container identifier. Required.</param>
     /// <param name="cancellationToken">cancellation token</param>
-    IAsyncEnumerable<IWopiFolder> GetWopiContainers(string? identifier = null, CancellationToken cancellationToken = default);
+    IAsyncEnumerable<IWopiFolder> GetWopiContainers(string identifier, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Reference to the root container.
+    /// The root container of this storage provider. Use <see cref="IWopiResource.Identifier"/>
+    /// to refer to the root in any API that takes a container identifier; use
+    /// <see cref="IWopiResource.Name"/> for UI surfaces (breadcrumbs etc.).
     /// </summary>
-    IWopiFolder RootContainerPointer { get; }
+    /// <remarks>
+    /// The single canonical way to address the root. Earlier revisions also accepted a <see langword="null"/>
+    /// container identifier as "root" on <see cref="GetWopiFiles"/> / <see cref="GetWopiContainers"/> /
+    /// <see cref="IWopiWritableStorageProvider.CreateWopiChildResource{T}"/>; that sugar was removed
+    /// in favour of this property to keep one obvious way to spell the same thing.
+    /// </remarks>
+    IWopiFolder RootContainer { get; }
 
     /// <summary>
     /// Returns the ancestors of the given container or file.

--- a/src/WopiHost.Abstractions/IWopiWritableStorageProvider.cs
+++ b/src/WopiHost.Abstractions/IWopiWritableStorageProvider.cs
@@ -14,13 +14,17 @@ public interface IWopiWritableStorageProvider
     /// <summary>
     /// Creates a new Wopi resource (Container or File) in the specified container.
     /// </summary>
-    /// <param name="name">the new Container's name</param>
-    /// <param name="containerId">identifier of parent container (or null to use root)</param>
+    /// <param name="containerId">
+    /// Identifier of the parent container. Required. Pass
+    /// <c><see cref="IWopiStorageProvider.RootContainer"/>.Identifier</c> to create directly under
+    /// the root.
+    /// </param>
+    /// <param name="name">the new resource's name</param>
     /// <param name="cancellationToken">cancellation token</param>
     /// <returns>identifier of new resource</returns>
     /// <remarks>creating a <see cref="WopiResourceType.File"/> always creates a 0-byte file</remarks>
     Task<T?> CreateWopiChildResource<T>(
-        string? containerId,
+        string containerId,
         string name,
         CancellationToken cancellationToken = default)
         where T : class, IWopiResource;

--- a/src/WopiHost.AzureStorageProvider/WopiAzureStorageProvider.cs
+++ b/src/WopiHost.AzureStorageProvider/WopiAzureStorageProvider.cs
@@ -35,7 +35,7 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
     private bool initialized;
 
     /// <inheritdoc/>
-    public IWopiFolder RootContainerPointer { get; }
+    public IWopiFolder RootContainer { get; }
 
     /// <summary>Create the provider from a configured <see cref="BlobContainerClient"/>.</summary>
     public WopiAzureStorageProvider(
@@ -47,7 +47,7 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
         this.idMap = idMap ?? throw new ArgumentNullException(nameof(idMap));
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
         var rootId = BlobIdMap.IdFromPath(string.Empty);
-        RootContainerPointer = new WopiBlobFolder(string.Empty, rootId);
+        RootContainer = new WopiBlobFolder(string.Empty, rootId);
     }
 
     private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
@@ -106,12 +106,13 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
 
     /// <inheritdoc/>
     public async IAsyncEnumerable<IWopiFile> GetWopiFiles(
-        string? identifier = null,
+        string identifier,
         string? searchPattern = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(identifier);
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        var folderPath = ResolveFolderPath(identifier ?? RootContainerPointer.Identifier);
+        var folderPath = ResolveFolderPath(identifier);
         var prefix = string.IsNullOrEmpty(folderPath) ? null : folderPath + "/";
 
         var matcher = BuildSearchMatcher(searchPattern);
@@ -142,11 +143,12 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
 
     /// <inheritdoc/>
     public async IAsyncEnumerable<IWopiFolder> GetWopiContainers(
-        string? identifier = null,
+        string identifier,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(identifier);
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        var folderPath = ResolveFolderPath(identifier ?? RootContainerPointer.Identifier);
+        var folderPath = ResolveFolderPath(identifier);
         var prefix = string.IsNullOrEmpty(folderPath) ? null : folderPath + "/";
 
         await foreach (var item in containerClient.GetBlobsByHierarchyAsync(traits: BlobTraits.None, states: BlobStates.None, delimiter: "/", prefix: prefix, cancellationToken: cancellationToken).ConfigureAwait(false))
@@ -287,14 +289,14 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
     }
 
     /// <inheritdoc/>
-    public async Task<T?> CreateWopiChildResource<T>(string? containerId, string name, CancellationToken cancellationToken = default)
+    public async Task<T?> CreateWopiChildResource<T>(string containerId, string name, CancellationToken cancellationToken = default)
         where T : class, IWopiResource
     {
+        ArgumentNullException.ThrowIfNull(containerId);
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        var parentId = containerId ?? RootContainerPointer.Identifier;
-        if (!idMap.TryGetPath(parentId, out var parentPath))
+        if (!idMap.TryGetPath(containerId, out var parentPath))
         {
-            throw new DirectoryNotFoundException($"Container '{parentId}' not found.");
+            throw new DirectoryNotFoundException($"Container '{containerId}' not found.");
         }
 
         if (typeof(IWopiFile).IsAssignableFrom(typeof(T)))

--- a/src/WopiHost.Core/Controllers/EcosystemController.cs
+++ b/src/WopiHost.Core/Controllers/EcosystemController.cs
@@ -43,7 +43,7 @@ public class EcosystemController(
     [Produces(MediaTypeNames.Application.Json)]
     public async Task<IActionResult> GetRootContainer(CancellationToken cancellationToken = default)
     {
-        var root = await storageProvider.GetWopiResource<IWopiFolder>(storageProvider.RootContainerPointer.Identifier, cancellationToken);
+        var root = await storageProvider.GetWopiResource<IWopiFolder>(storageProvider.RootContainer.Identifier, cancellationToken);
         if (root is null)
         {
             return NotFound();

--- a/src/WopiHost.Core/Controllers/WopiBootstrapperController.cs
+++ b/src/WopiHost.Core/Controllers/WopiBootstrapperController.cs
@@ -85,8 +85,7 @@ public class WopiBootstrapperController(
         var ecosystemToken = await accessTokenService.IssueAsync(BuildEcosystemTokenRequest(userId), cancellationToken);
         var bootstrap = BuildBootstrapInfo(userId, ecosystemToken);
 
-        var rootPointer = storageProvider.RootContainerPointer;
-        var rootContainer = await storageProvider.GetWopiResource<IWopiFolder>(rootPointer.Identifier, cancellationToken);
+        var rootContainer = await storageProvider.GetWopiResource<IWopiFolder>(storageProvider.RootContainer.Identifier, cancellationToken);
         if (rootContainer is null)
         {
             return NotFound();
@@ -169,7 +168,7 @@ public class WopiBootstrapperController(
         UserId = userId,
         UserDisplayName = User.FindFirstValue(ClaimTypes.Name),
         UserEmail = User.FindFirstValue(ClaimTypes.Email),
-        ResourceId = storageProvider.RootContainerPointer.Identifier,
+        ResourceId = storageProvider.RootContainer.Identifier,
         ResourceType = WopiResourceType.Container,
         ContainerPermissions = WopiContainerPermissions.None,
     };

--- a/src/WopiHost.Core/Infrastructure/WopiLockAwareWritableStorageProvider.cs
+++ b/src/WopiHost.Core/Infrastructure/WopiLockAwareWritableStorageProvider.cs
@@ -46,7 +46,7 @@ public sealed class WopiLockAwareWritableStorageProvider : IWopiWritableStorageP
     public int FileNameMaxLength => inner.FileNameMaxLength;
 
     /// <inheritdoc />
-    public Task<T?> CreateWopiChildResource<T>(string? containerId, string name, CancellationToken cancellationToken = default)
+    public Task<T?> CreateWopiChildResource<T>(string containerId, string name, CancellationToken cancellationToken = default)
         where T : class, IWopiResource
         => inner.CreateWopiChildResource<T>(containerId, name, cancellationToken);
 

--- a/src/WopiHost.FileSystemProvider/WopiFileSystemProvider.cs
+++ b/src/WopiHost.FileSystemProvider/WopiFileSystemProvider.cs
@@ -16,10 +16,8 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
     private readonly string wopiAbsolutePath;
     private readonly ILogger<WopiFileSystemProvider> logger;
 
-    /// <summary>
-    /// Reference to the root container.
-    /// </summary>
-    public IWopiFolder RootContainerPointer { get; }
+    /// <inheritdoc />
+    public IWopiFolder RootContainer { get; }
 
     /// <summary>
     /// Creates a new instance of the <see cref="WopiFileSystemProvider"/> based on the provided hosting environment and configuration.
@@ -53,7 +51,7 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         {
             throw new InvalidOperationException("Root directory not found.");
         }
-        RootContainerPointer = new WopiFolder(wopiAbsolutePath, rootId);
+        RootContainer = new WopiFolder(wopiAbsolutePath, rootId);
         LogProviderInitialized(this.logger, wopiAbsolutePath);
     }
 
@@ -75,11 +73,12 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
 
     /// <inheritdoc/>
     public async IAsyncEnumerable<IWopiFile> GetWopiFiles(
-        string? identifier = null,
+        string identifier,
         string? searchPattern = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        var folderPath = fileIds.GetPath(identifier ?? RootContainerPointer.Identifier)
+        ArgumentNullException.ThrowIfNull(identifier);
+        var folderPath = fileIds.GetPath(identifier)
             ?? throw new DirectoryNotFoundException($"Directory '{identifier}' not found");
 
         foreach (var path in Directory.GetFiles(Path.Combine(wopiAbsolutePath, folderPath), searchPattern ?? "*.*"))
@@ -96,10 +95,11 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
 
     /// <inheritdoc/>
     public async IAsyncEnumerable<IWopiFolder> GetWopiContainers(
-        string? identifier = null,
+        string identifier,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        var folderPath = fileIds.GetPath(identifier ?? RootContainerPointer.Identifier)
+        ArgumentNullException.ThrowIfNull(identifier);
+        var folderPath = fileIds.GetPath(identifier)
             ?? throw new DirectoryNotFoundException($"Directory '{identifier}' not found");
 
         foreach (var directory in Directory.GetDirectories(Path.Combine(wopiAbsolutePath, folderPath)))
@@ -133,7 +133,7 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
             result.Add(container);
         }
 
-        while (container.Identifier != RootContainerPointer.Identifier)
+        while (container.Identifier != RootContainer.Identifier)
         {
             var parentId = GetFolderParentIdentifier(container.Identifier);
             container = await GetWopiResource<IWopiFolder>(parentId, cancellationToken)
@@ -247,15 +247,16 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
 
     /// <inheritdoc/>
     public async Task<T?> CreateWopiChildResource<T>(
-        string? containerId,
+        string containerId,
         string name,
         CancellationToken cancellationToken = default)
         where T : class, IWopiResource
     {
+        ArgumentNullException.ThrowIfNull(containerId);
         return typeof(T) switch
         {
-            { } wopiFileType when typeof(IWopiFile).IsAssignableFrom(wopiFileType) => await CreateWopiFile(containerId ?? RootContainerPointer.Identifier, name, cancellationToken) as T,
-            { } wopiFolderType when typeof(IWopiFolder).IsAssignableFrom(wopiFolderType) => await CreateWopiChildContainer(containerId ?? RootContainerPointer.Identifier, name, cancellationToken) as T,
+            { } wopiFileType when typeof(IWopiFile).IsAssignableFrom(wopiFileType) => await CreateWopiFile(containerId, name, cancellationToken) as T,
+            { } wopiFolderType when typeof(IWopiFolder).IsAssignableFrom(wopiFolderType) => await CreateWopiChildContainer(containerId, name, cancellationToken) as T,
             _ => throw new NotSupportedException("Unsupported resource type.")
         };
     }

--- a/test/WopiHost.AzureStorageProvider.Tests/WopiAzureStorageProviderEdgeCaseTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/WopiAzureStorageProviderEdgeCaseTests.cs
@@ -19,7 +19,7 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
         var idMap = new BlobIdMap(NullLogger<BlobIdMap>.Instance);
         var provider = new WopiAzureStorageProvider(container, idMap, NullLogger<WopiAzureStorageProvider>.Instance);
         // Force init.
-        _ = await provider.GetWopiResource<IWopiFolder>(provider.RootContainerPointer.Identifier);
+        _ = await provider.GetWopiResource<IWopiFolder>(provider.RootContainer.Identifier);
         return (provider, container);
     }
 
@@ -51,7 +51,7 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
         var (provider, container) = await CreateProviderAsync();
         await UploadAsync(container, "x.txt");
         // Drain GetWopiFiles to populate the id map for the blob.
-        await foreach (var _ in provider.GetWopiFiles(provider.RootContainerPointer.Identifier)) { }
+        await foreach (var _ in provider.GetWopiFiles(provider.RootContainer.Identifier)) { }
         var anyId = BlobIdMap.IdFromPath("x.txt");
 
         await Assert.ThrowsAsync<NotSupportedException>(
@@ -62,7 +62,7 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
     public async Task GetWopiResource_Folder_RoundTripsViaIdentifier()
     {
         var (provider, _) = await CreateProviderAsync();
-        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(null, "folder1"))!;
+        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(provider.RootContainer.Identifier, "folder1"))!;
 
         var fetched = await provider.GetWopiResource<IWopiFolder>(folder.Identifier);
 
@@ -82,14 +82,14 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
     public async Task GetWopiResourceByName_Folder_FoundAndMissing()
     {
         var (provider, _) = await CreateProviderAsync();
-        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(null, "subA"))!;
+        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(provider.RootContainer.Identifier, "subA"))!;
         // The folder marker blob makes the folder discoverable.
 
-        var found = await provider.GetWopiResourceByName<IWopiFolder>(provider.RootContainerPointer.Identifier, "subA");
+        var found = await provider.GetWopiResourceByName<IWopiFolder>(provider.RootContainer.Identifier, "subA");
         Assert.NotNull(found);
         Assert.Equal(folder.Identifier, found.Identifier);
 
-        var missing = await provider.GetWopiResourceByName<IWopiFolder>(provider.RootContainerPointer.Identifier, "nope");
+        var missing = await provider.GetWopiResourceByName<IWopiFolder>(provider.RootContainer.Identifier, "nope");
         Assert.Null(missing);
     }
 
@@ -98,7 +98,7 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
     {
         var (provider, _) = await CreateProviderAsync();
         await Assert.ThrowsAsync<NotSupportedException>(
-            () => provider.GetWopiResourceByName<UnsupportedResource>(provider.RootContainerPointer.Identifier, "x"));
+            () => provider.GetWopiResourceByName<UnsupportedResource>(provider.RootContainer.Identifier, "x"));
     }
 
     [Fact]
@@ -113,12 +113,12 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
     public async Task GetAncestors_Folder_TopLevel_ReturnsRootOnly()
     {
         var (provider, _) = await CreateProviderAsync();
-        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(null, "topfolder"))!;
+        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(provider.RootContainer.Identifier, "topfolder"))!;
 
         var ancestors = await provider.GetAncestors<IWopiFolder>(folder.Identifier);
 
         Assert.Single(ancestors);
-        Assert.Equal(provider.RootContainerPointer.Identifier, ancestors[0].Identifier);
+        Assert.Equal(provider.RootContainer.Identifier, ancestors[0].Identifier);
     }
 
     [Fact]
@@ -130,7 +130,7 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
         await UploadAsync(container, "notes.txt");
 
         var matched = new List<string>();
-        await foreach (var f in provider.GetWopiFiles(provider.RootContainerPointer.Identifier, searchPattern: "*.docx"))
+        await foreach (var f in provider.GetWopiFiles(provider.RootContainer.Identifier, searchPattern: "*.docx"))
         {
             matched.Add(f.Name + "." + f.Extension);
         }
@@ -148,7 +148,7 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
 
         var matched = new List<string>();
         // "?.txt" → exactly one char before .txt
-        await foreach (var f in provider.GetWopiFiles(provider.RootContainerPointer.Identifier, searchPattern: "?.txt"))
+        await foreach (var f in provider.GetWopiFiles(provider.RootContainer.Identifier, searchPattern: "?.txt"))
         {
             matched.Add(f.Name + "." + f.Extension);
         }
@@ -169,7 +169,7 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
         await UploadAsync(container, "b.docx");
 
         var count = 0;
-        await foreach (var _ in provider.GetWopiFiles(provider.RootContainerPointer.Identifier, pattern))
+        await foreach (var _ in provider.GetWopiFiles(provider.RootContainer.Identifier, pattern))
         {
             count++;
         }
@@ -181,10 +181,10 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
     public async Task CreateWopiChildResource_Folder_DuplicateName_Throws()
     {
         var (provider, _) = await CreateProviderAsync();
-        _ = await provider.CreateWopiChildResource<IWopiFolder>(null, "dup-folder");
+        _ = await provider.CreateWopiChildResource<IWopiFolder>(provider.RootContainer.Identifier, "dup-folder");
 
         await Assert.ThrowsAsync<ArgumentException>(
-            () => provider.CreateWopiChildResource<IWopiFolder>(null, "dup-folder"));
+            () => provider.CreateWopiChildResource<IWopiFolder>(provider.RootContainer.Identifier, "dup-folder"));
     }
 
     [Fact]
@@ -192,7 +192,7 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
     {
         var (provider, _) = await CreateProviderAsync();
         await Assert.ThrowsAsync<NotSupportedException>(
-            () => provider.CreateWopiChildResource<UnsupportedResource>(null, "x"));
+            () => provider.CreateWopiChildResource<UnsupportedResource>(provider.RootContainer.Identifier, "x"));
     }
 
     [Fact]
@@ -208,14 +208,14 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
     {
         var (provider, _) = await CreateProviderAsync();
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => provider.DeleteWopiResource<IWopiFolder>(provider.RootContainerPointer.Identifier));
+            () => provider.DeleteWopiResource<IWopiFolder>(provider.RootContainer.Identifier));
     }
 
     [Fact]
     public async Task DeleteWopiResource_UnsupportedType_Throws()
     {
         var (provider, _) = await CreateProviderAsync();
-        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(null, "for-delete-unsupported"))!;
+        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(provider.RootContainer.Identifier, "for-delete-unsupported"))!;
         await Assert.ThrowsAsync<NotSupportedException>(
             () => provider.DeleteWopiResource<UnsupportedResource>(folder.Identifier));
     }
@@ -224,7 +224,7 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
     public async Task RenameWopiResource_InvalidName_Throws()
     {
         var (provider, _) = await CreateProviderAsync();
-        var file = (await provider.CreateWopiChildResource<IWopiFile>(null, "rn-invalid.txt"))!;
+        var file = (await provider.CreateWopiChildResource<IWopiFile>(provider.RootContainer.Identifier, "rn-invalid.txt"))!;
 
         await Assert.ThrowsAsync<ArgumentException>(
             () => provider.RenameWopiResource<IWopiFile>(file.Identifier, "bad/name.txt"));
@@ -243,14 +243,14 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
     {
         var (provider, _) = await CreateProviderAsync();
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => provider.RenameWopiResource<IWopiFolder>(provider.RootContainerPointer.Identifier, "newroot"));
+            () => provider.RenameWopiResource<IWopiFolder>(provider.RootContainer.Identifier, "newroot"));
     }
 
     [Fact]
     public async Task RenameWopiResource_UnsupportedType_Throws()
     {
         var (provider, _) = await CreateProviderAsync();
-        var file = (await provider.CreateWopiChildResource<IWopiFile>(null, "rn-unsupported.txt"))!;
+        var file = (await provider.CreateWopiChildResource<IWopiFile>(provider.RootContainer.Identifier, "rn-unsupported.txt"))!;
         await Assert.ThrowsAsync<NotSupportedException>(
             () => provider.RenameWopiResource<UnsupportedResource>(file.Identifier, "x"));
     }
@@ -259,7 +259,7 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
     public async Task RenameWopiResource_Folder_PreservesId_AndMovesChildren()
     {
         var (provider, _) = await CreateProviderAsync();
-        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(null, "rn-folder"))!;
+        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(provider.RootContainer.Identifier, "rn-folder"))!;
         var originalId = folder.Identifier;
         var child = (await provider.CreateWopiChildResource<IWopiFile>(folder.Identifier, "child.txt"))!;
 
@@ -281,7 +281,7 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
     {
         var (provider, _) = await CreateProviderAsync();
         await Assert.ThrowsAsync<ArgumentException>(
-            () => provider.GetSuggestedName<IWopiFile>(provider.RootContainerPointer.Identifier, "bad/name"));
+            () => provider.GetSuggestedName<IWopiFile>(provider.RootContainer.Identifier, "bad/name"));
     }
 
     [Fact]
@@ -296,10 +296,10 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
     public async Task GetSuggestedName_Folder_AppendsCounter_WhenExists()
     {
         var (provider, _) = await CreateProviderAsync();
-        _ = await provider.CreateWopiChildResource<IWopiFolder>(null, "dup");
+        _ = await provider.CreateWopiChildResource<IWopiFolder>(provider.RootContainer.Identifier, "dup");
 
         var suggested = await provider.GetSuggestedName<IWopiFolder>(
-            provider.RootContainerPointer.Identifier, "dup");
+            provider.RootContainer.Identifier, "dup");
 
         Assert.Equal("dup (1)", suggested);
     }
@@ -308,10 +308,10 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
     public async Task GetSuggestedName_File_NoExtension_AppendsCounter()
     {
         var (provider, _) = await CreateProviderAsync();
-        _ = await provider.CreateWopiChildResource<IWopiFile>(null, "noext");
+        _ = await provider.CreateWopiChildResource<IWopiFile>(provider.RootContainer.Identifier, "noext");
 
         var suggested = await provider.GetSuggestedName<IWopiFile>(
-            provider.RootContainerPointer.Identifier, "noext");
+            provider.RootContainer.Identifier, "noext");
 
         Assert.Equal("noext (1)", suggested);
     }
@@ -336,14 +336,14 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
     public async Task GetWopiContainers_FromRoot_ListsTopLevelFoldersOnly()
     {
         var (provider, _) = await CreateProviderAsync();
-        _ = await provider.CreateWopiChildResource<IWopiFolder>(null, "alpha");
-        _ = await provider.CreateWopiChildResource<IWopiFolder>(null, "beta");
+        _ = await provider.CreateWopiChildResource<IWopiFolder>(provider.RootContainer.Identifier, "alpha");
+        _ = await provider.CreateWopiChildResource<IWopiFolder>(provider.RootContainer.Identifier, "beta");
         // A nested folder shouldn't appear in the top-level listing.
-        var alphaId = (await provider.GetWopiResourceByName<IWopiFolder>(provider.RootContainerPointer.Identifier, "alpha"))!.Identifier;
+        var alphaId = (await provider.GetWopiResourceByName<IWopiFolder>(provider.RootContainer.Identifier, "alpha"))!.Identifier;
         _ = await provider.CreateWopiChildResource<IWopiFolder>(alphaId, "alpha-inner");
 
         var names = new List<string>();
-        await foreach (var f in provider.GetWopiContainers(provider.RootContainerPointer.Identifier))
+        await foreach (var f in provider.GetWopiContainers(provider.RootContainer.Identifier))
         {
             names.Add(f.Name);
         }
@@ -354,10 +354,10 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
     }
 
     [Fact]
-    public async Task RootContainerPointer_IsAddressableViaItsIdentifier()
+    public async Task RootContainer_IsAddressableViaItsIdentifier()
     {
         var (provider, _) = await CreateProviderAsync();
-        var root = await provider.GetWopiResource<IWopiFolder>(provider.RootContainerPointer.Identifier);
+        var root = await provider.GetWopiResource<IWopiFolder>(provider.RootContainer.Identifier);
         Assert.NotNull(root);
         Assert.Equal(string.Empty, root.Name);
     }

--- a/test/WopiHost.AzureStorageProvider.Tests/WopiAzureStorageProviderTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/WopiAzureStorageProviderTests.cs
@@ -17,7 +17,7 @@ public class WopiAzureStorageProviderTests(AzuriteFixture azurite)
         var provider = new WopiAzureStorageProvider(container, idMap, NullLogger<WopiAzureStorageProvider>.Instance);
 
         // Force initialization (creates the container, scans the empty space).
-        _ = await provider.GetWopiResource<IWopiFolder>(provider.RootContainerPointer.Identifier);
+        _ = await provider.GetWopiResource<IWopiFolder>(provider.RootContainer.Identifier);
         return (provider, container);
     }
 
@@ -36,7 +36,7 @@ public class WopiAzureStorageProviderTests(AzuriteFixture azurite)
 
         // Re-list so the id map picks up the seeded blob.
         var files = new List<IWopiFile>();
-        await foreach (var f in provider.GetWopiFiles(provider.RootContainerPointer.Identifier))
+        await foreach (var f in provider.GetWopiFiles(provider.RootContainer.Identifier))
         {
             files.Add(f);
         }
@@ -64,8 +64,8 @@ public class WopiAzureStorageProviderTests(AzuriteFixture azurite)
     {
         var (provider, container) = await CreateProviderAsync();
         await UploadAsync(container, "doc.txt", "stream-me");
-        await foreach (var f in provider.GetWopiFiles(provider.RootContainerPointer.Identifier)) { _ = f; }
-        var file = await provider.GetWopiResourceByName<IWopiFile>(provider.RootContainerPointer.Identifier, "doc.txt");
+        await foreach (var f in provider.GetWopiFiles(provider.RootContainer.Identifier)) { _ = f; }
+        var file = await provider.GetWopiResourceByName<IWopiFile>(provider.RootContainer.Identifier, "doc.txt");
 
         Assert.NotNull(file);
         await using var s = await file.GetReadStream();
@@ -77,7 +77,7 @@ public class WopiAzureStorageProviderTests(AzuriteFixture azurite)
     public async Task GetWriteStream_StoresContent_AndComputesSha256()
     {
         var (provider, _) = await CreateProviderAsync();
-        var created = await provider.CreateWopiChildResource<IWopiFile>(null, "writeable.txt");
+        var created = await provider.CreateWopiChildResource<IWopiFile>(provider.RootContainer.Identifier, "writeable.txt");
         Assert.NotNull(created);
         Assert.True(created.Exists);
 
@@ -102,7 +102,7 @@ public class WopiAzureStorageProviderTests(AzuriteFixture azurite)
     {
         var (provider, _) = await CreateProviderAsync();
 
-        var created = await provider.CreateWopiChildResource<IWopiFile>(null, "fresh.docx");
+        var created = await provider.CreateWopiChildResource<IWopiFile>(provider.RootContainer.Identifier, "fresh.docx");
 
         Assert.NotNull(created);
         Assert.True(created.Exists);
@@ -115,10 +115,10 @@ public class WopiAzureStorageProviderTests(AzuriteFixture azurite)
     public async Task CreateWopiChildResource_File_DuplicateName_Throws()
     {
         var (provider, _) = await CreateProviderAsync();
-        _ = await provider.CreateWopiChildResource<IWopiFile>(null, "dup.txt");
+        _ = await provider.CreateWopiChildResource<IWopiFile>(provider.RootContainer.Identifier, "dup.txt");
 
         await Assert.ThrowsAsync<ArgumentException>(
-            () => provider.CreateWopiChildResource<IWopiFile>(null, "dup.txt"));
+            () => provider.CreateWopiChildResource<IWopiFile>(provider.RootContainer.Identifier, "dup.txt"));
     }
 
     [Fact]
@@ -126,13 +126,13 @@ public class WopiAzureStorageProviderTests(AzuriteFixture azurite)
     {
         var (provider, _) = await CreateProviderAsync();
 
-        var folder = await provider.CreateWopiChildResource<IWopiFolder>(null, "subfolder");
+        var folder = await provider.CreateWopiChildResource<IWopiFolder>(provider.RootContainer.Identifier, "subfolder");
 
         Assert.NotNull(folder);
         Assert.Equal("subfolder", folder.Name);
 
         var folders = new List<IWopiFolder>();
-        await foreach (var f in provider.GetWopiContainers(provider.RootContainerPointer.Identifier))
+        await foreach (var f in provider.GetWopiContainers(provider.RootContainer.Identifier))
         {
             folders.Add(f);
         }
@@ -143,7 +143,7 @@ public class WopiAzureStorageProviderTests(AzuriteFixture azurite)
     public async Task GetWopiFiles_HidesFolderMarker()
     {
         var (provider, _) = await CreateProviderAsync();
-        var folder = await provider.CreateWopiChildResource<IWopiFolder>(null, "with-marker");
+        var folder = await provider.CreateWopiChildResource<IWopiFolder>(provider.RootContainer.Identifier, "with-marker");
 
         var files = new List<IWopiFile>();
         await foreach (var f in provider.GetWopiFiles(folder!.Identifier))
@@ -157,7 +157,7 @@ public class WopiAzureStorageProviderTests(AzuriteFixture azurite)
     public async Task DeleteWopiResource_File_RemovesBlob_AndDropsId()
     {
         var (provider, _) = await CreateProviderAsync();
-        var created = (await provider.CreateWopiChildResource<IWopiFile>(null, "doomed.txt"))!;
+        var created = (await provider.CreateWopiChildResource<IWopiFile>(provider.RootContainer.Identifier, "doomed.txt"))!;
 
         var deleted = await provider.DeleteWopiResource<IWopiFile>(created.Identifier);
 
@@ -169,7 +169,7 @@ public class WopiAzureStorageProviderTests(AzuriteFixture azurite)
     public async Task DeleteWopiResource_Folder_NonEmpty_Throws()
     {
         var (provider, _) = await CreateProviderAsync();
-        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(null, "with-content"))!;
+        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(provider.RootContainer.Identifier, "with-content"))!;
         _ = await provider.CreateWopiChildResource<IWopiFile>(folder.Identifier, "child.txt");
 
         await Assert.ThrowsAsync<InvalidOperationException>(
@@ -180,7 +180,7 @@ public class WopiAzureStorageProviderTests(AzuriteFixture azurite)
     public async Task DeleteWopiResource_Folder_Empty_Succeeds()
     {
         var (provider, _) = await CreateProviderAsync();
-        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(null, "ephemeral"))!;
+        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(provider.RootContainer.Identifier, "ephemeral"))!;
 
         var deleted = await provider.DeleteWopiResource<IWopiFolder>(folder.Identifier);
 
@@ -191,7 +191,7 @@ public class WopiAzureStorageProviderTests(AzuriteFixture azurite)
     public async Task RenameWopiResource_File_PreservesIdentifier()
     {
         var (provider, _) = await CreateProviderAsync();
-        var created = (await provider.CreateWopiChildResource<IWopiFile>(null, "before.txt"))!;
+        var created = (await provider.CreateWopiChildResource<IWopiFile>(provider.RootContainer.Identifier, "before.txt"))!;
         var originalId = created.Identifier;
 
         var renamed = await provider.RenameWopiResource<IWopiFile>(originalId, "after.txt");
@@ -206,8 +206,8 @@ public class WopiAzureStorageProviderTests(AzuriteFixture azurite)
     public async Task RenameWopiResource_File_TargetExists_Throws()
     {
         var (provider, _) = await CreateProviderAsync();
-        var src = (await provider.CreateWopiChildResource<IWopiFile>(null, "source.txt"))!;
-        _ = await provider.CreateWopiChildResource<IWopiFile>(null, "target.txt");
+        var src = (await provider.CreateWopiChildResource<IWopiFile>(provider.RootContainer.Identifier, "source.txt"))!;
+        _ = await provider.CreateWopiChildResource<IWopiFile>(provider.RootContainer.Identifier, "target.txt");
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => provider.RenameWopiResource<IWopiFile>(src.Identifier, "target.txt"));
@@ -217,10 +217,10 @@ public class WopiAzureStorageProviderTests(AzuriteFixture azurite)
     public async Task GetSuggestedName_File_ReturnsCounterSuffix_WhenNameExists()
     {
         var (provider, _) = await CreateProviderAsync();
-        _ = await provider.CreateWopiChildResource<IWopiFile>(null, "report.docx");
+        _ = await provider.CreateWopiChildResource<IWopiFile>(provider.RootContainer.Identifier, "report.docx");
 
         var suggested = await provider.GetSuggestedName<IWopiFile>(
-            provider.RootContainerPointer.Identifier, "report.docx");
+            provider.RootContainer.Identifier, "report.docx");
 
         Assert.Equal("report (1).docx", suggested);
     }
@@ -231,7 +231,7 @@ public class WopiAzureStorageProviderTests(AzuriteFixture azurite)
         var (provider, _) = await CreateProviderAsync();
 
         var suggested = await provider.GetSuggestedName<IWopiFile>(
-            provider.RootContainerPointer.Identifier, "fresh.docx");
+            provider.RootContainer.Identifier, "fresh.docx");
 
         Assert.Equal("fresh.docx", suggested);
     }
@@ -261,7 +261,7 @@ public class WopiAzureStorageProviderTests(AzuriteFixture azurite)
     public async Task GetAncestors_File_IncludesParentChain()
     {
         var (provider, _) = await CreateProviderAsync();
-        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(null, "outer"))!;
+        var folder = (await provider.CreateWopiChildResource<IWopiFolder>(provider.RootContainer.Identifier, "outer"))!;
         var inner = (await provider.CreateWopiChildResource<IWopiFolder>(folder.Identifier, "inner"))!;
         var file = (await provider.CreateWopiChildResource<IWopiFile>(inner.Identifier, "deep.txt"))!;
 
@@ -269,7 +269,7 @@ public class WopiAzureStorageProviderTests(AzuriteFixture azurite)
 
         // Expected: [root, outer, inner]
         Assert.Equal(3, ancestors.Count);
-        Assert.Equal(provider.RootContainerPointer.Identifier, ancestors[0].Identifier);
+        Assert.Equal(provider.RootContainer.Identifier, ancestors[0].Identifier);
         Assert.Equal("outer", ancestors[1].Name);
         Assert.Equal("inner", ancestors[2].Name);
     }

--- a/test/WopiHost.Core.Tests/Controllers/EcosystemControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/EcosystemControllerTests.cs
@@ -24,7 +24,7 @@ public class EcosystemControllerTests
     {
         _root.SetupGet(f => f.Identifier).Returns("root-id");
         _root.SetupGet(f => f.Name).Returns("Root");
-        _storage.SetupGet(s => s.RootContainerPointer).Returns(_root.Object);
+        _storage.SetupGet(s => s.RootContainer).Returns(_root.Object);
         _storage
             .Setup(s => s.GetWopiResource<IWopiFolder>("root-id", It.IsAny<CancellationToken>()))
             .ReturnsAsync(_root.Object);

--- a/test/WopiHost.Core.Tests/Controllers/WopiBootstrapperControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/WopiBootstrapperControllerTests.cs
@@ -24,7 +24,7 @@ public class WopiBootstrapperControllerTests
     {
         _rootFolder.SetupGet(f => f.Identifier).Returns("root-id");
         _rootFolder.SetupGet(f => f.Name).Returns("Root");
-        _storage.SetupGet(s => s.RootContainerPointer).Returns(_rootFolder.Object);
+        _storage.SetupGet(s => s.RootContainer).Returns(_rootFolder.Object);
         _storage
             .Setup(s => s.GetWopiResource<IWopiFolder>("root-id", It.IsAny<CancellationToken>()))
             .ReturnsAsync(_rootFolder.Object);

--- a/test/WopiHost.FileSystemProvider.Tests/WopiFileSystemProviderTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/WopiFileSystemProviderTests.cs
@@ -98,13 +98,13 @@ public class WopiFileSystemProviderTests : IDisposable
         var provider = CreateProvider(rootPath: "sub", ids, env);
 
         // The provider should now consider _sub as the root container.
-        Assert.Equal(_sub.Name, provider.RootContainerPointer.Name);
+        Assert.Equal(_sub.Name, provider.RootContainer.Name);
     }
 
     [Fact]
     public void Ctor_AbsoluteRootPath_UsedAsIs()
     {
-        Assert.Equal(_root.Name, _sut.RootContainerPointer.Name);
+        Assert.Equal(_root.Name, _sut.RootContainer.Name);
     }
 
     [Fact]
@@ -116,7 +116,7 @@ public class WopiFileSystemProviderTests : IDisposable
         ids.AddFile(_root.FullName);
 
         var provider = CreateProvider(_root.FullName, ids);
-        Assert.NotNull(provider.RootContainerPointer);
+        Assert.NotNull(provider.RootContainer);
     }
 
     [Fact]
@@ -176,7 +176,7 @@ public class WopiFileSystemProviderTests : IDisposable
     public async Task GetWopiFiles_DefaultRoot_EnumeratesRootFiles()
     {
         var files = new List<IWopiFile>();
-        await foreach (var f in _sut.GetWopiFiles())
+        await foreach (var f in _sut.GetWopiFiles(_sut.RootContainer.Identifier))
         {
             files.Add(f);
         }
@@ -187,7 +187,7 @@ public class WopiFileSystemProviderTests : IDisposable
     public async Task GetWopiFiles_WithSearchPattern_FiltersByPattern()
     {
         var files = new List<IWopiFile>();
-        await foreach (var f in _sut.GetWopiFiles(searchPattern: "*.docx"))
+        await foreach (var f in _sut.GetWopiFiles(_sut.RootContainer.Identifier, searchPattern: "*.docx"))
         {
             files.Add(f);
         }
@@ -224,7 +224,7 @@ public class WopiFileSystemProviderTests : IDisposable
     public async Task GetWopiContainers_DefaultRoot_EnumeratesSubfolders()
     {
         var containers = new List<IWopiFolder>();
-        await foreach (var c in _sut.GetWopiContainers())
+        await foreach (var c in _sut.GetWopiContainers(_sut.RootContainer.Identifier))
         {
             containers.Add(c);
         }
@@ -259,7 +259,7 @@ public class WopiFileSystemProviderTests : IDisposable
     [Fact]
     public async Task GetAncestors_RootFolder_ReturnsEmpty()
     {
-        var ancestors = await _sut.GetAncestors<IWopiFolder>(_sut.RootContainerPointer.Identifier);
+        var ancestors = await _sut.GetAncestors<IWopiFolder>(_sut.RootContainer.Identifier);
         Assert.Empty(ancestors);
     }
 
@@ -305,7 +305,7 @@ public class WopiFileSystemProviderTests : IDisposable
     [Fact]
     public async Task GetWopiResourceByName_File_ReturnsFile()
     {
-        var rootId = _sut.RootContainerPointer.Identifier;
+        var rootId = _sut.RootContainer.Identifier;
 
         var file = await _sut.GetWopiResourceByName<IWopiFile>(rootId, "root.txt");
 
@@ -316,7 +316,7 @@ public class WopiFileSystemProviderTests : IDisposable
     [Fact]
     public async Task GetWopiResourceByName_Folder_ReturnsFolder()
     {
-        var rootId = _sut.RootContainerPointer.Identifier;
+        var rootId = _sut.RootContainer.Identifier;
 
         var folder = await _sut.GetWopiResourceByName<IWopiFolder>(rootId, "sub");
 
@@ -334,7 +334,7 @@ public class WopiFileSystemProviderTests : IDisposable
     [Fact]
     public async Task GetWopiResourceByName_MissingName_ReturnsNull()
     {
-        var rootId = _sut.RootContainerPointer.Identifier;
+        var rootId = _sut.RootContainer.Identifier;
 
         var result = await _sut.GetWopiResourceByName<IWopiFile>(rootId, "no-such-file.txt");
 
@@ -344,7 +344,7 @@ public class WopiFileSystemProviderTests : IDisposable
     [Fact]
     public async Task GetWopiResourceByName_UnsupportedType_Throws()
     {
-        var rootId = _sut.RootContainerPointer.Identifier;
+        var rootId = _sut.RootContainer.Identifier;
 
         await Assert.ThrowsAsync<NotSupportedException>(() =>
             _sut.GetWopiResourceByName<IWopiResource>(rootId, "root.txt"));
@@ -398,7 +398,7 @@ public class WopiFileSystemProviderTests : IDisposable
     [Fact]
     public async Task GetSuggestedName_InvalidName_Throws()
     {
-        var rootId = _sut.RootContainerPointer.Identifier;
+        var rootId = _sut.RootContainer.Identifier;
         await Assert.ThrowsAsync<ArgumentException>(() =>
             _sut.GetSuggestedName<IWopiFile>(rootId, "bad\0name.txt"));
     }
@@ -413,7 +413,7 @@ public class WopiFileSystemProviderTests : IDisposable
     [Fact]
     public async Task GetSuggestedName_FolderNoCollision_ReturnsName()
     {
-        var rootId = _sut.RootContainerPointer.Identifier;
+        var rootId = _sut.RootContainer.Identifier;
         var name = await _sut.GetSuggestedName<IWopiFolder>(rootId, "fresh");
         Assert.Equal("fresh", name);
     }
@@ -421,7 +421,7 @@ public class WopiFileSystemProviderTests : IDisposable
     [Fact]
     public async Task GetSuggestedName_FolderCollision_AppendsCounter()
     {
-        var rootId = _sut.RootContainerPointer.Identifier;
+        var rootId = _sut.RootContainer.Identifier;
         // "sub" already exists in fixture
         var name = await _sut.GetSuggestedName<IWopiFolder>(rootId, "sub");
         Assert.Equal("sub (1)", name);
@@ -430,7 +430,7 @@ public class WopiFileSystemProviderTests : IDisposable
     [Fact]
     public async Task GetSuggestedName_FileNoCollision_ReturnsName()
     {
-        var rootId = _sut.RootContainerPointer.Identifier;
+        var rootId = _sut.RootContainer.Identifier;
         var name = await _sut.GetSuggestedName<IWopiFile>(rootId, "fresh.txt");
         Assert.Equal("fresh.txt", name);
     }
@@ -438,7 +438,7 @@ public class WopiFileSystemProviderTests : IDisposable
     [Fact]
     public async Task GetSuggestedName_FileCollision_AppendsCounter()
     {
-        var rootId = _sut.RootContainerPointer.Identifier;
+        var rootId = _sut.RootContainer.Identifier;
         // "root.txt" already exists in fixture
         var name = await _sut.GetSuggestedName<IWopiFile>(rootId, "root.txt");
         Assert.Equal("root (1).txt", name);
@@ -447,7 +447,7 @@ public class WopiFileSystemProviderTests : IDisposable
     [Fact]
     public async Task GetSuggestedName_UnsupportedType_Throws()
     {
-        var rootId = _sut.RootContainerPointer.Identifier;
+        var rootId = _sut.RootContainer.Identifier;
         await Assert.ThrowsAsync<NotSupportedException>(() =>
             _sut.GetSuggestedName<IWopiResource>(rootId, "anything"));
     }
@@ -457,7 +457,7 @@ public class WopiFileSystemProviderTests : IDisposable
     [Fact]
     public async Task CreateWopiChildResource_File_CreatesAndReturnsFile()
     {
-        var rootId = _sut.RootContainerPointer.Identifier;
+        var rootId = _sut.RootContainer.Identifier;
 
         var file = await _sut.CreateWopiChildResource<IWopiFile>(rootId, "new.txt");
 
@@ -466,9 +466,9 @@ public class WopiFileSystemProviderTests : IDisposable
     }
 
     [Fact]
-    public async Task CreateWopiChildResource_FileWithoutContainer_UsesRoot()
+    public async Task CreateWopiChildResource_FileAtRoot_CreatesFileInRoot()
     {
-        var file = await _sut.CreateWopiChildResource<IWopiFile>(containerId: null, "rootless.txt");
+        var file = await _sut.CreateWopiChildResource<IWopiFile>(_sut.RootContainer.Identifier, "rootless.txt");
 
         Assert.NotNull(file);
         Assert.True(File.Exists(Path.Combine(_root.FullName, "rootless.txt")));
@@ -477,7 +477,7 @@ public class WopiFileSystemProviderTests : IDisposable
     [Fact]
     public async Task CreateWopiChildResource_FileAlreadyExists_Throws()
     {
-        var rootId = _sut.RootContainerPointer.Identifier;
+        var rootId = _sut.RootContainer.Identifier;
         await Assert.ThrowsAsync<ArgumentException>(() =>
             _sut.CreateWopiChildResource<IWopiFile>(rootId, "root.txt"));
     }
@@ -492,7 +492,7 @@ public class WopiFileSystemProviderTests : IDisposable
     [Fact]
     public async Task CreateWopiChildResource_Folder_CreatesAndReturnsFolder()
     {
-        var rootId = _sut.RootContainerPointer.Identifier;
+        var rootId = _sut.RootContainer.Identifier;
 
         var folder = await _sut.CreateWopiChildResource<IWopiFolder>(rootId, "new-folder");
 
@@ -503,7 +503,7 @@ public class WopiFileSystemProviderTests : IDisposable
     [Fact]
     public async Task CreateWopiChildResource_FolderAlreadyExists_Throws()
     {
-        var rootId = _sut.RootContainerPointer.Identifier;
+        var rootId = _sut.RootContainer.Identifier;
         await Assert.ThrowsAsync<ArgumentException>(() =>
             _sut.CreateWopiChildResource<IWopiFolder>(rootId, "sub"));
     }
@@ -518,7 +518,7 @@ public class WopiFileSystemProviderTests : IDisposable
     [Fact]
     public async Task CreateWopiChildResource_UnsupportedType_Throws()
     {
-        var rootId = _sut.RootContainerPointer.Identifier;
+        var rootId = _sut.RootContainer.Identifier;
         await Assert.ThrowsAsync<NotSupportedException>(() =>
             _sut.CreateWopiChildResource<IWopiResource>(rootId, "x"));
     }


### PR DESCRIPTION
Addresses **1.5** from the architectural review in #369.

## The duplicate convention

`IWopiStorageProvider` shipped two ways to refer to the root container:

```csharp
// A: a property returning an IWopiFolder
IWopiFolder RootContainerPointer { get; }

// B: pass null to the listing methods
IAsyncEnumerable<IWopiFile>   GetWopiFiles(string? identifier = null, ...);
IAsyncEnumerable<IWopiFolder> GetWopiContainers(string? identifier = null, ...);
```

`IWopiWritableStorageProvider.CreateWopiChildResource<T>` did the same with `string? containerId`. Both providers (FS + Azure) internally collapsed the `null` sugar via `identifier ?? RootContainerPointer.Identifier`, so the two surfaces were two spellings of the same thing — easy to mix up, easy to pass `null` by accident, easy to forget.

## What this PR does

Picks the property as canonical and renames it. Three breaking changes in `WopiHost.Abstractions`:

1. **`RootContainerPointer` → `RootContainer`**. "Pointer" is a C/C++-ism that doesn't fit C# property naming; "Container" matches WOPI's own vocabulary (`CheckContainerInfo`, `ChildContainer`, `CreateChildContainer`, `RootContainerInfo`).
2. **`GetWopiFiles` / `GetWopiContainers`** signatures tighten from `string? identifier = null` to required `string identifier`. Callers must pass `provider.RootContainer.Identifier` to list the root.
3. **`CreateWopiChildResource<T>`** likewise tightens `containerId` to a required `string`.

Production code already used the explicit form everywhere — only two FS unit tests leaned on the `null` sugar (now: `_sut.RootContainer.Identifier`).

## Important non-rename

The WOPI ecosystem HTTP route `/wopi/ecosystem/root_container_pointer` is **deliberately preserved** — that's the wire-format path defined by the [M365 ecosystem spec](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/ecosystem) and is independent of our internal property name. Only the C# identifier moved.

## Diff shape

| Layer | Files | Notes |
|---|---|---|
| Abstractions | `IWopiStorageProvider.cs`, `IWopiWritableStorageProvider.cs` | Rename + tighten + updated xmldoc |
| Providers | `WopiFileSystemProvider.cs`, `WopiAzureStorageProvider.cs` | Drop `?? RootContainer.Identifier` fallbacks; add `ArgumentNullException.ThrowIfNull(identifier)` at entry |
| Core | `WopiBootstrapperController.cs`, `EcosystemController.cs`, `WopiLockAwareWritableStorageProvider.cs` | Mechanical rename + signature alignment in the decorator |
| Samples | `WopiHost.Web`, `WopiHost.Web.Oidc`, `WopiHost.Validator` | Mechanical rename |
| Tests | 5 files | Mechanical rename + switch 2 `GetWopiFiles()`/`GetWopiContainers()` calls and ~20 `CreateWopiChildResource<T>(null, …)` calls to `provider.RootContainer.Identifier` |

16 files, +141 / −125. No production behavior change — just API hygiene + a rename.

## Breaking change footer

```
BREAKING CHANGE:
- IWopiStorageProvider.RootContainerPointer → RootContainer.
- IWopiStorageProvider.GetWopiFiles / GetWopiContainers no longer accept
  a null identifier; pass provider.RootContainer.Identifier to list the
  root.
- IWopiWritableStorageProvider.CreateWopiChildResource similarly
  tightened on containerId.
```

## Test plan

- [x] `dotnet build WOPI.slnx` — `0 Warning(s) 0 Error(s)` across all TFMs under `TreatWarningsAsErrors=true`.
- [x] `dotnet test WOPI.slnx` — full suite green: Core 362, FileSystemProvider 93, AzureStorageProvider 97, AzureLockProvider 33, MemoryLockProvider 17, Discovery 80, Cobalt 64, Url 11, IntegrationTests 25, SmokeTests 5. ×3 TFMs where applicable.

(Same env-only `WopiHost.Core.Tests (net8.0)` abort on the local Windows dev box — Microsoft.AspNetCore.App 8.0.0 isn't installed locally — passes everywhere else.)

Closes #369 (1.5) — addresses one more item from the prioritized list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
