### PR TITLE
Use SHA256.HashDataAsync, drop shared static instance (#369 2.1)

### DIFF
--- a/src/WopiHost.Core/Extensions/WopiExtensions.cs
+++ b/src/WopiHost.Core/Extensions/WopiExtensions.cs
@@ -16,14 +16,19 @@ namespace WopiHost.Core.Extensions;
 /// </summary>
 public static class WopiExtensions
 {
-    private static readonly SHA256 Sha = SHA256.Create();
-
     /// <summary>
     /// Returns base64 encoding of checksum (or calculates it from original contents if not provided)
     /// </summary>
     /// <param name="file">File object.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>base64 encoded sha256 checksum</returns>
+    /// <remarks>
+    /// Uses the static <see cref="SHA256.HashDataAsync(Stream, CancellationToken)"/> one-shot
+    /// API rather than an instance-cached <see cref="SHA256"/>. A previous revision held a static
+    /// <see cref="SHA256"/> instance and called <c>ComputeHashAsync</c> on it from concurrent
+    /// CheckFileInfo requests; <see cref="SHA256"/> instance methods are not thread-safe, so that
+    /// pattern could corrupt the hash or throw under load.
+    /// </remarks>
     public static async Task<string> GetEncodedSha256(this IWopiFile file, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(file);
@@ -31,7 +36,7 @@ public static class WopiExtensions
         if (result is null)
         {
             using var stream = await file.GetReadStream(cancellationToken);
-            result = await Sha.ComputeHashAsync(stream, cancellationToken);
+            result = await SHA256.HashDataAsync(stream, cancellationToken);
         }
         return Convert.ToBase64String(result.Value.Span);
     }

--- a/test/WopiHost.Core.Tests/Extensions/WopiExtensionsTests.cs
+++ b/test/WopiHost.Core.Tests/Extensions/WopiExtensionsTests.cs
@@ -34,8 +34,7 @@ public class WopiExtensionsTests
 
         var result = await mockFile.Object.GetEncodedSha256();
 
-        var stream2 = new MemoryStream([1, 2, 3, 4, 5]);
-        var expectedChecksum = await SHA256.Create().ComputeHashAsync(stream2);
+        var expectedChecksum = SHA256.HashData([1, 2, 3, 4, 5]);
         Assert.Equal(Convert.ToBase64String(expectedChecksum), result);
     }
 


### PR DESCRIPTION
Fixes **2.1** from the architectural review in #369.

## The bug

```csharp
public static class WopiExtensions
{
    private static readonly SHA256 Sha = SHA256.Create();       // shared, mutable

    public static async Task<string> GetEncodedSha256(this IWopiFile file, ...)
    {
        // ...
        result = await Sha.ComputeHashAsync(stream, cancellationToken);  // instance method
        // ...
    }
}
```

`GetEncodedSha256` is on the **CheckFileInfo** hot path — every WOPI client poll calls into it. The static `SHA256` instance is reused across concurrent requests, but `SHA256` instance methods (`ComputeHashAsync`, `TransformBlock`, etc.) are **not thread-safe** — only the static one-shot APIs (`HashData`, `HashDataAsync`) are. Under concurrent load the hash state can be corrupted mid-update, producing wrong checksums (which WOPI clients use to decide whether to refresh their local copy) or throwing intermittently.

## The fix

```csharp
result = await SHA256.HashDataAsync(stream, cancellationToken);
```

Static one-shot API. No instance to share, no instance to allocate, no `Dispose` to forget. The regression class is structurally impossible to reintroduce without literally changing the API in use.

Same treatment for a test that recomputed an expected hash via `SHA256.Create().ComputeHashAsync(...)` (also undisposed) — now uses `SHA256.HashData(byte[])`.

## Why `HashDataAsync` over `using var sha = SHA256.Create()`

Both fix the bug, but the static API is strictly better:

| | `SHA256.HashDataAsync` | `using var sha = SHA256.Create()` |
|---|---|---|
| Thread-safety | ✅ no shared state period | ✅ as long as the instance stays local |
| Footgun resistance | ✅ no instance to hoist | ⚠️ trivial regression — someone "optimises" `Create()` out and we're back where we started |
| Allocations / call | ~1 (result byte[]) | ~2–3 (instance + state + result) |
| LOC | 1 | 2 + lifecycle |

Microsoft introduced the static `HashData`/`HashDataAsync` family in .NET 5/8 [specifically to replace](https://github.com/dotnet/runtime/issues/17590) the `Create/use/Dispose` pattern for one-shot hashing. The `CA1850` analyzer flags the instance form when both are available. Library multi-targets `net8;net9;net10` — the API is everywhere we ship.

## Documentation

The xmldoc on `GetEncodedSha256` now spells out **why** the static API is the required form, so the next person to read this method doesn't reintroduce a cached `SHA256` instance as a "perf optimisation":

```xml
/// <remarks>
/// Uses the static <see cref="SHA256.HashDataAsync(Stream, CancellationToken)"/> one-shot
/// API rather than an instance-cached <see cref="SHA256"/>. A previous revision held a static
/// <see cref="SHA256"/> instance and called <c>ComputeHashAsync</c> on it from concurrent
/// CheckFileInfo requests; <see cref="SHA256"/> instance methods are not thread-safe, so that
/// pattern could corrupt the hash or throw under load.
/// </remarks>
```

## What I didn't do

I considered adding a parallel-call smoke test (N×concurrent `GetEncodedSha256`, assert every result matches expected). I decided against it — race-condition tests are inherently flaky, and the fix makes the regression structurally impossible (the static `SHA256.HashDataAsync` has nothing to race on). The xmldoc comment is the durable signal.

## Test plan

- [x] `dotnet build WOPI.slnx` — `0 Warning(s) 0 Error(s)` across all TFMs under `TreatWarningsAsErrors=true`.
- [x] `dotnet test WOPI.slnx` — full suite green: Core 362, FileSystemProvider 93, AzureStorageProvider 97, AzureLockProvider 33, MemoryLockProvider 17, Discovery 80, Cobalt 64, Url 11, IntegrationTests 25, SmokeTests 5. ×3 TFMs where applicable.

Closes #369 (2.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
