### PR TITLE
Enforce ConfigureAwait(false) in library code via CA2007 (#369 3.6)

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,13 @@
+# Library-code-only overrides. WopiHost.* assemblies under src/ ship as NuGet
+# packages, so they may end up hosted under SynchronizationContext-bearing
+# frameworks (Windows Forms, WPF, Blazor Server, custom test harnesses).
+# Library guidance requires .ConfigureAwait(false) on every awaited Task to
+# avoid forcing the continuation back onto a caller-owned context. CA2007 is
+# the analyzer that enforces this; the root .editorconfig disables it
+# globally so it stays quiet under sample/ test/ infra/ (none of which ship
+# or host code that warrants the noise). This file re-enables it for src/.
+
+[*.cs]
+
+# CA2007: Consider calling ConfigureAwait on the awaited task
+dotnet_diagnostic.CA2007.severity = warning

--- a/src/WopiHost.Core/Controllers/ContainersController.cs
+++ b/src/WopiHost.Core/Controllers/ContainersController.cs
@@ -46,12 +46,12 @@ public class ContainersController(
     [WopiAuthorize(WopiResourceType.Container, Permission.Read)]
     public async Task<IActionResult> CheckContainerInfo(string id, CancellationToken cancellationToken = default)
     {
-        var container = await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken);
+        var container = await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken).ConfigureAwait(false);
         if (container is null)
         {
             return NotFound();
         }
-        var checkContainerInfo = await container.GetWopiCheckContainerInfo(HttpContext, cancellationToken);
+        var checkContainerInfo = await container.GetWopiCheckContainerInfo(HttpContext, cancellationToken).ConfigureAwait(false);
         return new JsonResult<WopiCheckContainerInfo>(checkContainerInfo);
     }
 
@@ -78,7 +78,7 @@ public class ContainersController(
     {
         ArgumentNullException.ThrowIfNull(writableStorageProvider);
 
-        if (await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken) is null)
+        if (await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken).ConfigureAwait(false) is null)
         {
             return NotFound();
         }
@@ -90,7 +90,7 @@ public class ContainersController(
             return new NotImplementedResult();
         }
         // If the specified name is illegal, the host must respond with a 400 Bad Request.
-        if (!await writableStorageProvider.CheckValidName<IWopiFolder>((suggestedTarget ?? relativeTarget)!, cancellationToken))
+        if (!await writableStorageProvider.CheckValidName<IWopiFolder>((suggestedTarget ?? relativeTarget)!, cancellationToken).ConfigureAwait(false))
         {
             return new BadRequestResult();
         }
@@ -100,25 +100,25 @@ public class ContainersController(
         // "specific mode" - The host must not modify the name to fulfill the request.
         if (!string.IsNullOrWhiteSpace(relativeTarget))
         {
-            newFolder = await storageProvider.GetWopiResourceByName<IWopiFolder>(id, relativeTarget, cancellationToken);
+            newFolder = await storageProvider.GetWopiResourceByName<IWopiFolder>(id, relativeTarget, cancellationToken).ConfigureAwait(false);
             // If a container with the specified name already exists
             if (newFolder is not null)
             {
                 // the host may include an X-WOPI-ValidRelativeTarget specifying a container name that is valid
-                var suggestedName = await writableStorageProvider.GetSuggestedName<IWopiFolder>(id, relativeTarget, cancellationToken);
+                var suggestedName = await writableStorageProvider.GetSuggestedName<IWopiFolder>(id, relativeTarget, cancellationToken).ConfigureAwait(false);
                 Response.Headers[WopiHeaders.VALID_RELATIVE_TARGET] = UtfString.FromDecoded(suggestedName).ToString(true);
                 // the host must respond with a 409 Conflict
                 return new ConflictResult();
             }
             else
             {
-                newFolder = await writableStorageProvider.CreateWopiChildResource<IWopiFolder>(id, relativeTarget, cancellationToken);
+                newFolder = await writableStorageProvider.CreateWopiChildResource<IWopiFolder>(id, relativeTarget, cancellationToken).ConfigureAwait(false);
             }
         }
         else if (!string.IsNullOrWhiteSpace(suggestedTarget))
         {
-            var newName = await writableStorageProvider.GetSuggestedName<IWopiFolder>(id, suggestedTarget, cancellationToken);
-            newFolder = await writableStorageProvider.CreateWopiChildResource<IWopiFolder>(id, newName, cancellationToken);
+            var newName = await writableStorageProvider.GetSuggestedName<IWopiFolder>(id, suggestedTarget, cancellationToken).ConfigureAwait(false);
+            newFolder = await writableStorageProvider.CreateWopiChildResource<IWopiFolder>(id, newName, cancellationToken).ConfigureAwait(false);
         }
         else
         {
@@ -127,7 +127,7 @@ public class ContainersController(
 
         if (newFolder is not null)
         {
-            var checkContainerInfo = await newFolder.GetWopiCheckContainerInfo(HttpContext, cancellationToken);
+            var checkContainerInfo = await newFolder.GetWopiCheckContainerInfo(HttpContext, cancellationToken).ConfigureAwait(false);
             return new JsonResult(
                 new CreateChildContainerResponse(
                     new(newFolder.Name, Url.GetWopiSrc(WopiResourceType.Container, newFolder.Identifier)),
@@ -162,7 +162,7 @@ public class ContainersController(
     {
         ArgumentNullException.ThrowIfNull(writableStorageProvider);
 
-        var container = await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken);
+        var container = await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken).ConfigureAwait(false);
         if (container is null)
         {
             return NotFound();
@@ -181,13 +181,13 @@ public class ContainersController(
         if (!string.IsNullOrWhiteSpace(relativeTarget))
         {
             // If the specified name is illegal, the host must respond with a 400 Bad Request.
-            if (!await writableStorageProvider.CheckValidName<IWopiFile>(relativeTarget, cancellationToken))
+            if (!await writableStorageProvider.CheckValidName<IWopiFile>(relativeTarget, cancellationToken).ConfigureAwait(false))
             {
                 return new BadRequestResult();
             }
 
             // check if such file already exists
-            newFile = await storageProvider.GetWopiResourceByName<IWopiFile>(id, relativeTarget, cancellationToken);
+            newFile = await storageProvider.GetWopiResourceByName<IWopiFile>(id, relativeTarget, cancellationToken).ConfigureAwait(false);
 
             // If a file with the specified name already exists
             if (newFile is not null)
@@ -196,7 +196,7 @@ public class ContainersController(
                 if (overwriteRelativeTarget == false)
                 {
                     // the host might include an X-WOPI-ValidRelativeTarget specifying a file name that's valid
-                    var suggestedName = await writableStorageProvider.GetSuggestedName<IWopiFile>(id, relativeTarget, cancellationToken);
+                    var suggestedName = await writableStorageProvider.GetSuggestedName<IWopiFile>(id, relativeTarget, cancellationToken).ConfigureAwait(false);
                     Response.Headers[WopiHeaders.VALID_RELATIVE_TARGET] = UtfString.FromDecoded(suggestedName).ToString(true);
                     // the host must respond with a 409 Conflict
                     return new ConflictResult();
@@ -206,7 +206,7 @@ public class ContainersController(
                     // a file matching the target name might be locked
                     var existingLock = lockProvider is null
                         ? null
-                        : await lockProvider.GetLockAsync(newFile.Identifier, cancellationToken);
+                        : await lockProvider.GetLockAsync(newFile.Identifier, cancellationToken).ConfigureAwait(false);
                     if (existingLock is not null)
                     {
                         // the host must respond with a 409 Conflict and include a X-WOPI-Lock response header
@@ -219,7 +219,7 @@ public class ContainersController(
                 newFile = await writableStorageProvider.CreateWopiChildResource<IWopiFile>(
                     container.Identifier,
                     relativeTarget,
-                    cancellationToken);
+                    cancellationToken).ConfigureAwait(false);
             }
         }
         else if (!string.IsNullOrWhiteSpace(suggestedTarget))
@@ -231,16 +231,16 @@ public class ContainersController(
                 suggestedTargetString = Guid.NewGuid().ToString("N") + suggestedTargetString;
             }
             // If the specified name is illegal, the host must respond with a 400 Bad Request.
-            else if (!await writableStorageProvider.CheckValidName<IWopiFile>(suggestedTargetString, cancellationToken))
+            else if (!await writableStorageProvider.CheckValidName<IWopiFile>(suggestedTargetString, cancellationToken).ConfigureAwait(false))
             {
                 return new BadRequestResult();
             }
 
-            var newName = await writableStorageProvider.GetSuggestedName<IWopiFile>(container.Identifier, suggestedTargetString, cancellationToken);
+            var newName = await writableStorageProvider.GetSuggestedName<IWopiFile>(container.Identifier, suggestedTargetString, cancellationToken).ConfigureAwait(false);
             newFile = await writableStorageProvider.CreateWopiChildResource<IWopiFile>(
                 container.Identifier,
                 newName,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
         }
         else
         {
@@ -251,7 +251,7 @@ public class ContainersController(
 
         if (newFile is not null)
         {
-            var checkFileInfo = await newFile.GetWopiCheckFileInfo(HttpContext, cancellationToken: cancellationToken);
+            var checkFileInfo = await newFile.GetWopiCheckFileInfo(HttpContext, cancellationToken: cancellationToken).ConfigureAwait(false);
             return new JsonResult(
                 new ChildFile(
                     newFile.Name + '.' + newFile.Extension,
@@ -280,13 +280,13 @@ public class ContainersController(
     public async Task<IActionResult> DeleteContainer(string id, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(writableStorageProvider);
-        if (await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken) is null)
+        if (await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken).ConfigureAwait(false) is null)
         {
             return NotFound();
         }
         try
         {
-            if (await writableStorageProvider.DeleteWopiResource<IWopiFolder>(id, cancellationToken))
+            if (await writableStorageProvider.DeleteWopiResource<IWopiFolder>(id, cancellationToken).ConfigureAwait(false))
             {
                 return Ok();
             }
@@ -324,13 +324,13 @@ public class ContainersController(
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(writableStorageProvider);
-        var container = await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken);
+        var container = await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken).ConfigureAwait(false);
         if (container is null)
         {
             // 404 Not Found – Resource not found/user unauthorized
             return NotFound();
         }
-        if (!await writableStorageProvider.CheckValidName<IWopiFolder>(requestedName, cancellationToken))
+        if (!await writableStorageProvider.CheckValidName<IWopiFolder>(requestedName, cancellationToken).ConfigureAwait(false))
         {
             // 400 Bad Request – Specified name is illegal
             // A string describing the reason the rename operation couldn't be completed.
@@ -340,7 +340,7 @@ public class ContainersController(
         }
         try
         {
-            if (await writableStorageProvider.RenameWopiResource<IWopiFolder>(id, requestedName, cancellationToken))
+            if (await writableStorageProvider.RenameWopiResource<IWopiFolder>(id, requestedName, cancellationToken).ConfigureAwait(false))
             {
                 // The response to a RenameContainer call is JSON containing the following required property:
                 // Name(string) - The name of the renamed container.
@@ -390,7 +390,7 @@ public class ContainersController(
         [FromServices] IWopiAccessTokenService accessTokenService,
         CancellationToken cancellationToken = default)
     {
-        var container = await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken);
+        var container = await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken).ConfigureAwait(false);
         if (container is null)
         {
             return NotFound();
@@ -410,7 +410,7 @@ public class ContainersController(
             ResourceId = container.Identifier,
             ResourceType = WopiResourceType.Container,
             ContainerPermissions = WopiContainerPermissions.None,
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
 
         return new JsonResult<UrlResponse>(
             new(Url.GetWopiSrc(WopiRouteNames.CheckEcosystem, identifier: null, accessToken: token.Token)));
@@ -429,12 +429,12 @@ public class ContainersController(
     [Produces(MediaTypeNames.Application.Json)]
     public async Task<IActionResult> EnumerateAncestors(string id, CancellationToken cancellationToken = default)
     {
-        if (await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken) is null)
+        if (await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken).ConfigureAwait(false) is null)
         {
             return NotFound();
         }
 
-        var ancestors = await storageProvider.GetAncestors<IWopiFolder>(id, cancellationToken);
+        var ancestors = await storageProvider.GetAncestors<IWopiFolder>(id, cancellationToken).ConfigureAwait(false);
         return new JsonResult(
             new EnumerateAncestorsResponse(ancestors
                 .Select(a => new ChildContainer(a.Name, Url.GetWopiSrc(WopiResourceType.Container, a.Identifier))
@@ -461,7 +461,7 @@ public class ContainersController(
         [FromHeader(Name = WopiHeaders.FILE_EXTENSION_FILTER_LIST)] string? fileExtensionFilterList = null,
         CancellationToken cancellationToken = default)
     {
-        if (await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken) is null)
+        if (await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken).ConfigureAwait(false) is null)
         {
             return NotFound();
         }
@@ -469,7 +469,7 @@ public class ContainersController(
         var files = new List<ChildFile>();
         var containers = new List<ChildContainer>();
         var fileExtensions = fileExtensionFilterList?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        await foreach (var wopiFile in storageProvider.GetWopiFiles(id, cancellationToken: cancellationToken))
+        await foreach (var wopiFile in storageProvider.GetWopiFiles(id, cancellationToken: cancellationToken).ConfigureAwait(false))
         {
             // If included, the host must only return child files whose file extensions match the filter list, based on a case-insensitive match.
             if (fileExtensions?.Length > 0 && !fileExtensions.Contains('.' + wopiFile.Extension, StringComparer.OrdinalIgnoreCase))
@@ -484,7 +484,7 @@ public class ContainersController(
             });
         }
 
-        await foreach (var wopiContainer in storageProvider.GetWopiContainers(id, cancellationToken))
+        await foreach (var wopiContainer in storageProvider.GetWopiContainers(id, cancellationToken).ConfigureAwait(false))
         {
             containers.Add(
                 new ChildContainer(wopiContainer.Name, Url.GetWopiSrc(WopiResourceType.Container, wopiContainer.Identifier)));

--- a/src/WopiHost.Core/Controllers/EcosystemController.cs
+++ b/src/WopiHost.Core/Controllers/EcosystemController.cs
@@ -43,7 +43,7 @@ public class EcosystemController(
     [Produces(MediaTypeNames.Application.Json)]
     public async Task<IActionResult> GetRootContainer(CancellationToken cancellationToken = default)
     {
-        var root = await storageProvider.GetWopiResource<IWopiFolder>(storageProvider.RootContainer.Identifier, cancellationToken);
+        var root = await storageProvider.GetWopiResource<IWopiFolder>(storageProvider.RootContainer.Identifier, cancellationToken).ConfigureAwait(false);
         if (root is null)
         {
             return NotFound();
@@ -52,7 +52,7 @@ public class EcosystemController(
         // Issue a per-container access token. Re-using the inbound token in
         // ContainerPointer.Url violates the WOPI "preventing token trading" guidance:
         // https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/concepts#preventing-token-trading
-        var permissions = await permissionProvider.GetContainerPermissionsAsync(User, root, cancellationToken);
+        var permissions = await permissionProvider.GetContainerPermissionsAsync(User, root, cancellationToken).ConfigureAwait(false);
         var token = await accessTokenService.IssueAsync(new WopiAccessTokenRequest
         {
             UserId = User.GetUserId(),
@@ -61,7 +61,7 @@ public class EcosystemController(
             ResourceId = root.Identifier,
             ResourceType = WopiResourceType.Container,
             ContainerPermissions = permissions,
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
 
         var rc = new RootContainerInfo
         {
@@ -70,7 +70,7 @@ public class EcosystemController(
                 Url.GetWopiSrc(WopiResourceType.Container, root.Identifier, token.Token)),
             // The spec strongly recommends including ContainerInfo so the WOPI client
             // does not have to round-trip back to CheckContainerInfo.
-            ContainerInfo = await root.GetWopiCheckContainerInfo(HttpContext, cancellationToken),
+            ContainerInfo = await root.GetWopiCheckContainerInfo(HttpContext, cancellationToken).ConfigureAwait(false),
         };
         return new JsonResult(rc);
     }
@@ -130,7 +130,7 @@ public class EcosystemController(
         // Allow the host to override before returning, mirroring OnCheckFileInfo /
         // OnCheckContainerInfo / OnCheckFolderInfo.
         checkEcosystem = await wopiHostOptions.Value.OnCheckEcosystem(
-            new WopiCheckEcosystemContext(User, checkEcosystem));
+            new WopiCheckEcosystemContext(User, checkEcosystem)).ConfigureAwait(false);
 
         return new JsonResult(checkEcosystem);
     }

--- a/src/WopiHost.Core/Controllers/FilesController.cs
+++ b/src/WopiHost.Core/Controllers/FilesController.cs
@@ -68,7 +68,7 @@ public class FilesController(
     public async Task<IActionResult> CheckFileInfo(string id, CancellationToken cancellationToken = default)
     {
         // Get file
-        var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken);
+        var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken).ConfigureAwait(false);
         if (file is null)
         {
             return NotFound();
@@ -78,7 +78,7 @@ public class FilesController(
         _ = memoryCache.TryGetValue($"{UserInfoCacheKeyPrefix}{User.GetUserId()}", out string? userInfo);
 
         // build default checkFileInfo
-        var checkFileInfo = await file.GetWopiCheckFileInfo(HttpContext, HostCapabilities, userInfo, cancellationToken);
+        var checkFileInfo = await file.GetWopiCheckFileInfo(HttpContext, HostCapabilities, userInfo, cancellationToken).ConfigureAwait(false);
 
         // instead of JsonResult we must .Serialize<object>() to support properties that
         // might be defined on custom WopiCheckFileInfo objects
@@ -107,7 +107,7 @@ public class FilesController(
         CancellationToken cancellationToken = default)
     {
         // Get file
-        var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken);
+        var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken).ConfigureAwait(false);
         if (file is null)
         {
             return NotFound();
@@ -131,7 +131,7 @@ public class FilesController(
         }
 
         // Try to read content from a stream
-        return new FileStreamResult(await file.GetReadStream(cancellationToken), MediaTypeNames.Application.Octet);
+        return new FileStreamResult(await file.GetReadStream(cancellationToken).ConfigureAwait(false), MediaTypeNames.Application.Octet);
     }
 
     /// <summary>
@@ -156,7 +156,7 @@ public class FilesController(
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(writableStorageProvider);
-        var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken);
+        var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken).ConfigureAwait(false);
         if (file is null)
         {
             // 404 Not Found – Resource not found/user unauthorized
@@ -167,7 +167,7 @@ public class FilesController(
         // and include an X-WOPI-Lock response header containing the value of the current lock on the file
         if (lockProvider is not null)
         {
-            var existingLock = await lockProvider.GetLockAsync(id, cancellationToken);
+            var existingLock = await lockProvider.GetLockAsync(id, cancellationToken).ConfigureAwait(false);
             if (existingLock is not null && !lockComparer.AreEqual(existingLock.LockId, lockIdentifier))
             {
                 return new LockMismatchResult(Response, existingLock.LockId);
@@ -176,7 +176,7 @@ public class FilesController(
 
         // If the host can't rename the file because the name requested is invalid ... it should return an HTTP status code 400 Bad Request.
         // The response must include an X-WOPI-InvalidFileNameError header that describes why the file name was invalid
-        if (!await writableStorageProvider.CheckValidName<IWopiFolder>(requestedName, cancellationToken))
+        if (!await writableStorageProvider.CheckValidName<IWopiFolder>(requestedName, cancellationToken).ConfigureAwait(false))
         {
             // 400 Bad Request – Specified name is illegal
             // A string describing the reason the rename operation couldn't be completed.
@@ -189,8 +189,8 @@ public class FilesController(
         {
             // If the host can't rename the file because the name requested is invalid or conflicts with an existing file,
             // the host should try to generate a different name based on the requested name that meets the file name requirements
-            var newName = await writableStorageProvider.GetSuggestedName<IWopiFile>(id, requestedName + '.' + file.Extension, cancellationToken);
-            if (await writableStorageProvider.RenameWopiResource<IWopiFile>(id, newName, cancellationToken))
+            var newName = await writableStorageProvider.GetSuggestedName<IWopiFile>(id, requestedName + '.' + file.Extension, cancellationToken).ConfigureAwait(false);
+            if (await writableStorageProvider.RenameWopiResource<IWopiFile>(id, newName, cancellationToken).ConfigureAwait(false))
             {
                 // The response to a RenameFile call is JSON containing a single required property
                 // Name (string) - The name of the renamed file without a path or file extension.
@@ -241,7 +241,7 @@ public class FilesController(
         CancellationToken cancellationToken = default)
     {
         // Get file
-        var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken);
+        var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken).ConfigureAwait(false);
         if (file is null)
         {
             return NotFound();
@@ -261,7 +261,7 @@ public class FilesController(
             ResourceId = file.Identifier,
             ResourceType = WopiResourceType.File,
             FilePermissions = WopiFilePermissions.None,
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
 
         return new JsonResult<UrlResponse>(
             new(Url.GetWopiSrc(WopiRouteNames.CheckEcosystem, identifier: null, accessToken: token.Token)));
@@ -281,13 +281,13 @@ public class FilesController(
     public async Task<IActionResult> EnumerateAncestors(string id, CancellationToken cancellationToken = default)
     {
         // Get file
-        var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken);
+        var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken).ConfigureAwait(false);
         if (file is null)
         {
             return NotFound();
         }
 
-        var ancestors = await storageProvider.GetAncestors<IWopiFile>(id, cancellationToken);
+        var ancestors = await storageProvider.GetAncestors<IWopiFile>(id, cancellationToken).ConfigureAwait(false);
         return new JsonResult(
             new EnumerateAncestorsResponse(ancestors
                 .Select(a => new ChildContainer(a.Name, Url.GetWopiSrc(WopiResourceType.Container, a.Identifier)))
@@ -316,7 +316,7 @@ public class FilesController(
         CancellationToken cancellationToken = default)
     {
         // https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/online/scenarios/createnew
-        var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken);
+        var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken).ConfigureAwait(false);
         if (file is null)
         {
             return NotFound();
@@ -336,7 +336,7 @@ public class FilesController(
             if (file.Length == 0)
             {
                 // copy new contents to storage
-                await HttpContext.CopyToWriteStream(file, cancellationToken);
+                await HttpContext.CopyToWriteStream(file, cancellationToken).ConfigureAwait(false);
                 if (file.Version is not null)
                 {
                     Response.Headers[WopiHeaders.ITEM_VERSION] = file.Version;
@@ -353,12 +353,12 @@ public class FilesController(
         }
 
         // Acquire lock
-        var lockResult = await ProcessLock(id, wopiOverrideHeader: WopiFileOperations.Lock, newLockIdentifier: newLockIdentifier, cancellationToken: cancellationToken);
+        var lockResult = await ProcessLock(id, wopiOverrideHeader: WopiFileOperations.Lock, newLockIdentifier: newLockIdentifier, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         if (lockResult is OkResult)
         {
             // copy new contents to storage
-            await HttpContext.CopyToWriteStream(file, cancellationToken);
+            await HttpContext.CopyToWriteStream(file, cancellationToken).ConfigureAwait(false);
             if (file.Version is not null)
             {
                 Response.Headers[WopiHeaders.ITEM_VERSION] = file.Version;
@@ -454,7 +454,7 @@ public class FilesController(
     {
         ArgumentNullException.ThrowIfNull(writableStorageProvider);
 
-        var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken);
+        var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken).ConfigureAwait(false);
         if (file is null)
         {
             return NotFound();
@@ -476,7 +476,7 @@ public class FilesController(
         }
 
         // find target container id based on the relative file specified by id
-        var ancestors = await storageProvider.GetAncestors<IWopiFile>(id, cancellationToken);
+        var ancestors = await storageProvider.GetAncestors<IWopiFile>(id, cancellationToken).ConfigureAwait(false);
         var parentContainer = ancestors.LastOrDefault()
             ?? throw new ArgumentException("Cannot find parent container", nameof(id));
 
@@ -486,13 +486,13 @@ public class FilesController(
         if (!string.IsNullOrWhiteSpace(relativeTarget))
         {
             // If the specified name is illegal, the host must respond with a 400 Bad Request.
-            if (!await writableStorageProvider.CheckValidName<IWopiFile>(relativeTarget, cancellationToken))
+            if (!await writableStorageProvider.CheckValidName<IWopiFile>(relativeTarget, cancellationToken).ConfigureAwait(false))
             {
                 return new BadRequestResult();
             }
 
             // check if such file already exists
-            newFile = await storageProvider.GetWopiResourceByName<IWopiFile>(parentContainer.Identifier, relativeTarget, cancellationToken);
+            newFile = await storageProvider.GetWopiResourceByName<IWopiFile>(parentContainer.Identifier, relativeTarget, cancellationToken).ConfigureAwait(false);
 
             // If a file with the specified name already exists
             if (newFile is not null)
@@ -501,7 +501,7 @@ public class FilesController(
                 if (overwriteRelativeTarget == false)
                 {
                     // the host might include an X-WOPI-ValidRelativeTarget specifying a file name that's valid
-                    var suggestedName = await writableStorageProvider.GetSuggestedName<IWopiFile>(id, relativeTarget, cancellationToken);
+                    var suggestedName = await writableStorageProvider.GetSuggestedName<IWopiFile>(id, relativeTarget, cancellationToken).ConfigureAwait(false);
                     Response.Headers[WopiHeaders.VALID_RELATIVE_TARGET] = UtfString.FromDecoded(suggestedName).ToString(true);
                     // the host must respond with a 409 Conflict
                     return new ConflictResult();
@@ -511,7 +511,7 @@ public class FilesController(
                     // a file matching the target name might be locked
                     var existingLock = lockProvider is null
                         ? null
-                        : await lockProvider.GetLockAsync(newFile.Identifier, cancellationToken);
+                        : await lockProvider.GetLockAsync(newFile.Identifier, cancellationToken).ConfigureAwait(false);
                     if (existingLock is not null)
                     {
                         // the host must respond with a 409 Conflict and include a X-WOPI-Lock response header
@@ -524,7 +524,7 @@ public class FilesController(
                 newFile = await writableStorageProvider.CreateWopiChildResource<IWopiFile>(
                     parentContainer.Identifier,
                     relativeTarget,
-                    cancellationToken);
+                    cancellationToken).ConfigureAwait(false);
             }
         }
         else if (!string.IsNullOrWhiteSpace(suggestedTarget))
@@ -536,16 +536,16 @@ public class FilesController(
                 suggestedTargetString = file.Name + suggestedTargetString;
             }
             // If the specified name is illegal, the host must respond with a 400 Bad Request.
-            else if (!await writableStorageProvider.CheckValidName<IWopiFile>(suggestedTargetString, cancellationToken))
+            else if (!await writableStorageProvider.CheckValidName<IWopiFile>(suggestedTargetString, cancellationToken).ConfigureAwait(false))
             {
                 return new BadRequestResult();
             }
 
-            var newName = await writableStorageProvider.GetSuggestedName<IWopiFile>(parentContainer.Identifier, suggestedTargetString, cancellationToken);
+            var newName = await writableStorageProvider.GetSuggestedName<IWopiFile>(parentContainer.Identifier, suggestedTargetString, cancellationToken).ConfigureAwait(false);
             newFile = await writableStorageProvider.CreateWopiChildResource<IWopiFile>(
                 parentContainer.Identifier,
                 newName,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
         }
         else
         {
@@ -557,9 +557,9 @@ public class FilesController(
         if (newFile is not null)
         {
             // copy new contents to storage
-            await HttpContext.CopyToWriteStream(newFile, cancellationToken);
+            await HttpContext.CopyToWriteStream(newFile, cancellationToken).ConfigureAwait(false);
             await InvokePutRelativeFileCallbackAsync(file, newFile, fileConversion, declaredSize).ConfigureAwait(false);
-            var checkFileInfo = await newFile.GetWopiCheckFileInfo(HttpContext, HostCapabilities, cancellationToken: cancellationToken);
+            var checkFileInfo = await newFile.GetWopiCheckFileInfo(HttpContext, HostCapabilities, cancellationToken: cancellationToken).ConfigureAwait(false);
             return new JsonResult(
                 new ChildFile(
                     newFile.Name + '.' + newFile.Extension,
@@ -609,7 +609,7 @@ public class FilesController(
         CancellationToken cancellationToken = default)
     {
         // Get file
-        var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken);
+        var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken).ConfigureAwait(false);
         if (file is null)
         {
             return NotFound();
@@ -647,7 +647,7 @@ public class FilesController(
         ArgumentNullException.ThrowIfNull(writableStorageProvider);
 
         // Get file
-        var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken);
+        var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken).ConfigureAwait(false);
         if (file is null)
         {
             return NotFound();
@@ -657,16 +657,16 @@ public class FilesController(
         // and include an X-WOPI-Lock response header containing the value of the current lock on the file
         if (lockProvider is not null)
         {
-            var existingLock = await lockProvider.GetLockAsync(id, cancellationToken);
+            var existingLock = await lockProvider.GetLockAsync(id, cancellationToken).ConfigureAwait(false);
             if (existingLock is not null)
             {
                 return new LockMismatchResult(Response, existingLock.LockId);
             }
         }
 
-        if (await writableStorageProvider.CheckValidName<IWopiFile>(id, cancellationToken))
+        if (await writableStorageProvider.CheckValidName<IWopiFile>(id, cancellationToken).ConfigureAwait(false))
         {
-            if (await writableStorageProvider.DeleteWopiResource<IWopiFile>(id, cancellationToken))
+            if (await writableStorageProvider.DeleteWopiResource<IWopiFile>(id, cancellationToken).ConfigureAwait(false))
             {
                 return Ok();
             }
@@ -693,10 +693,10 @@ public class FilesController(
     {
         ArgumentNullException.ThrowIfNull(cobaltProcessor);
 
-        var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken)
+        var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken).ConfigureAwait(false)
             ?? throw new InvalidOperationException("File not found");
 
-        var responseBytes = await cobaltProcessor.ProcessCobalt(file, User, await HttpContext.Request.Body.ReadBytesAsync(cancellationToken), cancellationToken);
+        var responseBytes = await cobaltProcessor.ProcessCobalt(file, User, await HttpContext.Request.Body.ReadBytesAsync(cancellationToken).ConfigureAwait(false), cancellationToken).ConfigureAwait(false);
         if (!string.IsNullOrEmpty(correlationId))
         {
             HttpContext.Response.Headers.Append(WopiHeaders.CORRELATION_ID, correlationId);
@@ -749,21 +749,21 @@ public class FilesController(
             return BadRequest();
         }
 
-        var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken)
+        var file = await storageProvider.GetWopiResource<IWopiFile>(id, cancellationToken).ConfigureAwait(false)
                    ?? throw new InvalidOperationException("File not found");
         Response.Headers[WopiHeaders.ITEM_VERSION] = file.Version;
 
-        var existingLock = await lockProvider.GetLockAsync(id, cancellationToken);
+        var existingLock = await lockProvider.GetLockAsync(id, cancellationToken).ConfigureAwait(false);
         // The Lock override doubles as UnlockAndRelock when X-WOPI-OldLock is present, so dispatch
         // by header presence rather than baking a third branch into the switch.
         return wopiOverrideHeader switch
         {
             WopiFileOperations.GetLock => HandleGetLock(existingLock),
             WopiFileOperations.Lock or WopiFileOperations.Put => oldLockIdentifier is null
-                ? await HandleLock(id, newLockIdentifier, existingLock, cancellationToken)
-                : await HandleUnlockAndRelock(id, oldLockIdentifier, newLockIdentifier, existingLock, cancellationToken),
-            WopiFileOperations.Unlock => await HandleUnlock(id, newLockIdentifier, existingLock, cancellationToken),
-            WopiFileOperations.RefreshLock => await HandleRefreshLock(newLockIdentifier, existingLock, cancellationToken),
+                ? await HandleLock(id, newLockIdentifier, existingLock, cancellationToken).ConfigureAwait(false)
+                : await HandleUnlockAndRelock(id, oldLockIdentifier, newLockIdentifier, existingLock, cancellationToken).ConfigureAwait(false),
+            WopiFileOperations.Unlock => await HandleUnlock(id, newLockIdentifier, existingLock, cancellationToken).ConfigureAwait(false),
+            WopiFileOperations.RefreshLock => await HandleRefreshLock(newLockIdentifier, existingLock, cancellationToken).ConfigureAwait(false),
             _ => new NotImplementedResult(),
         };
     }
@@ -793,9 +793,9 @@ public class FilesController(
         }
         if (existingLock is not null)
         {
-            return await LockOrRefresh(newLockIdentifier, existingLock, cancellationToken);
+            return await LockOrRefresh(newLockIdentifier, existingLock, cancellationToken).ConfigureAwait(false);
         }
-        return await lockProvider.AddLockAsync(id, newLockIdentifier, cancellationToken) is not null
+        return await lockProvider.AddLockAsync(id, newLockIdentifier, cancellationToken).ConfigureAwait(false) is not null
             ? Ok()
             : new LockMismatchResult(Response, "Could not create lock");
     }
@@ -826,7 +826,7 @@ public class FilesController(
         // X-WOPI-Lock header on a stale-cache mismatch) but not sufficient — without the CAS, a
         // concurrent UnlockAndRelock from another client between our GetLockAsync and the swap
         // would silently steal the lock.
-        return await lockProvider.TryUnlockAndRelockAsync(id, newLockIdentifier, oldLockIdentifier, cancellationToken)
+        return await lockProvider.TryUnlockAndRelockAsync(id, newLockIdentifier, oldLockIdentifier, cancellationToken).ConfigureAwait(false)
             ? Ok()
             : new LockMismatchResult(Response, existingLock.LockId, reason: "Lock changed concurrently");
     }
@@ -844,7 +844,7 @@ public class FilesController(
             return new LockMismatchResult(Response, existingLock.LockId);
         }
 
-        return await lockProvider.RemoveLockAsync(id, cancellationToken)
+        return await lockProvider.RemoveLockAsync(id, cancellationToken).ConfigureAwait(false)
             ? Ok()
             : new LockMismatchResult(Response, "Could not remove lock");
     }
@@ -859,7 +859,7 @@ public class FilesController(
         {
             return new LockMismatchResult(Response, reason: "Missing new lock identifier");
         }
-        return await LockOrRefresh(newLockIdentifier, existingLock, cancellationToken);
+        return await LockOrRefresh(newLockIdentifier, existingLock, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<IActionResult> LockOrRefresh(string newLock, WopiLockInfo existingLock, CancellationToken cancellationToken)
@@ -871,7 +871,7 @@ public class FilesController(
             return new LockMismatchResult(Response, existingLock.LockId);
         }
         // File is currently locked and the lock ids match, refresh lock (extend the lock timeout)
-        return await lockProvider.RefreshLockAsync(existingLock.FileId, cancellationToken: cancellationToken)
+        return await lockProvider.RefreshLockAsync(existingLock.FileId, cancellationToken: cancellationToken).ConfigureAwait(false)
             ? Ok()
             : new LockMismatchResult(Response, reason: "Could not refresh lock");
     }

--- a/src/WopiHost.Core/Controllers/FoldersController.cs
+++ b/src/WopiHost.Core/Controllers/FoldersController.cs
@@ -45,7 +45,7 @@ public class FoldersController(IWopiStorageProvider storageProvider) : Controlle
     [WopiAuthorize(WopiResourceType.Container, Permission.Read)]
     public async Task<IActionResult> CheckFolderInfo(string id, CancellationToken cancellationToken = default)
     {
-        var folder = await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken);
+        var folder = await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken).ConfigureAwait(false);
         if (folder is null)
         {
             return NotFound();
@@ -59,7 +59,7 @@ public class FoldersController(IWopiStorageProvider storageProvider) : Controlle
         if (options is not null)
         {
             checkFolderInfo = await options.Value.OnCheckFolderInfo(
-                new WopiCheckFolderInfoContext(HttpContext.User, folder, checkFolderInfo));
+                new WopiCheckFolderInfoContext(HttpContext.User, folder, checkFolderInfo)).ConfigureAwait(false);
         }
         return new JsonResult<WopiCheckFolderInfo>(checkFolderInfo);
     }
@@ -85,14 +85,14 @@ public class FoldersController(IWopiStorageProvider storageProvider) : Controlle
         [FromHeader(Name = WopiHeaders.FILE_EXTENSION_FILTER_LIST)] string? fileExtensionFilterList = null,
         CancellationToken cancellationToken = default)
     {
-        if (await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken) is null)
+        if (await storageProvider.GetWopiResource<IWopiFolder>(id, cancellationToken).ConfigureAwait(false) is null)
         {
             return NotFound();
         }
 
         var files = new List<ChildFile>();
         var fileExtensions = fileExtensionFilterList?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        await foreach (var wopiFile in storageProvider.GetWopiFiles(id, cancellationToken: cancellationToken))
+        await foreach (var wopiFile in storageProvider.GetWopiFiles(id, cancellationToken: cancellationToken).ConfigureAwait(false))
         {
             // If included, the host must only return child files whose file extensions match the filter list, based on a case-insensitive match.
             if (fileExtensions?.Length > 0 && !fileExtensions.Contains('.' + wopiFile.Extension, StringComparer.OrdinalIgnoreCase))

--- a/src/WopiHost.Core/Controllers/WopiBootstrapperController.cs
+++ b/src/WopiHost.Core/Controllers/WopiBootstrapperController.cs
@@ -56,7 +56,7 @@ public class WopiBootstrapperController(
         // Direct interface await keeps Infer# happy — see #363; the previous private async
         // helper (BuildBootstrapInfoAsync) became an Infer null-deref FP that no analyzer
         // annotation could suppress. Sync helpers do the request-shape and result-shape work.
-        var ecosystemToken = await accessTokenService.IssueAsync(BuildEcosystemTokenRequest(userId), cancellationToken);
+        var ecosystemToken = await accessTokenService.IssueAsync(BuildEcosystemTokenRequest(userId), cancellationToken).ConfigureAwait(false);
         var bootstrap = BuildBootstrapInfo(userId, ecosystemToken);
         return new JsonResult(new BootstrapRootContainerInfo { Bootstrap = bootstrap });
     }
@@ -73,8 +73,8 @@ public class WopiBootstrapperController(
     {
         return ecosystemOperation switch
         {
-            "GET_ROOT_CONTAINER" => await GetRootContainerAsync(cancellationToken),
-            "GET_NEW_ACCESS_TOKEN" => await GetNewAccessTokenAsync(wopiSrc, cancellationToken),
+            "GET_ROOT_CONTAINER" => await GetRootContainerAsync(cancellationToken).ConfigureAwait(false),
+            "GET_NEW_ACCESS_TOKEN" => await GetNewAccessTokenAsync(wopiSrc, cancellationToken).ConfigureAwait(false),
             _ => new NotImplementedResult(),
         };
     }
@@ -82,16 +82,16 @@ public class WopiBootstrapperController(
     private async Task<IActionResult> GetRootContainerAsync(CancellationToken cancellationToken)
     {
         var userId = GetUserIdOrThrow();
-        var ecosystemToken = await accessTokenService.IssueAsync(BuildEcosystemTokenRequest(userId), cancellationToken);
+        var ecosystemToken = await accessTokenService.IssueAsync(BuildEcosystemTokenRequest(userId), cancellationToken).ConfigureAwait(false);
         var bootstrap = BuildBootstrapInfo(userId, ecosystemToken);
 
-        var rootContainer = await storageProvider.GetWopiResource<IWopiFolder>(storageProvider.RootContainer.Identifier, cancellationToken);
+        var rootContainer = await storageProvider.GetWopiResource<IWopiFolder>(storageProvider.RootContainer.Identifier, cancellationToken).ConfigureAwait(false);
         if (rootContainer is null)
         {
             return NotFound();
         }
 
-        var token = await IssueContainerTokenAsync(rootContainer, cancellationToken);
+        var token = await IssueContainerTokenAsync(rootContainer, cancellationToken).ConfigureAwait(false);
         return new JsonResult(new BootstrapRootContainerInfo
         {
             Bootstrap = bootstrap,
@@ -100,7 +100,7 @@ public class WopiBootstrapperController(
                 ContainerPointer = new ChildContainer(
                     rootContainer.Name,
                     Url.GetWopiSrc(WopiResourceType.Container, rootContainer.Identifier, token.Token)),
-                ContainerInfo = await rootContainer.GetWopiCheckContainerInfo(HttpContext, cancellationToken),
+                ContainerInfo = await rootContainer.GetWopiCheckContainerInfo(HttpContext, cancellationToken).ConfigureAwait(false),
             },
         });
     }
@@ -115,29 +115,29 @@ public class WopiBootstrapperController(
         }
 
         var userId = GetUserIdOrThrow();
-        var ecosystemToken = await accessTokenService.IssueAsync(BuildEcosystemTokenRequest(userId), cancellationToken);
+        var ecosystemToken = await accessTokenService.IssueAsync(BuildEcosystemTokenRequest(userId), cancellationToken).ConfigureAwait(false);
         var bootstrap = BuildBootstrapInfo(userId, ecosystemToken);
         WopiAccessToken token;
 
         if (resourceType == WopiResourceType.File)
         {
-            var file = await storageProvider.GetWopiResource<IWopiFile>(resourceId, cancellationToken);
+            var file = await storageProvider.GetWopiResource<IWopiFile>(resourceId, cancellationToken).ConfigureAwait(false);
             // Spec: "must only provide a WOPI access token if the requested WopiSrc exists
             // and the user is authorized to access it."
             if (file is null)
             {
                 return NotFound();
             }
-            token = await IssueFileTokenAsync(file, cancellationToken);
+            token = await IssueFileTokenAsync(file, cancellationToken).ConfigureAwait(false);
         }
         else
         {
-            var container = await storageProvider.GetWopiResource<IWopiFolder>(resourceId, cancellationToken);
+            var container = await storageProvider.GetWopiResource<IWopiFolder>(resourceId, cancellationToken).ConfigureAwait(false);
             if (container is null)
             {
                 return NotFound();
             }
-            token = await IssueContainerTokenAsync(container, cancellationToken);
+            token = await IssueContainerTokenAsync(container, cancellationToken).ConfigureAwait(false);
         }
 
         return new JsonResult(new BootstrapRootContainerInfo
@@ -188,20 +188,20 @@ public class WopiBootstrapperController(
 
     private async Task<WopiAccessToken> IssueFileTokenAsync(IWopiFile file, CancellationToken cancellationToken)
     {
-        var perms = await permissionProvider.GetFilePermissionsAsync(User, file, cancellationToken);
+        var perms = await permissionProvider.GetFilePermissionsAsync(User, file, cancellationToken).ConfigureAwait(false);
         return await accessTokenService.IssueAsync(BuildRequest(file.Identifier, WopiResourceType.File) with
         {
             FilePermissions = perms,
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<WopiAccessToken> IssueContainerTokenAsync(IWopiFolder container, CancellationToken cancellationToken)
     {
-        var perms = await permissionProvider.GetContainerPermissionsAsync(User, container, cancellationToken);
+        var perms = await permissionProvider.GetContainerPermissionsAsync(User, container, cancellationToken).ConfigureAwait(false);
         return await accessTokenService.IssueAsync(BuildRequest(container.Identifier, WopiResourceType.Container) with
         {
             ContainerPermissions = perms,
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     private WopiAccessTokenRequest BuildRequest(string resourceId, WopiResourceType resourceType) => new()

--- a/src/WopiHost.Core/Extensions/Extensions.cs
+++ b/src/WopiHost.Core/Extensions/Extensions.cs
@@ -17,7 +17,7 @@ internal static class Extensions
     public static async Task<byte[]> ReadBytesAsync(this Stream input, CancellationToken cancellationToken = default)
     {
         using var ms = new MemoryStream();
-        await input.CopyToAsync(ms, cancellationToken);
+        await input.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
         return ms.ToArray();
     }
 
@@ -124,10 +124,10 @@ internal static class Extensions
     /// <returns></returns>
     public static async Task CopyToWriteStream(this HttpContext httpContext, IWopiFile file, CancellationToken cancellationToken = default)
     {
-        using var stream = await file.GetWriteStream(cancellationToken);
+        using var stream = await file.GetWriteStream(cancellationToken).ConfigureAwait(false);
         await httpContext.Request.Body.CopyToAsync(
             stream,
-            cancellationToken);
+            cancellationToken).ConfigureAwait(false);
     }
 
     private static string? ProxyAwareRouteUrl(this IUrlHelper helper,

--- a/src/WopiHost.Core/Extensions/WopiExtensions.cs
+++ b/src/WopiHost.Core/Extensions/WopiExtensions.cs
@@ -35,8 +35,8 @@ public static class WopiExtensions
         var result = file.Checksum;
         if (result is null)
         {
-            using var stream = await file.GetReadStream(cancellationToken);
-            result = await SHA256.HashDataAsync(stream, cancellationToken);
+            using var stream = await file.GetReadStream(cancellationToken).ConfigureAwait(false);
+            result = await SHA256.HashDataAsync(stream, cancellationToken).ConfigureAwait(false);
         }
         return Convert.ToBase64String(result.Value.Span);
     }
@@ -98,7 +98,7 @@ public static class WopiExtensions
 
         var writableStorageProvider = httpContext.RequestServices.GetService<IWopiWritableStorageProvider>();
         checkFileInfo.FileNameMaxLength = writableStorageProvider?.FileNameMaxLength ?? 0;
-        checkFileInfo.Sha256 = await file.GetEncodedSha256(cancellationToken);
+        checkFileInfo.Sha256 = await file.GetEncodedSha256(cancellationToken).ConfigureAwait(false);
 
         if (httpContext.User?.Identity?.IsAuthenticated == true)
         {
@@ -108,7 +108,7 @@ public static class WopiExtensions
             checkFileInfo.UserPrincipalName = httpContext.User.FindFirst(ClaimTypes.Upn)?.Value;
 
             var permissionProvider = httpContext.RequestServices.GetRequiredService<IWopiPermissionProvider>();
-            var permissions = await permissionProvider.GetFilePermissionsAsync(httpContext.User, file, cancellationToken);
+            var permissions = await permissionProvider.GetFilePermissionsAsync(httpContext.User, file, cancellationToken).ConfigureAwait(false);
             checkFileInfo.ReadOnly = permissions.HasFlag(WopiFilePermissions.ReadOnly);
             checkFileInfo.RestrictedWebViewOnly = permissions.HasFlag(WopiFilePermissions.RestrictedWebViewOnly);
             checkFileInfo.UserCanAttend = permissions.HasFlag(WopiFilePermissions.UserCanAttend);
@@ -166,7 +166,7 @@ public static class WopiExtensions
         var wopiHostOptions = httpContext.RequestServices.GetService<IOptions<WopiHostOptions>>();
         if (wopiHostOptions is not null)
         {
-            checkFileInfo = await wopiHostOptions.Value.OnCheckFileInfo(new WopiCheckFileInfoContext(httpContext.User, file, checkFileInfo));
+            checkFileInfo = await wopiHostOptions.Value.OnCheckFileInfo(new WopiCheckFileInfoContext(httpContext.User, file, checkFileInfo)).ConfigureAwait(false);
         }
 
         return checkFileInfo;
@@ -188,7 +188,7 @@ public static class WopiExtensions
         ArgumentNullException.ThrowIfNull(httpContext);
 
         var permissionProvider = httpContext.RequestServices.GetRequiredService<IWopiPermissionProvider>();
-        var permissions = await permissionProvider.GetContainerPermissionsAsync(httpContext.User, container, cancellationToken);
+        var permissions = await permissionProvider.GetContainerPermissionsAsync(httpContext.User, container, cancellationToken).ConfigureAwait(false);
 
         var checkContainerInfo = new WopiCheckContainerInfo()
         {
@@ -204,7 +204,7 @@ public static class WopiExtensions
         var wopiHostOptions = httpContext.RequestServices.GetService<IOptions<WopiHostOptions>>();
         if (wopiHostOptions is not null)
         {
-            checkContainerInfo = await wopiHostOptions.Value.OnCheckContainerInfo(new WopiCheckContainerInfoContext(httpContext.User, container, checkContainerInfo));
+            checkContainerInfo = await wopiHostOptions.Value.OnCheckContainerInfo(new WopiCheckContainerInfoContext(httpContext.User, container, checkContainerInfo)).ConfigureAwait(false);
         }
 
         return checkContainerInfo;

--- a/src/WopiHost.Core/Infrastructure/FromStringBodyModelBinder.cs
+++ b/src/WopiHost.Core/Infrastructure/FromStringBodyModelBinder.cs
@@ -26,7 +26,7 @@ public sealed class FromStringBodyModelBinder : IModelBinder
             {
                 request.Body.Position = 0;
                 using var reader = new StreamReader(request.Body);
-                body = await reader.ReadToEndAsync();
+                body = await reader.ReadToEndAsync().ConfigureAwait(false);
                 request.Body.Position = 0;
             }
 

--- a/src/WopiHost.Core/Results/FileResult.cs
+++ b/src/WopiHost.Core/Results/FileResult.cs
@@ -57,7 +57,7 @@ public class FileResult : ActionResult
         var targetStream = response.Body;
         if (Content is not null)
         {
-            await targetStream.WriteAsync(Content.AsMemory(0, Content.Length), ct);
+            await targetStream.WriteAsync(Content.AsMemory(0, Content.Length), ct).ConfigureAwait(false);
         }
         else
         {
@@ -68,7 +68,7 @@ public class FileResult : ActionResult
                 {
                     SourceStream.Seek(0, SeekOrigin.Begin);
                 }
-                await SourceStream.CopyToAsync(targetStream, ct);
+                await SourceStream.CopyToAsync(targetStream, ct).ConfigureAwait(false);
             }
         }
     }

--- a/src/WopiHost.Core/Security/Authentication/AccessTokenHandler.cs
+++ b/src/WopiHost.Core/Security/Authentication/AccessTokenHandler.cs
@@ -37,7 +37,7 @@ public partial class AccessTokenHandler(
             return AuthenticateResult.Fail("Access token missing.");
         }
 
-        var validation = await accessTokenService.ValidateAsync(token, Context.RequestAborted);
+        var validation = await accessTokenService.ValidateAsync(token, Context.RequestAborted).ConfigureAwait(false);
         if (!validation.IsValid || validation.Principal is null)
         {
             LogTokenValidationFailed(Logger, validation.FailureReason);

--- a/src/WopiHost.Core/Security/Authentication/WopiOriginValidationActionFilter.cs
+++ b/src/WopiHost.Core/Security/Authentication/WopiOriginValidationActionFilter.cs
@@ -39,7 +39,7 @@ public partial class WopiOriginValidationActionFilter(IWopiProofValidator proofV
             return;
         }
 
-        var validated = await proofValidator.ValidateProofAsync(context.HttpContext, accessToken);
+        var validated = await proofValidator.ValidateProofAsync(context.HttpContext, accessToken).ConfigureAwait(false);
         if (!validated)
         {
             LogProofRejected(logger);
@@ -49,6 +49,6 @@ public partial class WopiOriginValidationActionFilter(IWopiProofValidator proofV
             return;
         }
 
-        await next();
+        await next().ConfigureAwait(false);
     }
 }

--- a/src/WopiHost.Core/Security/Authentication/WopiProofValidator.cs
+++ b/src/WopiHost.Core/Security/Authentication/WopiProofValidator.cs
@@ -55,7 +55,7 @@ public partial class WopiProofValidator(IDiscoverer discoverer, ILogger<WopiProo
                 return false;
             }
 
-            var sourceProofKeys = await discoverer.GetProofKeysAsync();
+            var sourceProofKeys = await discoverer.GetProofKeysAsync().ConfigureAwait(false);
 
             // Per WOPI spec: X-WOPI-TimeStamp is .NET DateTime.Ticks (UTC).
             // Reject stale timestamps; allow a small future skew.

--- a/src/WopiHost.Discovery/HttpDiscoveryFileProvider.cs
+++ b/src/WopiHost.Discovery/HttpDiscoveryFileProvider.cs
@@ -23,7 +23,7 @@ public partial class HttpDiscoveryFileProvider(HttpClient httpClient, ILogger<Ht
         var sw = Stopwatch.StartNew();
         try
         {
-            var stream = await _httpClient.GetStreamAsync(new Uri("/hosting/discovery", UriKind.Relative));
+            var stream = await _httpClient.GetStreamAsync(new Uri("/hosting/discovery", UriKind.Relative)).ConfigureAwait(false);
             var xml = XElement.Load(stream);
             LogDiscoveryFetched(_logger, _httpClient.BaseAddress, sw.ElapsedMilliseconds);
             return xml;

--- a/src/WopiHost.Discovery/WopiDiscoverer.cs
+++ b/src/WopiHost.Discovery/WopiDiscoverer.cs
@@ -58,7 +58,7 @@ public partial class WopiDiscoverer : IDiscoverer, IDisposable
 
         _apps = new AsyncExpiringLazy<IEnumerable<XElement>>(async _ =>
         {
-            var apps = (await discoveryFileProvider.GetDiscoveryXmlAsync())
+            var apps = (await discoveryFileProvider.GetDiscoveryXmlAsync().ConfigureAwait(false))
                 .Elements(ElementNetZone)
                 .Where(ValidateNetZone)
                 .Elements(ElementApp)
@@ -73,7 +73,7 @@ public partial class WopiDiscoverer : IDiscoverer, IDisposable
 
         _proofKey = new AsyncExpiringLazy<XElement>(async _ =>
         {
-            var proofKey = (await discoveryFileProvider.GetDiscoveryXmlAsync())
+            var proofKey = (await discoveryFileProvider.GetDiscoveryXmlAsync().ConfigureAwait(false))
                 .Elements(ElementProofKey)
                 .FirstOrDefault() ?? new XElement(ElementProofKey);
             LogProofKeyRefreshed(_logger);
@@ -85,9 +85,9 @@ public partial class WopiDiscoverer : IDiscoverer, IDisposable
         });
     }
 
-    internal async Task<IEnumerable<XElement>> GetAppsAsync() => await _apps.Value();
+    internal async Task<IEnumerable<XElement>> GetAppsAsync() => await _apps.Value().ConfigureAwait(false);
 
-    internal async Task<XElement> GetProofKeyAsync() => await _proofKey.Value();
+    internal async Task<XElement> GetProofKeyAsync() => await _proofKey.Value().ConfigureAwait(false);
 
     private bool ValidateNetZone(XElement e)
     {
@@ -104,7 +104,7 @@ public partial class WopiDiscoverer : IDiscoverer, IDisposable
     ///<inheritdoc />
     public async Task<bool> SupportsExtensionAsync(string extension)
     {
-        var query = (await GetAppsAsync()).Elements()
+        var query = (await GetAppsAsync().ConfigureAwait(false)).Elements()
             .FirstOrDefault(e => string.Equals(e.Attribute(AttrActionExtension)?.Value, extension, StringComparison.OrdinalIgnoreCase));
         return query is not null;
     }
@@ -114,8 +114,8 @@ public partial class WopiDiscoverer : IDiscoverer, IDisposable
     {
         var actionString = action.ToString().ToUpperInvariant();
 
-        var query = (await GetAppsAsync()).Elements()
-            .Where(e => string.Equals(e.Attribute(AttrActionExtension)?.Value, extension, StringComparison.OrdinalIgnoreCase) && 
+        var query = (await GetAppsAsync().ConfigureAwait(false)).Elements()
+            .Where(e => string.Equals(e.Attribute(AttrActionExtension)?.Value, extension, StringComparison.OrdinalIgnoreCase) &&
                 e.Attribute(AttrActionName)?.Value.Equals(actionString, StringComparison.InvariantCultureIgnoreCase) == true);
 
         return query.Any();
@@ -126,7 +126,7 @@ public partial class WopiDiscoverer : IDiscoverer, IDisposable
     {
         var actionString = action.ToString().ToUpperInvariant();
 
-        var query = (await GetAppsAsync()).Elements()
+        var query = (await GetAppsAsync().ConfigureAwait(false)).Elements()
             .Where(e => string.Equals(e.Attribute(AttrActionExtension)?.Value, extension, StringComparison.OrdinalIgnoreCase) &&
                 e.Attribute(AttrActionName)?.Value.Equals(actionString, StringComparison.InvariantCultureIgnoreCase) == true)
             .Select(e => e.Attribute(AttrActionRequires)?.Value.Split(','));
@@ -138,8 +138,8 @@ public partial class WopiDiscoverer : IDiscoverer, IDisposable
     public async Task<string?> GetUrlTemplateAsync(string extension, WopiActionEnum action)
     {
         var actionString = action.ToString().ToUpperInvariant();
-        var query = (await GetAppsAsync()).Elements()
-            .Where(e => string.Equals(e.Attribute(AttrActionExtension)?.Value, extension, StringComparison.OrdinalIgnoreCase) && 
+        var query = (await GetAppsAsync().ConfigureAwait(false)).Elements()
+            .Where(e => string.Equals(e.Attribute(AttrActionExtension)?.Value, extension, StringComparison.OrdinalIgnoreCase) &&
                 e.Attribute(AttrActionName)?.Value.Equals(actionString, StringComparison.InvariantCultureIgnoreCase) == true)
             .Select(e => e.Attribute(AttrActionUrl)?.Value);
         return query.FirstOrDefault();
@@ -148,7 +148,7 @@ public partial class WopiDiscoverer : IDiscoverer, IDisposable
     ///<inheritdoc />
     public async Task<string?> GetApplicationNameAsync(string extension)
     {
-        var query = (await GetAppsAsync())
+        var query = (await GetAppsAsync().ConfigureAwait(false))
             .Where(e => e.Descendants(ElementAction).Any(d => string.Equals(d.Attribute(AttrActionExtension)?.Value, extension, StringComparison.OrdinalIgnoreCase)))
             .Select(e => e.Attribute(AttrAppName)?.Value);
 
@@ -158,17 +158,17 @@ public partial class WopiDiscoverer : IDiscoverer, IDisposable
     ///<inheritdoc />
     public async Task<Uri?> GetApplicationFavIconAsync(string extension)
     {
-        var query = (await GetAppsAsync())
+        var query = (await GetAppsAsync().ConfigureAwait(false))
             .Where(e => e.Descendants(ElementAction).Any(d => string.Equals(d.Attribute(AttrActionExtension)?.Value, extension, StringComparison.OrdinalIgnoreCase)))
             .Select(e => e.Attribute(AttrAppFavicon)?.Value);
         var result = query.FirstOrDefault();
         return result is not null ? new Uri(result) : null;
     }
-    
+
     ///<inheritdoc />
     public async Task<WopiProofKeys> GetProofKeysAsync()
     {
-        var proofKey = await GetProofKeyAsync();
+        var proofKey = await GetProofKeyAsync().ConfigureAwait(false);
 
         return new WopiProofKeys
         {

--- a/src/WopiHost.FileSystemProvider/WopiFileSystemProvider.cs
+++ b/src/WopiHost.FileSystemProvider/WopiFileSystemProvider.cs
@@ -86,7 +86,7 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
             var filePath = Path.Combine(folderPath, Path.GetFileName(path));
             if (fileIds.TryGetFileId(filePath, out var fileId))
             {
-                var result = await GetWopiResource<IWopiFile>(fileId, cancellationToken)
+                var result = await GetWopiResource<IWopiFile>(fileId, cancellationToken).ConfigureAwait(false)
                     ?? throw new FileNotFoundException($"File '{fileId}' not found");
                 yield return result;
             }
@@ -106,12 +106,12 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         {
             if (fileIds.TryGetFileId(directory, out var folderId))
             {
-                var result = await GetWopiResource<IWopiFolder>(folderId, cancellationToken)
+                var result = await GetWopiResource<IWopiFolder>(folderId, cancellationToken).ConfigureAwait(false)
                     ?? throw new DirectoryNotFoundException($"Directory '{folderId}' not found");
                 yield return result;
             }
         }
-        await Task.CompletedTask;
+        await Task.CompletedTask.ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -124,7 +124,7 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         {
             identifier = GetFileParentIdentifier(identifier);
         }
-        var container = await GetWopiResource<IWopiFolder>(identifier, cancellationToken)
+        var container = await GetWopiResource<IWopiFolder>(identifier, cancellationToken).ConfigureAwait(false)
             ?? throw new DirectoryNotFoundException($"Directory '{identifier}' not found.");
         if (typeof(T) == typeof(IWopiFile))
         {
@@ -136,7 +136,7 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         while (container.Identifier != RootContainer.Identifier)
         {
             var parentId = GetFolderParentIdentifier(container.Identifier);
-            container = await GetWopiResource<IWopiFolder>(parentId, cancellationToken)
+            container = await GetWopiResource<IWopiFolder>(parentId, cancellationToken).ConfigureAwait(false)
                 ?? throw new DirectoryNotFoundException($"Directory '{parentId}' not found.");
             result.Add(container);
         }
@@ -161,8 +161,8 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
 
         T? result = typeof(T) switch
         {
-            { } wopiFileType when typeof(IWopiFile).IsAssignableFrom(wopiFileType) => await GetWopiResource<IWopiFile>(nameId, cancellationToken) as T,
-            { } wopiFolderType when typeof(IWopiFolder).IsAssignableFrom(wopiFolderType) => await GetWopiResource<IWopiFolder>(nameId, cancellationToken) as T,
+            { } wopiFileType when typeof(IWopiFile).IsAssignableFrom(wopiFileType) => await GetWopiResource<IWopiFile>(nameId, cancellationToken).ConfigureAwait(false) as T,
+            { } wopiFolderType when typeof(IWopiFolder).IsAssignableFrom(wopiFolderType) => await GetWopiResource<IWopiFolder>(nameId, cancellationToken).ConfigureAwait(false) as T,
             _ => throw new NotSupportedException("Unsupported resource type.")
         };
         return result;
@@ -194,7 +194,7 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         CancellationToken cancellationToken = default)
         where T : class, IWopiResource
     {
-        if (!await CheckValidName<T>(name, cancellationToken))
+        if (!await CheckValidName<T>(name, cancellationToken).ConfigureAwait(false))
         {
             throw new ArgumentException(message: "Invalid characters in the name.", paramName: nameof(name));
         }
@@ -255,8 +255,8 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         ArgumentNullException.ThrowIfNull(containerId);
         return typeof(T) switch
         {
-            { } wopiFileType when typeof(IWopiFile).IsAssignableFrom(wopiFileType) => await CreateWopiFile(containerId, name, cancellationToken) as T,
-            { } wopiFolderType when typeof(IWopiFolder).IsAssignableFrom(wopiFolderType) => await CreateWopiChildContainer(containerId, name, cancellationToken) as T,
+            { } wopiFileType when typeof(IWopiFile).IsAssignableFrom(wopiFileType) => await CreateWopiFile(containerId, name, cancellationToken).ConfigureAwait(false) as T,
+            { } wopiFolderType when typeof(IWopiFolder).IsAssignableFrom(wopiFolderType) => await CreateWopiChildContainer(containerId, name, cancellationToken).ConfigureAwait(false) as T,
             _ => throw new NotSupportedException("Unsupported resource type.")
         };
     }
@@ -365,7 +365,7 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
     public async Task<bool> RenameWopiResource<T>(string identifier, string requestedName, CancellationToken cancellationToken = default)
         where T : class, IWopiResource
     {
-        if (!await CheckValidName<T>(requestedName, cancellationToken))
+        if (!await CheckValidName<T>(requestedName, cancellationToken).ConfigureAwait(false))
         {
             throw new ArgumentException(message: "Invalid characters in the name.", paramName: nameof(requestedName));
         }

--- a/src/WopiHost.Url/WopiUrlBuilder.cs
+++ b/src/WopiHost.Url/WopiUrlBuilder.cs
@@ -62,7 +62,7 @@ public partial class WopiUrlBuilder(
         // values in the same URL.
         combinedUrlSettings[WopiUrlSettings.Placeholders.WopiSource] = wopiFileUrl.ToString();
 
-        var template = await _wopiDiscoverer.GetUrlTemplateAsync(extension, action);
+        var template = await _wopiDiscoverer.GetUrlTemplateAsync(extension, action).ConfigureAwait(false);
         if (string.IsNullOrEmpty(template))
         {
             LogTemplateNotFound(_logger, extension, action);


### PR DESCRIPTION
Addresses **3.6** from the architectural review in #369.

## The drift

`ConfigureAwait(false)` coverage across the NuGet-shipped libraries was wildly inconsistent before this PR:

| Library | awaits | with ConfigureAwait | coverage |
|---|---|---|---|
| WopiHost.Abstractions | 0 | 0 | n/a (interfaces only) |
| WopiHost.AzureLockProvider | 28 | 28 | **100%** ✅ |
| WopiHost.AzureStorageProvider | 44 | 43 | 98% |
| WopiHost.Cobalt | 7 | 6 | 86% |
| **WopiHost.Core** | 135 | 11 | **8%** ❌ |
| WopiHost.Discovery | 17 | 5 | 29% |
| **WopiHost.FileSystemProvider** | 11 | 0 | **0%** ❌ |
| WopiHost.MemoryLockProvider | 1 | 1 | 100% ✅ |
| WopiHost.Url | 1 | 0 | 0% |

## Root cause

The repo-level `.editorconfig` was disabling the analyzer that would have caught every drift:

```
# CA2007: Consider calling ConfigureAwait on the awaited task
dotnet_diagnostic.CA2007.severity = none
```

That blanket disable was correct for tests, samples, and infra — none of them ship as packages, and ASP.NET Core has no `SynchronizationContext` to worry about — but it also masked the rule under `src/`, where library guidance does require `.ConfigureAwait(false)` on every awaited Task because consumers may host the assembly under a SyncContext-bearing framework (Windows Forms, WPF, Blazor Server, a custom test harness with `AsyncContext`, etc.).

## The fix, in two parts

### 1. Enforce going forward

A new `src/.editorconfig` re-enables CA2007 at `warning` severity, scoped to library code only:

```ini
[*.cs]
dotnet_diagnostic.CA2007.severity = warning
```

`.editorconfig` cascades by directory, so the repo-level `severity = none` still applies under `sample/`, `test/`, and `infra/`. Combined with the repo's `TreatWarningsAsErrors=true`, **a missing `.ConfigureAwait(false)` in library code is now a build error**. Drift becomes structurally impossible without an explicit per-call suppression.

### 2. Backfill what's there now

124 missing call sites across 13 files. Applied via `dotnet format analyzers --diagnostics CA2007 --severity warn`, so insertions are produced by the analyzer's own code-fix provider — handles chained expressions, `await` inside switch expressions, `await` inside collection initializers, etc., without me hand-rolling regex.

Files touched:

```
src/WopiHost.Core/Controllers/{ContainersController,EcosystemController,
    FilesController,FoldersController,WopiBootstrapperController}.cs
src/WopiHost.Core/Extensions/{Extensions,WopiExtensions}.cs
src/WopiHost.Core/Infrastructure/FromStringBodyModelBinder.cs
src/WopiHost.Core/Results/FileResult.cs
src/WopiHost.Core/Security/Authentication/{AccessTokenHandler,
    WopiOriginValidationActionFilter,WopiProofValidator}.cs
src/WopiHost.Discovery/{HttpDiscoveryFileProvider,WopiDiscoverer}.cs
src/WopiHost.FileSystemProvider/WopiFileSystemProvider.cs
src/WopiHost.Url/WopiUrlBuilder.cs
```

## Why not the alternatives I considered

- **Hand-roll sed over every `await`**: brittle on chained calls, `await using`, switch expressions, ternaries; the analyzer-driven fix is unambiguously safe.
- **Per-project `<NoWarn>CA2007</NoWarn>` removal**: would have to touch 9 `.csproj` files and is invisible to anyone reading `.editorconfig` first. `src/.editorconfig` is co-located with the policy comment explaining *why*.
- **Set CA2007 = error directly**: same effect at this repo (`TreatWarningsAsErrors=true`) and one fewer place for a future maintainer to forget. Kept `warning` for portability if anyone ever turns `TreatWarningsAsErrors` off; the build is still strict because of the repo-wide setting.

## What I didn't change

- **No behavior change.** Every existing `await` got the same continuation semantic explicitly that it had implicitly under the test/sample hosts that already had no SyncContext. Production behavior is identical.
- **Sample/test/infra projects untouched.** The repo-level `.editorconfig` still suppresses CA2007 there. Adding `.ConfigureAwait(false)` to test code is noise — the test runner has no SyncContext and never will.
- **Repo-level `.editorconfig` line 3–4 left in place.** Removing it would force every sample/test file to also adopt the convention; that's a separate (and unnecessary) churn.

## Test plan

- [x] `dotnet build WOPI.slnx` — `0 Warning(s) 0 Error(s)` across all TFMs under `TreatWarningsAsErrors=true` + new `CA2007 = warning`.
- [x] `dotnet test WOPI.slnx` — full suite green: Core 362, FileSystemProvider 93, AzureStorageProvider 97, AzureLockProvider 33, MemoryLockProvider 17, Discovery 80, Cobalt 64, Url 11, IntegrationTests 25, SmokeTests 5. ×3 TFMs where applicable.

Same env-only `WopiHost.Core.Tests (net8.0)` abort on the dev box that's been there since the ASP.NET 8.0.0 runtime stopped shipping locally — passes everywhere else.

Part of #369 — addresses 3.6. The tracker stays open for the remaining items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


