### PR TITLE
Replace searchPattern glob with WOPI extension-list filter (#369 3.5)

### DIFF
--- a/src/WopiHost.Abstractions/IWopiStorageProvider.cs
+++ b/src/WopiHost.Abstractions/IWopiStorageProvider.cs
@@ -17,13 +17,29 @@ public interface IWopiStorageProvider
         where T : class, IWopiResource;
 
     /// <summary>
-    /// Returns all files contained by the container identified by <paramref name="identifier"/>.
-    /// Pass <c><see cref="RootContainer"/>.Identifier</c> to enumerate the root.
+    /// Returns the files contained by the container identified by <paramref name="identifier"/>,
+    /// optionally filtered by file extension. Pass <c><see cref="RootContainer"/>.Identifier</c>
+    /// to enumerate the root.
     /// </summary>
     /// <param name="identifier">Container identifier. Required.</param>
-    /// <param name="searchPattern">search pattern for files</param>
+    /// <param name="fileExtensions">
+    /// Optional list of file extensions to include in the result. Each element must be a
+    /// leading-dot extension (<c>".docx"</c>, not <c>"docx"</c>); matching is case-insensitive,
+    /// per the WOPI <c>X-WOPI-FileExtensionFilterList</c> spec. When <see langword="null"/> or
+    /// empty, every file in the container is returned. Wildcard characters in the elements
+    /// are matched literally — the parameter is not a glob.
+    /// </param>
     /// <param name="cancellationToken">cancellation token</param>
-    IAsyncEnumerable<IWopiFile> GetWopiFiles(string identifier, string? searchPattern = null, CancellationToken cancellationToken = default);
+    /// <remarks>
+    /// Implementations are expected to push filtering as close to the underlying storage as
+    /// the backend allows: the filesystem provider uses <c>Directory.EnumerateFiles</c> with a
+    /// per-extension glob so the OS handles selection; the Azure-blob provider filters each
+    /// item at the streaming-list boundary as items arrive from <c>GetBlobsByHierarchyAsync</c>,
+    /// since the Blob list API exposes only a prefix filter at the wire level. Callers should
+    /// not post-filter the returned <see cref="IAsyncEnumerable{T}"/> by extension — the
+    /// provider has already done it.
+    /// </remarks>
+    IAsyncEnumerable<IWopiFile> GetWopiFiles(string identifier, IReadOnlyCollection<string>? fileExtensions = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns all containers contained by the container identified by <paramref name="identifier"/>.

--- a/src/WopiHost.AzureStorageProvider/WopiAzureStorageProvider.cs
+++ b/src/WopiHost.AzureStorageProvider/WopiAzureStorageProvider.cs
@@ -1,7 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Runtime.CompilerServices;
-using System.Text.RegularExpressions;
 using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
@@ -107,7 +106,7 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
     /// <inheritdoc/>
     public async IAsyncEnumerable<IWopiFile> GetWopiFiles(
         string identifier,
-        string? searchPattern = null,
+        IReadOnlyCollection<string>? fileExtensions = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(identifier);
@@ -115,7 +114,14 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
         var folderPath = ResolveFolderPath(identifier);
         var prefix = string.IsNullOrEmpty(folderPath) ? null : folderPath + "/";
 
-        var matcher = BuildSearchMatcher(searchPattern);
+        // Azure Blob Storage's list API exposes only a prefix filter at the wire level — no
+        // suffix / extension / regex support — so the extension filter is applied at the
+        // streaming-list boundary inside the loop. Each non-matching blob is dropped before
+        // we allocate a WopiBlobFile for it. The hashset (OrdinalIgnoreCase) gives us O(1)
+        // membership checks regardless of how many extensions the caller asked for.
+        var extensionFilter = (fileExtensions is { Count: > 0 })
+            ? new HashSet<string>(fileExtensions, StringComparer.OrdinalIgnoreCase)
+            : null;
 
         await foreach (var item in containerClient.GetBlobsByHierarchyAsync(traits: BlobTraits.None, states: BlobStates.None, delimiter: "/", prefix: prefix, cancellationToken: cancellationToken).ConfigureAwait(false))
         {
@@ -131,7 +137,7 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
                 continue;
             }
             var fileName = name[(name.LastIndexOf('/') + 1)..];
-            if (matcher is not null && !matcher(fileName))
+            if (extensionFilter is not null && !extensionFilter.Contains(Path.GetExtension(fileName)))
             {
                 continue;
             }
@@ -491,17 +497,5 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
         var stem = name[..dot];
         var ext = name[dot..];
         return $"{stem} ({counter.ToString(CultureInfo.InvariantCulture)}){ext}";
-    }
-
-    private static Func<string, bool>? BuildSearchMatcher(string? searchPattern)
-    {
-        if (string.IsNullOrEmpty(searchPattern) || searchPattern == "*" || searchPattern == "*.*")
-        {
-            return null;
-        }
-        // Translate the simple glob (FileSystemProvider semantics) into a regex anchored to full names.
-        var escaped = Regex.Escape(searchPattern).Replace("\\*", ".*").Replace("\\?", ".");
-        var regex = new Regex("^" + escaped + "$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-        return name => regex.IsMatch(name);
     }
 }

--- a/src/WopiHost.Core/Controllers/ContainersController.cs
+++ b/src/WopiHost.Core/Controllers/ContainersController.cs
@@ -468,14 +468,12 @@ public class ContainersController(
 
         var files = new List<ChildFile>();
         var containers = new List<ChildContainer>();
+        // Parse the WOPI wire format once and hand the typed list to the provider, which is
+        // responsible for filtering at (or as close as possible to) the storage layer. See
+        // IWopiStorageProvider.GetWopiFiles for the contract on extension matching.
         var fileExtensions = fileExtensionFilterList?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        await foreach (var wopiFile in storageProvider.GetWopiFiles(id, cancellationToken: cancellationToken).ConfigureAwait(false))
+        await foreach (var wopiFile in storageProvider.GetWopiFiles(id, fileExtensions, cancellationToken).ConfigureAwait(false))
         {
-            // If included, the host must only return child files whose file extensions match the filter list, based on a case-insensitive match.
-            if (fileExtensions?.Length > 0 && !fileExtensions.Contains('.' + wopiFile.Extension, StringComparer.OrdinalIgnoreCase))
-            {
-                continue;
-            }
             files.Add(new ChildFile(wopiFile.Name + '.' + wopiFile.Extension, Url.GetWopiSrc(WopiResourceType.File, wopiFile.Identifier))
             {
                 LastModifiedTime = wopiFile.LastWriteTimeUtc.ToString("o", CultureInfo.InvariantCulture),

--- a/src/WopiHost.Core/Controllers/FoldersController.cs
+++ b/src/WopiHost.Core/Controllers/FoldersController.cs
@@ -91,14 +91,12 @@ public class FoldersController(IWopiStorageProvider storageProvider) : Controlle
         }
 
         var files = new List<ChildFile>();
+        // Parse the WOPI wire format once and hand the typed list to the provider, which is
+        // responsible for filtering at (or as close as possible to) the storage layer. See
+        // IWopiStorageProvider.GetWopiFiles for the contract on extension matching.
         var fileExtensions = fileExtensionFilterList?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        await foreach (var wopiFile in storageProvider.GetWopiFiles(id, cancellationToken: cancellationToken).ConfigureAwait(false))
+        await foreach (var wopiFile in storageProvider.GetWopiFiles(id, fileExtensions, cancellationToken).ConfigureAwait(false))
         {
-            // If included, the host must only return child files whose file extensions match the filter list, based on a case-insensitive match.
-            if (fileExtensions?.Length > 0 && !fileExtensions.Contains('.' + wopiFile.Extension, StringComparer.OrdinalIgnoreCase))
-            {
-                continue;
-            }
             files.Add(new ChildFile(wopiFile.Name + '.' + wopiFile.Extension, Url.GetWopiSrc(WopiResourceType.File, wopiFile.Identifier))
             {
                 LastModifiedTime = wopiFile.LastWriteTimeUtc.ToString("o", CultureInfo.InvariantCulture),

--- a/src/WopiHost.FileSystemProvider/WopiFileSystemProvider.cs
+++ b/src/WopiHost.FileSystemProvider/WopiFileSystemProvider.cs
@@ -74,14 +74,29 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
     /// <inheritdoc/>
     public async IAsyncEnumerable<IWopiFile> GetWopiFiles(
         string identifier,
-        string? searchPattern = null,
+        IReadOnlyCollection<string>? fileExtensions = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(identifier);
         var folderPath = fileIds.GetPath(identifier)
             ?? throw new DirectoryNotFoundException($"Directory '{identifier}' not found");
 
-        foreach (var path in Directory.GetFiles(Path.Combine(wopiAbsolutePath, folderPath), searchPattern ?? "*.*"))
+        var absolutePath = Path.Combine(wopiAbsolutePath, folderPath);
+
+        // Push the extension filter into the OS-level enumeration: one Directory.EnumerateFiles
+        // call per requested extension, each with its own glob. Distinct extensions produce
+        // disjoint result sets so no dedup is needed when we concatenate. With no filter, fall
+        // back to a single unfiltered enumeration.
+        //
+        // MatchCasing.CaseInsensitive is explicit because the EnumerationOptions default is
+        // PlatformDefault, which means case-sensitive matching on Linux. WOPI requires
+        // case-insensitive extension matching, so we force it here regardless of host OS.
+        var options = new EnumerationOptions { MatchCasing = MatchCasing.CaseInsensitive };
+        var enumeration = (fileExtensions is { Count: > 0 })
+            ? fileExtensions.SelectMany(ext => Directory.EnumerateFiles(absolutePath, "*" + ext, options))
+            : Directory.EnumerateFiles(absolutePath, "*", options);
+
+        foreach (var path in enumeration)
         {
             var filePath = Path.Combine(folderPath, Path.GetFileName(path));
             if (fileIds.TryGetFileId(filePath, out var fileId))

--- a/test/WopiHost.AzureStorageProvider.Tests/WopiAzureStorageProviderEdgeCaseTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/WopiAzureStorageProviderEdgeCaseTests.cs
@@ -122,7 +122,7 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
     }
 
     [Fact]
-    public async Task GetWopiFiles_SearchPattern_FiltersByExtension()
+    public async Task GetWopiFiles_SingleExtensionFilter_FiltersByExtension()
     {
         var (provider, container) = await CreateProviderAsync();
         await UploadAsync(container, "doc.docx");
@@ -130,7 +130,7 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
         await UploadAsync(container, "notes.txt");
 
         var matched = new List<string>();
-        await foreach (var f in provider.GetWopiFiles(provider.RootContainer.Identifier, searchPattern: "*.docx"))
+        await foreach (var f in provider.GetWopiFiles(provider.RootContainer.Identifier, new[] { ".docx" }))
         {
             matched.Add(f.Name + "." + f.Extension);
         }
@@ -140,41 +140,80 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
     }
 
     [Fact]
-    public async Task GetWopiFiles_SearchPattern_QuestionMarkWildcard()
+    public async Task GetWopiFiles_MultipleExtensionFilter_ReturnsUnion()
     {
         var (provider, container) = await CreateProviderAsync();
-        await UploadAsync(container, "a.txt");
-        await UploadAsync(container, "ab.txt");
+        await UploadAsync(container, "doc.docx");
+        await UploadAsync(container, "sheet.xlsx");
+        await UploadAsync(container, "notes.txt");
 
         var matched = new List<string>();
-        // "?.txt" → exactly one char before .txt
-        await foreach (var f in provider.GetWopiFiles(provider.RootContainer.Identifier, searchPattern: "?.txt"))
+        await foreach (var f in provider.GetWopiFiles(provider.RootContainer.Identifier, new[] { ".docx", ".txt" }))
+        {
+            matched.Add(f.Name + "." + f.Extension);
+        }
+
+        Assert.Equal(2, matched.Count);
+        Assert.Contains("doc.docx", matched);
+        Assert.Contains("notes.txt", matched);
+    }
+
+    [Fact]
+    public async Task GetWopiFiles_ExtensionFilter_IsCaseInsensitive()
+    {
+        var (provider, container) = await CreateProviderAsync();
+        await UploadAsync(container, "doc.DOCX");
+        await UploadAsync(container, "notes.txt");
+
+        var matched = new List<string>();
+        await foreach (var f in provider.GetWopiFiles(provider.RootContainer.Identifier, new[] { ".docx" }))
         {
             matched.Add(f.Name + "." + f.Extension);
         }
 
         Assert.Single(matched);
-        Assert.Equal("a.txt", matched[0]);
     }
 
-    [Theory]
-    [InlineData("*")]
-    [InlineData("*.*")]
-    [InlineData(null)]
-    [InlineData("")]
-    public async Task GetWopiFiles_NoPatternOrWildcard_ReturnsEverything(string? pattern)
+    [Fact]
+    public async Task GetWopiFiles_ExtensionFilter_WildcardCharactersMatchedLiterally()
+    {
+        // WOPI spec forbids wildcards in the filter list. The provider treats any glob-looking
+        // character as a literal — passing "*.docx" matches only a file named literally "*.docx"
+        // (which Azure won't let us upload anyway), so the result is empty. This pin guards
+        // against anyone reintroducing a regex/glob translator on the assumption that the old
+        // semantic is still in effect.
+        var (provider, container) = await CreateProviderAsync();
+        await UploadAsync(container, "doc.docx");
+
+        var matched = new List<string>();
+        await foreach (var f in provider.GetWopiFiles(provider.RootContainer.Identifier, new[] { "*.docx" }))
+        {
+            matched.Add(f.Name + "." + f.Extension);
+        }
+
+        Assert.Empty(matched);
+    }
+
+    [Fact]
+    public async Task GetWopiFiles_NullOrEmptyExtensionFilter_ReturnsEverything()
     {
         var (provider, container) = await CreateProviderAsync();
         await UploadAsync(container, "a.txt");
         await UploadAsync(container, "b.docx");
 
-        var count = 0;
-        await foreach (var _ in provider.GetWopiFiles(provider.RootContainer.Identifier, pattern))
+        var nullCount = 0;
+        await foreach (var _ in provider.GetWopiFiles(provider.RootContainer.Identifier, fileExtensions: null))
         {
-            count++;
+            nullCount++;
+        }
+        var emptyCount = 0;
+        await foreach (var _ in provider.GetWopiFiles(provider.RootContainer.Identifier, Array.Empty<string>()))
+        {
+            emptyCount++;
         }
 
-        Assert.Equal(2, count);
+        Assert.Equal(2, nullCount);
+        Assert.Equal(2, emptyCount);
     }
 
     [Fact]

--- a/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
@@ -594,8 +594,14 @@ public class ContainersControllerTests
     }
 
     [Fact]
-    public async Task EnumerateChildren_FiltersFilesByExtension()
+    public async Task EnumerateChildren_ForwardsExtensionFilterToProvider()
     {
+        // The controller's only job here is to parse X-WOPI-FileExtensionFilterList into a
+        // typed list and hand it to the provider — the provider does the actual filtering at
+        // the storage layer. This test pins both halves of that contract:
+        //   1) the controller forwards the parsed [".txt"] (not the raw header) to the provider;
+        //   2) the controller materializes whatever the provider returned, no in-memory filter.
+        // The mock returns only file1 (the .txt match) — what a real filtering provider would.
         var containerId = "container";
         var fileMock1 = new Mock<IWopiFile>();
         fileMock1.Setup(f => f.Name).Returns("file1");
@@ -604,15 +610,13 @@ public class ContainersControllerTests
         fileMock1.Setup(f => f.Length).Returns(123);
         fileMock1.Setup(f => f.Identifier).Returns("fileId1");
 
-        var fileMock2 = new Mock<IWopiFile>();
-        fileMock2.Setup(f => f.Name).Returns("file2");
-        fileMock2.Setup(f => f.Extension).Returns("doc");
-        fileMock2.Setup(f => f.LastWriteTimeUtc).Returns(DateTime.UtcNow);
-        fileMock2.Setup(f => f.Length).Returns(456);
-        fileMock2.Setup(f => f.Identifier).Returns("fileId2");
-
         storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
-        storageProviderMock.Setup(sp => sp.GetWopiFiles(containerId, null, It.IsAny<CancellationToken>())).Returns(new[] { fileMock1.Object, fileMock2.Object }.ToAsyncEnumerable());
+        storageProviderMock
+            .Setup(sp => sp.GetWopiFiles(
+                containerId,
+                It.Is<IReadOnlyCollection<string>?>(exts => exts != null && exts.SequenceEqual(new[] { ".txt" })),
+                It.IsAny<CancellationToken>()))
+            .Returns(new[] { fileMock1.Object }.ToAsyncEnumerable());
         storageProviderMock.Setup(sp => sp.GetWopiContainers(containerId, It.IsAny<CancellationToken>())).Returns(AsyncEnumerable.Empty<IWopiFolder>());
 
         var result = await _controller.EnumerateChildren(containerId, ".txt") as JsonResult;

--- a/test/WopiHost.Core.Tests/Controllers/FoldersControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/FoldersControllerTests.cs
@@ -204,8 +204,12 @@ public class FoldersControllerTests
     }
 
     [Fact]
-    public async Task EnumerateChildren_FiltersFilesByExtension()
+    public async Task EnumerateChildren_ForwardsExtensionFilterToProvider()
     {
+        // The controller forwards X-WOPI-FileExtensionFilterList — parsed into a typed list —
+        // to the provider; the provider filters at the storage layer. This test pins both
+        // halves: the parsed [".one"] reaches the provider, and the controller materializes
+        // whatever it returned without any in-memory post-filter.
         var folderId = "folder";
         var fileMock1 = new Mock<IWopiFile>();
         fileMock1.Setup(f => f.Name).Returns("notebook1");
@@ -214,19 +218,15 @@ public class FoldersControllerTests
         fileMock1.Setup(f => f.Length).Returns(1024);
         fileMock1.Setup(f => f.Identifier).Returns("fileId1");
 
-        var fileMock2 = new Mock<IWopiFile>();
-        fileMock2.Setup(f => f.Name).Returns("document");
-        fileMock2.Setup(f => f.Extension).Returns("docx");
-        fileMock2.Setup(f => f.LastWriteTimeUtc).Returns(DateTime.UtcNow);
-        fileMock2.Setup(f => f.Length).Returns(512);
-        fileMock2.Setup(f => f.Identifier).Returns("fileId2");
-
         storageProviderMock
             .Setup(sp => sp.GetWopiResource<IWopiFolder>(folderId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Mock<IWopiFolder>().Object);
         storageProviderMock
-            .Setup(sp => sp.GetWopiFiles(folderId, null, It.IsAny<CancellationToken>()))
-            .Returns(new[] { fileMock1.Object, fileMock2.Object }.ToAsyncEnumerable());
+            .Setup(sp => sp.GetWopiFiles(
+                folderId,
+                It.Is<IReadOnlyCollection<string>?>(exts => exts != null && exts.SequenceEqual(new[] { ".one" })),
+                It.IsAny<CancellationToken>()))
+            .Returns(new[] { fileMock1.Object }.ToAsyncEnumerable());
 
         var result = await _controller.EnumerateChildren(folderId, ".one") as JsonResult;
 

--- a/test/WopiHost.FileSystemProvider.Tests/WopiFileSystemProviderTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/WopiFileSystemProviderTests.cs
@@ -184,16 +184,65 @@ public class WopiFileSystemProviderTests : IDisposable
     }
 
     [Fact]
-    public async Task GetWopiFiles_WithSearchPattern_FiltersByPattern()
+    public async Task GetWopiFiles_WithSingleExtensionFilter_FiltersByExtension()
     {
         var files = new List<IWopiFile>();
-        await foreach (var f in _sut.GetWopiFiles(_sut.RootContainer.Identifier, searchPattern: "*.docx"))
+        await foreach (var f in _sut.GetWopiFiles(_sut.RootContainer.Identifier, new[] { ".docx" }))
         {
             files.Add(f);
         }
         Assert.Single(files);
         Assert.Equal("root", files[0].Name);
         Assert.Equal("docx", files[0].Extension);
+    }
+
+    [Fact]
+    public async Task GetWopiFiles_WithMultipleExtensionFilter_ReturnsUnionOfExtensions()
+    {
+        // The fixture writes root.txt + root.docx; both should come back when both extensions
+        // are requested. Confirms the SelectMany-over-extensions plumbing emits disjoint
+        // result sets without dropping any.
+        var files = new List<IWopiFile>();
+        await foreach (var f in _sut.GetWopiFiles(_sut.RootContainer.Identifier, new[] { ".docx", ".txt" }))
+        {
+            files.Add(f);
+        }
+        Assert.Equal(2, files.Count);
+        Assert.Contains(files, f => f.Extension == "docx");
+        Assert.Contains(files, f => f.Extension == "txt");
+    }
+
+    [Fact]
+    public async Task GetWopiFiles_WithExtensionFilter_IsCaseInsensitive()
+    {
+        // WOPI spec mandates case-insensitive extension matching. The provider enforces this
+        // explicitly via EnumerationOptions.MatchCasing — without it, Linux hosts would
+        // case-sensitively miss a request for ".DOCX" against a "root.docx" file.
+        var files = new List<IWopiFile>();
+        await foreach (var f in _sut.GetWopiFiles(_sut.RootContainer.Identifier, new[] { ".DOCX" }))
+        {
+            files.Add(f);
+        }
+        Assert.Single(files);
+        Assert.Equal("docx", files[0].Extension);
+    }
+
+    [Fact]
+    public async Task GetWopiFiles_WithEmptyExtensionFilter_ReturnsAllFiles()
+    {
+        // Per the contract: null OR empty = no filter.
+        var withNull = new List<IWopiFile>();
+        await foreach (var f in _sut.GetWopiFiles(_sut.RootContainer.Identifier, fileExtensions: null))
+        {
+            withNull.Add(f);
+        }
+        var withEmpty = new List<IWopiFile>();
+        await foreach (var f in _sut.GetWopiFiles(_sut.RootContainer.Identifier, Array.Empty<string>()))
+        {
+            withEmpty.Add(f);
+        }
+        Assert.Equal(2, withNull.Count); // root.txt + root.docx
+        Assert.Equal(2, withEmpty.Count);
     }
 
     [Fact]


### PR DESCRIPTION
Addresses **3.5** from the architectural review in #369.

## The leaky bit

`IWopiStorageProvider.GetWopiFiles` took a `string? searchPattern` — a glob string passed through to either `Directory.GetFiles(path, pattern)` (filesystem) or a hand-rolled regex translator `BuildSearchMatcher` (Azure). That parameter is a `System.IO` concept; it had no business being on a cross-cutting WOPI abstraction.

It was also **dead code in the WOPI request path**: both `EnumerateChildren` endpoints (`ContainersController` and `FoldersController`) read `X-WOPI-FileExtensionFilterList` themselves, then called `GetWopiFiles(id, cancellationToken: cancellationToken)` with no pattern, then filtered the full result set in-memory afterward. The parameter survived only to satisfy a handful of glob-pattern tests.

## The new contract

```csharp
/// Optional list of file extensions to include in the result. Each element must be a
/// leading-dot extension (".docx", not "docx"); matching is case-insensitive, per the
/// WOPI X-WOPI-FileExtensionFilterList spec. When null or empty, every file in the
/// container is returned. Wildcard characters in the elements are matched literally —
/// the parameter is not a glob.
IAsyncEnumerable<IWopiFile> GetWopiFiles(
    string identifier,
    IReadOnlyCollection<string>? fileExtensions = null,
    CancellationToken cancellationToken = default);
```

And the xmldoc remarks commit implementations to pushing the filter as close to the storage layer as their backend allows — that commitment is part of the published contract, not a one-time implementation detail.

## Three-layer translation

```
WOPI client              Controller                      Provider
─────────────            ───────────                     ────────
X-WOPI-FileExt-          parse → string[] fileExts       GetWopiFiles(id, fileExts, ct)
  FilterList:            (single place that owns the     ────────────►
  ".docx,.pdf"           wire-format split)              filters at storage,
                                                          returns only matches
                                                          ◄─────────── result
                         materialize ChildFile per       (no inline filter)
                         result
```

Each layer has one job. The controller's old post-enumeration `if (!fileExtensions.Contains('.' + wopiFile.Extension, ...)) continue;` loop is gone.

## How each provider honors the "push to storage" commitment

**FileSystemProvider** — push to the OS:

```csharp
var options = new EnumerationOptions { MatchCasing = MatchCasing.CaseInsensitive };
var enumeration = (fileExtensions is { Count: > 0 })
    ? fileExtensions.SelectMany(ext => Directory.EnumerateFiles(absolutePath, "*" + ext, options))
    : Directory.EnumerateFiles(absolutePath, "*", options);
```

One OS call per extension. Distinct extensions produce disjoint result sets so no dedup. `MatchCasing.CaseInsensitive` is **explicit** because `EnumerationOptions.MatchCasing`'s default is `PlatformDefault`, which is case-sensitive on Linux — and the WOPI spec mandates case-insensitive matching. Without the override, a Linux host would silently miss `.DOCX` files when the WOPI client asks for `.docx`.

**AzureStorageProvider** — push as close to source as the SDK allows:

The Azure Blob Storage list API takes only a `prefix` filter at the wire level — no suffix / extension / regex support. So filtering happens at the **streaming-list boundary** inside the `GetBlobsByHierarchyAsync` foreach, before any `WopiBlobFile` allocation:

```csharp
var extensionFilter = (fileExtensions is { Count: > 0 })
    ? new HashSet<string>(fileExtensions, StringComparer.OrdinalIgnoreCase)
    : null;

await foreach (var item in containerClient.GetBlobsByHierarchyAsync(..., prefix: prefix, ...))
{
    // ... skip folder-markers, extract fileName ...
    if (extensionFilter is not null && !extensionFilter.Contains(Path.GetExtension(fileName)))
        continue;                               // dropped before any allocation
    yield return await WopiBlobFile.CreateAsync(...);
}
```

`HashSet<string>(OrdinalIgnoreCase)` built once outside the loop — O(1) membership regardless of how many extensions the caller asked for. The `BuildSearchMatcher` regex helper and the `System.Text.RegularExpressions` import are gone.

## Tests

Three test surfaces touched:

| File | Before | After |
|---|---|---|
| `WopiFileSystemProviderTests.cs` | 1 SearchPattern glob test | 4 contract tests: single-ext, multi-ext, case-insensitive, null-or-empty = no filter |
| `WopiAzureStorageProviderEdgeCaseTests.cs` | 3 SearchPattern/Theory tests | 5 contract tests: single-ext, multi-ext, case-insensitive, wildcards-matched-literally, null-or-empty |
| `WopiHost.Core.Tests` controllers | 2 `FiltersFilesByExtension` (checking the inline-filter behavior) | 2 `ForwardsExtensionFilterToProvider` (pinning both halves of the new contract: controller forwards, provider returns pre-filtered) |

The "wildcards-matched-literally" test deliberately passes `[ "*.docx" ]` and asserts an empty result — guards against anyone reintroducing a regex/glob translator on the assumption that the old semantic is still in effect.

## Breaking change

```
BREAKING CHANGE:
IWopiStorageProvider.GetWopiFiles dropped its string? searchPattern parameter.
The replacement is IReadOnlyCollection<string>? fileExtensions — a list of
leading-dot, case-insensitive file extensions to filter by, matching the WOPI
spec's X-WOPI-FileExtensionFilterList vocabulary. Callers that previously
passed a glob ("*.docx") now pass [".docx"]. Glob characters in any element
no longer have wildcard semantics — they are matched literally.
```

The repo is still stabilizing the API surface, so this is in keeping with the prior breaking-change PRs in this tracker.

## Test plan

- [x] `dotnet build WOPI.slnx` — `0 Warning(s) 0 Error(s)` across all TFMs under `TreatWarningsAsErrors=true`.
- [x] `dotnet test WOPI.slnx` — full suite green: Core 362, FileSystemProvider 96 (+3), AzureStorageProvider 96 (-1), AzureLockProvider 33, MemoryLockProvider 17, Discovery 80, Cobalt 64, Url 11, IntegrationTests 25, SmokeTests 5. ×3 TFMs where applicable. Same env-only `WopiHost.Core.Tests (net8.0)` abort on the dev box that's been there since the ASP.NET 8.0.0 runtime stopped shipping locally; passes everywhere else.

Part of #369 — addresses 3.5. The tracker stays open for the remaining items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
