### PR TITLE
Gate UseDeveloperExceptionPage behind IsDevelopment in frontend samples (#380 2.8)

### DIFF
--- a/sample/WopiHost.Web.Oidc/Program.cs
+++ b/sample/WopiHost.Web.Oidc/Program.cs
@@ -99,8 +99,16 @@ if (builder.Environment.IsDevelopment())
 
 var app = builder.Build();
 
-app.UseDeveloperExceptionPage();
-app.UseExceptionHandler("/Error");
+// Gate the developer exception page behind the Development environment — it leaks stack
+// traces and configuration values. Production falls through to the /Error handler.
+if (app.Environment.IsDevelopment())
+{
+    app.UseDeveloperExceptionPage();
+}
+else
+{
+    app.UseExceptionHandler("/Error");
+}
 app.UseStaticFiles();
 app.UseRouting();
 app.UseAuthentication();

--- a/sample/WopiHost.Web/Program.cs
+++ b/sample/WopiHost.Web/Program.cs
@@ -30,11 +30,17 @@ builder.Services.AddScoped<IWopiStorageProvider, WopiFileSystemProvider>();
 
 var app = builder.Build();
 
-// Configure the HTTP request pipeline
-app.UseDeveloperExceptionPage();
-
-// Configure exception handler as a fallback for production
-app.UseExceptionHandler("/Error");
+// Configure the HTTP request pipeline. The developer exception page leaks stack traces and
+// configuration values, so gate it behind the Development environment — production deployments
+// fall through to the /Error handler below.
+if (app.Environment.IsDevelopment())
+{
+    app.UseDeveloperExceptionPage();
+}
+else
+{
+    app.UseExceptionHandler("/Error");
+}
 
 //app.UseHttpsRedirection();
 


### PR DESCRIPTION
Addresses **2.8** from the architectural review tracker in #380.

## The bug

`WopiHost.Web` and `WopiHost.Web.Oidc` both shipped this in their `Program.cs`:

```csharp
// Configure the HTTP request pipeline
app.UseDeveloperExceptionPage();
app.UseExceptionHandler("/Error");
```

No environment guard. The developer exception page leaks stack traces, request details, configuration values, claim values — exactly the things you don't want surfacing in production. And because `UseDeveloperExceptionPage` runs first in the middleware order, the `/Error` handler that comes after it never actually wins in production: the dev page short-circuits the response.

The backend sample (`sample/WopiHost/Program.cs:114`) already gates this correctly behind `app.Environment.IsDevelopment()`. The frontends just hadn't been updated to match.

## The fix

```csharp
// Gate the developer exception page behind the Development environment — it leaks stack
// traces and configuration values. Production falls through to the /Error handler.
if (app.Environment.IsDevelopment())
{
    app.UseDeveloperExceptionPage();
}
else
{
    app.UseExceptionHandler("/Error");
}
```

`if/else` instead of "both, always" — only one handler is wired up per environment, with the correct one picked at startup.

## Behavioural change

- **In Development**: identical to before — full dev exception page when something throws.
- **In any other environment**: the `/Error` MVC view (which the samples already shipped, just unreachable) now actually fires. Stack traces stop leaking.

## Scope

Two files, both `Program.cs` of the frontend samples. ~21 lines added (mostly the `if/else` ceremony + clarifying comment), 7 removed.

## Test plan

- [x] `dotnet build WOPI.slnx` — `0 Warning(s) 0 Error(s)` across all TFMs under `TreatWarningsAsErrors=true`.
- [x] `dotnet test WOPI.slnx` — full suite green: Core 362, FileSystemProvider 96, AzureStorageProvider 96, AzureLockProvider 33, MemoryLockProvider 17, Discovery 80, Cobalt 64, Url 11, IntegrationTests 25, SmokeTests 5. ×3 TFMs where applicable.

Part of #380 — addresses 2.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
