### PR TITLE
Unify private-field naming via IDE1006 (#380 3.1)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,3 +24,48 @@ dotnet_diagnostic.IDE0005.severity = warning
 # IDE0161: Convert to file-scoped namespace
 csharp_style_namespace_declarations = file_scoped:warning
 dotnet_diagnostic.IDE0161.severity = warning
+
+# === .NET naming conventions ===
+# Picks the dotnet/runtime convention (also what Microsoft's "Common C# coding conventions"
+# recommends): _camelCase for private instance fields, s_camelCase for private static,
+# PascalCase for constants. Enforced at warning severity → build error under
+# TreatWarningsAsErrors. The IDE1006 analyzer powers all three rules below.
+
+# IDE1006: Naming rule violation — analyzer that surfaces the per-rule severities below.
+# Must be set independently of the dotnet_naming_rule entries because Roslyn treats the
+# diagnostic ID and the rule severities as separate knobs.
+dotnet_diagnostic.IDE1006.severity = warning
+
+# --- Symbols ---
+dotnet_naming_symbols.constants.applicable_kinds = field
+dotnet_naming_symbols.constants.applicable_accessibilities = *
+dotnet_naming_symbols.constants.required_modifiers = const
+
+dotnet_naming_symbols.private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_fields.required_modifiers = static
+
+dotnet_naming_symbols.private_instance_fields.applicable_kinds = field
+dotnet_naming_symbols.private_instance_fields.applicable_accessibilities = private
+
+# --- Styles ---
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.s_underscore_camel_case.required_prefix = s_
+dotnet_naming_style.s_underscore_camel_case.capitalization = camel_case
+
+dotnet_naming_style.underscore_camel_case.required_prefix = _
+dotnet_naming_style.underscore_camel_case.capitalization = camel_case
+
+# --- Rules (order matters: first match wins, so the most-specific rule comes first) ---
+dotnet_naming_rule.constants_should_be_pascal_case.symbols = constants
+dotnet_naming_rule.constants_should_be_pascal_case.style = pascal_case
+dotnet_naming_rule.constants_should_be_pascal_case.severity = warning
+
+dotnet_naming_rule.private_static_fields_should_be_s_underscore_camel_case.symbols = private_static_fields
+dotnet_naming_rule.private_static_fields_should_be_s_underscore_camel_case.style = s_underscore_camel_case
+dotnet_naming_rule.private_static_fields_should_be_s_underscore_camel_case.severity = warning
+
+dotnet_naming_rule.private_instance_fields_should_be_underscore_camel_case.symbols = private_instance_fields
+dotnet_naming_rule.private_instance_fields_should_be_underscore_camel_case.style = underscore_camel_case
+dotnet_naming_rule.private_instance_fields_should_be_underscore_camel_case.severity = warning

--- a/sample/WopiHost.Validator/Pages/HostPage.cshtml.cs
+++ b/sample/WopiHost.Validator/Pages/HostPage.cshtml.cs
@@ -30,7 +30,7 @@ public class HostPageModel(
     public string AccessTokenTtl { get; set; } = string.Empty;
     public Uri? UrlSrc { get; set; }
 
-    private readonly WopiUrlBuilder urlGenerator = new(discoverer, urlBuilderLogger, new WopiUrlSettings { UiLlcc = CultureInfo.CurrentUICulture });
+    private readonly WopiUrlBuilder _urlGenerator = new(discoverer, urlBuilderLogger, new WopiUrlSettings { UiLlcc = CultureInfo.CurrentUICulture });
 
     public async Task<IActionResult> OnGet(CancellationToken cancellationToken = default)
     {
@@ -67,7 +67,7 @@ public class HostPageModel(
             wopiOptions.Value.HostUrl,
             linkGenerator.GetPathByRouteValues(WopiRouteNames.CheckFileInfo, new { id = FileId })
             ?? throw new InvalidOperationException($"Could not generate route for '{WopiRouteNames.CheckFileInfo}'"));
-        var urlSrcString = await urlGenerator.GetFileUrlAsync(extension, wopiFileUrl, WopiAction)
+        var urlSrcString = await _urlGenerator.GetFileUrlAsync(extension, wopiFileUrl, WopiAction)
             ?? throw new InvalidOperationException($"Could not retrieve WopiUrl for extension '{extension}'");
         UrlSrc = new Uri(urlSrcString, UriKind.Absolute);
         ViewData["favicon"] = await discoverer.GetApplicationFavIconAsync(extension);

--- a/sample/WopiHost.Web.Oidc/Infrastructure/OidcRolePermissionMapper.cs
+++ b/sample/WopiHost.Web.Oidc/Infrastructure/OidcRolePermissionMapper.cs
@@ -30,7 +30,7 @@ public static class OidcRolePermissionMapper
     /// <summary>Role string that grants read-only access.</summary>
     public const string ViewerRole = "wopi.viewer";
 
-    private static readonly WopiFilePermissions EditorPermissions =
+    private static readonly WopiFilePermissions s_editorPermissions =
         WopiFilePermissions.UserCanWrite |
         WopiFilePermissions.UserCanRename |
         WopiFilePermissions.UserCanAttend |
@@ -56,7 +56,7 @@ public static class OidcRolePermissionMapper
 
         if (roles.Any(r => string.Equals(r, EditorRole, StringComparison.OrdinalIgnoreCase)))
         {
-            return EditorPermissions;
+            return s_editorPermissions;
         }
         if (roles.Any(r => string.Equals(r, ViewerRole, StringComparison.OrdinalIgnoreCase)))
         {

--- a/sample/WopiHost.Web/Controllers/HomeController.cs
+++ b/sample/WopiHost.Web/Controllers/HomeController.cs
@@ -30,7 +30,7 @@ public class HomeController(
     IDiscoverer discoverer,
     ILogger<WopiUrlBuilder> urlBuilderLogger) : Controller
 {
-    private readonly WopiUrlBuilder urlGenerator = new(
+    private readonly WopiUrlBuilder _urlGenerator = new(
         discoverer,
         urlBuilderLogger,
         new WopiUrlSettings { UiLlcc = ResolveUiCulture(wopiOptions.Value.UiCulture) });
@@ -40,7 +40,7 @@ public class HomeController(
 
     // Demo-only shared key — must match the WopiHost server's Wopi:Security:SigningKey.
     // In a real frontend, load this from the same managed secret store the server uses.
-    private static readonly byte[] SharedSigningKey = DerivePaddedKey("wopi-sample-shared-dev-key");
+    private static readonly byte[] s_sharedSigningKey = DerivePaddedKey("wopi-sample-shared-dev-key");
 
     public async Task<ActionResult> Index(string? containerId = null, string? parentContainerId = null, CancellationToken cancellationToken = default)
     {
@@ -144,7 +144,7 @@ public class HomeController(
         ViewData["access_token_ttl"] = expiresAt.ToUnixTimeMilliseconds();
 
         var extension = file.Extension.TrimStart('.');
-        ViewData["urlsrc"] = await urlGenerator.GetFileUrlAsync(extension, new Uri(wopiOptions.Value.HostUrl, $"/wopi/files/{id}"), actionEnum);
+        ViewData["urlsrc"] = await _urlGenerator.GetFileUrlAsync(extension, new Uri(wopiOptions.Value.HostUrl, $"/wopi/files/{id}"), actionEnum);
         ViewData["favicon"] = await discoverer.GetApplicationFavIconAsync(extension);
 
         // Host page headers per WOPI spec — prevent browser caching.
@@ -191,7 +191,7 @@ public class HomeController(
             ]),
             NotBefore = DateTime.UtcNow,
             Expires = expires.UtcDateTime,
-            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(SharedSigningKey), SecurityAlgorithms.HmacSha256),
+            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(s_sharedSigningKey), SecurityAlgorithms.HmacSha256),
         };
         var handler = new JwtSecurityTokenHandler { MapInboundClaims = false };
         return (handler.WriteToken(handler.CreateToken(descriptor)), expires);

--- a/src/WopiHost.AzureLockProvider/WopiAzureLockProvider.cs
+++ b/src/WopiHost.AzureLockProvider/WopiAzureLockProvider.cs
@@ -35,12 +35,12 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
     internal const string LeaseIdKey = "wopi_lease_id";
     internal const string CreatedKey = "wopi_created";
 
-    private readonly BlobContainerClient containerClient;
-    private readonly ILogger<WopiAzureLockProvider> logger;
-    private readonly IWopiLockComparer lockComparer;
-    private readonly TimeProvider timeProvider;
-    private readonly SemaphoreSlim initLock = new(1, 1);
-    private bool initialized;
+    private readonly BlobContainerClient _containerClient;
+    private readonly ILogger<WopiAzureLockProvider> _logger;
+    private readonly IWopiLockComparer _lockComparer;
+    private readonly TimeProvider _timeProvider;
+    private readonly SemaphoreSlim _initLock = new(1, 1);
+    private bool _initialized;
 
     /// <summary>
     /// Creates the provider.
@@ -63,10 +63,10 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
         TimeProvider? timeProvider = null,
         IWopiLockComparer? lockComparer = null)
     {
-        this.containerClient = containerClient ?? throw new ArgumentNullException(nameof(containerClient));
-        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        this.timeProvider = timeProvider ?? TimeProvider.System;
-        this.lockComparer = lockComparer ?? OrdinalWopiLockComparer.Instance;
+        _containerClient = containerClient ?? throw new ArgumentNullException(nameof(containerClient));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _lockComparer = lockComparer ?? OrdinalWopiLockComparer.Instance;
     }
 
     /// <inheritdoc />
@@ -79,7 +79,7 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
         {
             return null;
         }
-        if (!info.IsExpiredAt(timeProvider.GetUtcNow()))
+        if (!info.IsExpiredAt(_timeProvider.GetUtcNow()))
         {
             return info;
         }
@@ -87,7 +87,7 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
         // WOPI-expired. Break the lease so subsequent AddLock calls can take over, then evict.
         await TryBreakLeaseAsync(blobClient, cancellationToken).ConfigureAwait(false);
         await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-        LogLockExpired(logger, fileId, info.LockId);
+        LogLockExpired(_logger, fileId, info.LockId);
         return null;
     }
 
@@ -103,9 +103,9 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
         {
             if (TryReadLock(fileId, existing, out var existingInfo))
             {
-                if (!existingInfo.IsExpiredAt(timeProvider.GetUtcNow()))
+                if (!existingInfo.IsExpiredAt(_timeProvider.GetUtcNow()))
                 {
-                    LogLockAddRejected(logger, fileId, lockId, existingInfo.LockId);
+                    LogLockAddRejected(_logger, fileId, lockId, existingInfo.LockId);
                     return null;
                 }
                 // Stale (>30 min old) — clean up so we can take over.
@@ -120,7 +120,7 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
                 // crashed between Upload and lease acquisition. Either way, treat it as
                 // "lock-attempt in progress" and yield. (Aggressive cleanup here was the prior
                 // bug that broke healthy peers via lease-break + delete in their acquire window.)
-                LogLockAddRaceLost(logger, fileId, lockId);
+                LogLockAddRaceLost(_logger, fileId, lockId);
                 return null;
             }
         }
@@ -132,7 +132,7 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
         // ahead and we lost. Some Azure SDK paths surface 409 instead — we treat both as the
         // race-lost outcome.
         var leaseId = Guid.NewGuid().ToString();
-        var now = timeProvider.GetUtcNow();
+        var now = _timeProvider.GetUtcNow();
         var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
         {
             [LockIdKey] = lockId,
@@ -153,7 +153,7 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
         }
         catch (RequestFailedException ex) when (ex.Status == 409 || ex.Status == 412)
         {
-            LogLockAddRaceLost(logger, fileId, lockId);
+            LogLockAddRaceLost(_logger, fileId, lockId);
             return null;
         }
 
@@ -167,12 +167,12 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
         }
         catch (RequestFailedException ex)
         {
-            LogLeaseAcquireFailed(logger, ex, fileId);
+            LogLeaseAcquireFailed(_logger, ex, fileId);
             await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             return null;
         }
 
-        LogLockAcquired(logger, fileId, lockId);
+        LogLockAcquired(_logger, fileId, lockId);
         return new WopiLockInfo { FileId = fileId, LockId = lockId, DateCreated = now };
     }
 
@@ -186,7 +186,7 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
         {
             return false;
         }
-        if (info.IsExpiredAt(timeProvider.GetUtcNow()))
+        if (info.IsExpiredAt(_timeProvider.GetUtcNow()))
         {
             return false;
         }
@@ -204,13 +204,13 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
         }
         catch (RequestFailedException ex)
         {
-            LogLeaseRenewFailed(logger, ex, fileId);
+            LogLeaseRenewFailed(_logger, ex, fileId);
             return false;
         }
 
         var updated = new Dictionary<string, string>(props.Metadata, StringComparer.Ordinal)
         {
-            [CreatedKey] = timeProvider.GetUtcNow().ToString("O", CultureInfo.InvariantCulture),
+            [CreatedKey] = _timeProvider.GetUtcNow().ToString("O", CultureInfo.InvariantCulture),
         };
         try
         {
@@ -221,7 +221,7 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
         }
         catch (RequestFailedException ex)
         {
-            LogLockMetadataUpdateFailed(logger, ex, fileId);
+            LogLockMetadataUpdateFailed(_logger, ex, fileId);
             return false;
         }
     }
@@ -236,7 +236,7 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
         {
             return false;
         }
-        if (info.IsExpiredAt(timeProvider.GetUtcNow()) || !lockComparer.AreEqual(info.LockId, expectedExistingLockId))
+        if (info.IsExpiredAt(_timeProvider.GetUtcNow()) || !_lockComparer.AreEqual(info.LockId, expectedExistingLockId))
         {
             return false;
         }
@@ -256,14 +256,14 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
         }
         catch (RequestFailedException ex)
         {
-            LogLeaseRenewFailed(logger, ex, fileId);
+            LogLeaseRenewFailed(_logger, ex, fileId);
             return false;
         }
 
         var updated = new Dictionary<string, string>(props.Metadata, StringComparer.Ordinal)
         {
             [LockIdKey] = newLockId,
-            [CreatedKey] = timeProvider.GetUtcNow().ToString("O", CultureInfo.InvariantCulture),
+            [CreatedKey] = _timeProvider.GetUtcNow().ToString("O", CultureInfo.InvariantCulture),
         };
         try
         {
@@ -275,12 +275,12 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
         catch (RequestFailedException ex) when (ex.Status == 412 || ex.Status == 409)
         {
             // 412 = ETag changed (concurrent swap). 409 = lease conflict. Either way, swap aborted.
-            LogLockMetadataUpdateFailed(logger, ex, fileId);
+            LogLockMetadataUpdateFailed(_logger, ex, fileId);
             return false;
         }
         catch (RequestFailedException ex)
         {
-            LogLockMetadataUpdateFailed(logger, ex, fileId);
+            LogLockMetadataUpdateFailed(_logger, ex, fileId);
             return false;
         }
     }
@@ -311,30 +311,30 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
         if (deleted.Value)
         {
             var removedLockId = props.Metadata.TryGetValue(LockIdKey, out var lid) ? lid : null;
-            LogLockRemoved(logger, fileId, removedLockId);
+            LogLockRemoved(_logger, fileId, removedLockId);
         }
         return deleted.Value;
     }
 
     private async Task EnsureContainerAsync(CancellationToken cancellationToken)
     {
-        if (initialized)
+        if (_initialized)
         {
             return;
         }
-        await initLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await _initLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            if (initialized)
+            if (_initialized)
             {
                 return;
             }
-            await containerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-            initialized = true;
+            await _containerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            _initialized = true;
         }
         finally
         {
-            initLock.Release();
+            _initLock.Release();
         }
     }
 
@@ -342,7 +342,7 @@ public partial class WopiAzureLockProvider : IWopiLockProvider
     {
         // Hash the fileId so any caller-supplied identifier is reduced to a safe blob name.
         var name = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(fileId))).ToLowerInvariant();
-        return containerClient.GetBlobClient(name);
+        return _containerClient.GetBlobClient(name);
     }
 
     private static async Task<BlobProperties?> TryGetPropertiesAsync(BlobClient blobClient, CancellationToken cancellationToken)

--- a/src/WopiHost.AzureStorageProvider/BlobIdMap.cs
+++ b/src/WopiHost.AzureStorageProvider/BlobIdMap.cs
@@ -37,19 +37,19 @@ public sealed partial class BlobIdMap(ILogger<BlobIdMap> logger)
     /// </remarks>
     public const string FolderMarker = ".wopi.folder";
 
-    private readonly Dictionary<string, string> idToPath = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, string> _idToPath = new(StringComparer.Ordinal);
 
     /// <summary>Whether <see cref="ScanAll(IEnumerable{string})"/> has been called.</summary>
     public bool WasScanned { get; private set; }
 
     /// <summary>Looks up the blob path for an identifier.</summary>
     public bool TryGetPath(string fileId, [NotNullWhen(true)] out string? path)
-        => idToPath.TryGetValue(fileId, out path);
+        => _idToPath.TryGetValue(fileId, out path);
 
     /// <summary>Looks up the identifier for a blob path. Path comparison is case-sensitive.</summary>
     public bool TryGetFileId(string path, [NotNullWhen(true)] out string? fileId)
     {
-        foreach (var pair in idToPath)
+        foreach (var pair in _idToPath)
         {
             if (pair.Value == path)
             {
@@ -65,15 +65,15 @@ public sealed partial class BlobIdMap(ILogger<BlobIdMap> logger)
     public string Add(string path)
     {
         var id = IdFromPath(path);
-        idToPath[id] = path;
+        _idToPath[id] = path;
         return id;
     }
 
     /// <summary>Removes a mapping by id.</summary>
-    public bool Remove(string fileId) => idToPath.Remove(fileId);
+    public bool Remove(string fileId) => _idToPath.Remove(fileId);
 
     /// <summary>Updates the path for an existing id (used after a rename to keep the id stable).</summary>
-    public void Update(string fileId, string newPath) => idToPath[fileId] = newPath;
+    public void Update(string fileId, string newPath) => _idToPath[fileId] = newPath;
 
     /// <summary>
     /// Rebuilds the map from a flat enumeration of blob paths. The empty path is treated as the root
@@ -82,9 +82,9 @@ public sealed partial class BlobIdMap(ILogger<BlobIdMap> logger)
     /// </summary>
     public void ScanAll(IEnumerable<string> blobPaths)
     {
-        idToPath.Clear();
+        _idToPath.Clear();
         // Root container is always identified by the empty string.
-        idToPath[IdFromPath(string.Empty)] = string.Empty;
+        _idToPath[IdFromPath(string.Empty)] = string.Empty;
 
         var seenDirs = new HashSet<string>(StringComparer.Ordinal);
         foreach (var path in blobPaths)
@@ -98,7 +98,7 @@ public sealed partial class BlobIdMap(ILogger<BlobIdMap> logger)
                 continue;
             }
 
-            idToPath[IdFromPath(path)] = path;
+            _idToPath[IdFromPath(path)] = path;
 
             var lastSlash = path.LastIndexOf('/');
             if (lastSlash > 0)
@@ -108,7 +108,7 @@ public sealed partial class BlobIdMap(ILogger<BlobIdMap> logger)
         }
 
         WasScanned = true;
-        LogScannedEntries(logger, idToPath.Count);
+        LogScannedEntries(logger, _idToPath.Count);
     }
 
     private void AddDirectoryAndAncestors(string dirPath, HashSet<string> seen)
@@ -116,7 +116,7 @@ public sealed partial class BlobIdMap(ILogger<BlobIdMap> logger)
         var current = dirPath;
         while (!string.IsNullOrEmpty(current) && seen.Add(current))
         {
-            idToPath[IdFromPath(current)] = current;
+            _idToPath[IdFromPath(current)] = current;
             var slash = current.LastIndexOf('/');
             current = slash > 0 ? current[..slash] : string.Empty;
         }

--- a/src/WopiHost.AzureStorageProvider/HashingBlobWriteStream.cs
+++ b/src/WopiHost.AzureStorageProvider/HashingBlobWriteStream.cs
@@ -11,9 +11,9 @@ namespace WopiHost.AzureStorageProvider;
 /// </summary>
 internal sealed class HashingBlobWriteStream(Stream inner, BlobClient blobClient, Dictionary<string, string> preservedMetadata) : Stream
 {
-    private readonly Dictionary<string, string> metadataToWrite = preservedMetadata;
-    private readonly IncrementalHash hasher = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
-    private bool disposed;
+    private readonly Dictionary<string, string> _metadataToWrite = preservedMetadata;
+    private readonly IncrementalHash _hasher = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+    private bool _disposed;
 
     public override bool CanRead => false;
     public override bool CanSeek => false;
@@ -35,44 +35,44 @@ internal sealed class HashingBlobWriteStream(Stream inner, BlobClient blobClient
 
     public override void Write(byte[] buffer, int offset, int count)
     {
-        hasher.AppendData(buffer, offset, count);
+        _hasher.AppendData(buffer, offset, count);
         inner.Write(buffer, offset, count);
     }
 
     public override void Write(ReadOnlySpan<byte> buffer)
     {
-        hasher.AppendData(buffer);
+        _hasher.AppendData(buffer);
         inner.Write(buffer);
     }
 
     public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
     {
-        hasher.AppendData(buffer, offset, count);
+        _hasher.AppendData(buffer, offset, count);
         await inner.WriteAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
     }
 
     public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
     {
-        hasher.AppendData(buffer.Span);
+        _hasher.AppendData(buffer.Span);
         await inner.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
     }
 
     public override async ValueTask DisposeAsync()
     {
-        if (disposed)
+        if (_disposed)
         {
             return;
         }
-        disposed = true;
+        _disposed = true;
 
         // Closing/disposing the inner Azure write stream is what actually commits the blob.
         await inner.DisposeAsync().ConfigureAwait(false);
 
-        var hash = hasher.GetCurrentHash();
-        hasher.Dispose();
-        metadataToWrite[WopiBlobFile.Sha256MetadataKey] = Convert.ToHexString(hash).ToLowerInvariant();
+        var hash = _hasher.GetCurrentHash();
+        _hasher.Dispose();
+        _metadataToWrite[WopiBlobFile.Sha256MetadataKey] = Convert.ToHexString(hash).ToLowerInvariant();
 
-        await blobClient.SetMetadataAsync(metadataToWrite).ConfigureAwait(false);
+        await blobClient.SetMetadataAsync(_metadataToWrite).ConfigureAwait(false);
     }
 
     protected override void Dispose(bool disposing)
@@ -81,16 +81,16 @@ internal sealed class HashingBlobWriteStream(Stream inner, BlobClient blobClient
         // expensive bits inline. Intentionally no GetAwaiter().GetResult() on user-facing async
         // calls here — we already removed sync-over-async from the lock provider; this stream is the
         // last necessary sync-over-async boundary because Stream.Dispose can't be async.
-        if (disposed || !disposing)
+        if (_disposed || !disposing)
         {
             return;
         }
-        disposed = true;
+        _disposed = true;
 
         inner.Dispose();
-        var hash = hasher.GetCurrentHash();
-        hasher.Dispose();
-        metadataToWrite[WopiBlobFile.Sha256MetadataKey] = Convert.ToHexString(hash).ToLowerInvariant();
-        blobClient.SetMetadata(metadataToWrite);
+        var hash = _hasher.GetCurrentHash();
+        _hasher.Dispose();
+        _metadataToWrite[WopiBlobFile.Sha256MetadataKey] = Convert.ToHexString(hash).ToLowerInvariant();
+        blobClient.SetMetadata(_metadataToWrite);
     }
 }

--- a/src/WopiHost.AzureStorageProvider/WopiAzureStorageProvider.cs
+++ b/src/WopiHost.AzureStorageProvider/WopiAzureStorageProvider.cs
@@ -27,11 +27,11 @@ namespace WopiHost.AzureStorageProvider;
 /// </remarks>
 public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWritableStorageProvider
 {
-    private readonly BlobContainerClient containerClient;
-    private readonly BlobIdMap idMap;
-    private readonly ILogger<WopiAzureStorageProvider> logger;
-    private readonly SemaphoreSlim initLock = new(1, 1);
-    private bool initialized;
+    private readonly BlobContainerClient _containerClient;
+    private readonly BlobIdMap _idMap;
+    private readonly ILogger<WopiAzureStorageProvider> _logger;
+    private readonly SemaphoreSlim _initLock = new(1, 1);
+    private bool _initialized;
 
     /// <inheritdoc/>
     public IWopiFolder RootContainer { get; }
@@ -42,42 +42,42 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
         BlobIdMap idMap,
         ILogger<WopiAzureStorageProvider> logger)
     {
-        this.containerClient = containerClient ?? throw new ArgumentNullException(nameof(containerClient));
-        this.idMap = idMap ?? throw new ArgumentNullException(nameof(idMap));
-        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _containerClient = containerClient ?? throw new ArgumentNullException(nameof(containerClient));
+        _idMap = idMap ?? throw new ArgumentNullException(nameof(idMap));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         var rootId = BlobIdMap.IdFromPath(string.Empty);
         RootContainer = new WopiBlobFolder(string.Empty, rootId);
     }
 
     private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
     {
-        if (initialized)
+        if (_initialized)
         {
             return;
         }
-        await initLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await _initLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            if (initialized)
+            if (_initialized)
             {
                 return;
             }
-            await containerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-            if (!idMap.WasScanned)
+            await _containerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (!_idMap.WasScanned)
             {
                 var paths = new List<string>();
-                await foreach (var item in containerClient.GetBlobsAsync(traits: BlobTraits.None, states: BlobStates.None, prefix: null, cancellationToken: cancellationToken).ConfigureAwait(false))
+                await foreach (var item in _containerClient.GetBlobsAsync(traits: BlobTraits.None, states: BlobStates.None, prefix: null, cancellationToken: cancellationToken).ConfigureAwait(false))
                 {
                     paths.Add(item.Name);
                 }
-                idMap.ScanAll(paths);
+                _idMap.ScanAll(paths);
             }
-            initialized = true;
-            LogInitialized(logger, containerClient.Name);
+            _initialized = true;
+            LogInitialized(_logger, _containerClient.Name);
         }
         finally
         {
-            initLock.Release();
+            _initLock.Release();
         }
     }
 
@@ -86,14 +86,14 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
         where T : class, IWopiResource
     {
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        if (!idMap.TryGetPath(identifier, out var path))
+        if (!_idMap.TryGetPath(identifier, out var path))
         {
             return null;
         }
 
         if (typeof(IWopiFile).IsAssignableFrom(typeof(T)))
         {
-            var blobClient = containerClient.GetBlobClient(path);
+            var blobClient = _containerClient.GetBlobClient(path);
             return await WopiBlobFile.CreateAsync(blobClient, path, identifier, cancellationToken).ConfigureAwait(false) as T;
         }
         if (typeof(IWopiFolder).IsAssignableFrom(typeof(T)))
@@ -123,7 +123,7 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
             ? new HashSet<string>(fileExtensions, StringComparer.OrdinalIgnoreCase)
             : null;
 
-        await foreach (var item in containerClient.GetBlobsByHierarchyAsync(traits: BlobTraits.None, states: BlobStates.None, delimiter: "/", prefix: prefix, cancellationToken: cancellationToken).ConfigureAwait(false))
+        await foreach (var item in _containerClient.GetBlobsByHierarchyAsync(traits: BlobTraits.None, states: BlobStates.None, delimiter: "/", prefix: prefix, cancellationToken: cancellationToken).ConfigureAwait(false))
         {
             if (item.IsBlob is false)
             {
@@ -141,8 +141,8 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
             {
                 continue;
             }
-            var id = idMap.TryGetFileId(name, out var existingId) ? existingId : idMap.Add(name);
-            var blobClient = containerClient.GetBlobClient(name);
+            var id = _idMap.TryGetFileId(name, out var existingId) ? existingId : _idMap.Add(name);
+            var blobClient = _containerClient.GetBlobClient(name);
             yield return await WopiBlobFile.CreateAsync(blobClient, name, id, cancellationToken).ConfigureAwait(false);
         }
     }
@@ -157,14 +157,14 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
         var folderPath = ResolveFolderPath(identifier);
         var prefix = string.IsNullOrEmpty(folderPath) ? null : folderPath + "/";
 
-        await foreach (var item in containerClient.GetBlobsByHierarchyAsync(traits: BlobTraits.None, states: BlobStates.None, delimiter: "/", prefix: prefix, cancellationToken: cancellationToken).ConfigureAwait(false))
+        await foreach (var item in _containerClient.GetBlobsByHierarchyAsync(traits: BlobTraits.None, states: BlobStates.None, delimiter: "/", prefix: prefix, cancellationToken: cancellationToken).ConfigureAwait(false))
         {
             if (item.IsPrefix is false)
             {
                 continue;
             }
             var subPrefix = item.Prefix.TrimEnd('/');
-            var id = idMap.TryGetFileId(subPrefix, out var existingId) ? existingId : idMap.Add(subPrefix);
+            var id = _idMap.TryGetFileId(subPrefix, out var existingId) ? existingId : _idMap.Add(subPrefix);
             yield return new WopiBlobFolder(subPrefix, id);
         }
     }
@@ -174,7 +174,7 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
         where T : class, IWopiResource
     {
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        if (!idMap.TryGetPath(identifier, out var path))
+        if (!_idMap.TryGetPath(identifier, out var path))
         {
             throw new DirectoryNotFoundException($"Resource '{identifier}' not found.");
         }
@@ -185,7 +185,7 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
         {
             // Always include the immediate parent for files (matches WopiFileSystemProvider behavior).
             var parentPath = GetParentPath(path);
-            var parentId = idMap.TryGetFileId(parentPath, out var existingId) ? existingId : idMap.Add(parentPath);
+            var parentId = _idMap.TryGetFileId(parentPath, out var existingId) ? existingId : _idMap.Add(parentPath);
             result.Add(new WopiBlobFolder(parentPath, parentId));
             path = parentPath;
         }
@@ -193,7 +193,7 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
         while (!string.IsNullOrEmpty(path))
         {
             path = GetParentPath(path);
-            var ancestorId = idMap.TryGetFileId(path, out var existingId) ? existingId : idMap.Add(path);
+            var ancestorId = _idMap.TryGetFileId(path, out var existingId) ? existingId : _idMap.Add(path);
             result.Add(new WopiBlobFolder(path, ancestorId));
             if (string.IsNullOrEmpty(path))
             {
@@ -209,7 +209,7 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
         where T : class, IWopiResource
     {
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        if (!idMap.TryGetPath(containerId, out var folderPath))
+        if (!_idMap.TryGetPath(containerId, out var folderPath))
         {
             throw new DirectoryNotFoundException($"Container '{containerId}' not found.");
         }
@@ -217,7 +217,7 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
 
         if (typeof(IWopiFile).IsAssignableFrom(typeof(T)))
         {
-            var blobClient = containerClient.GetBlobClient(combined);
+            var blobClient = _containerClient.GetBlobClient(combined);
             try
             {
                 _ = await blobClient.GetPropertiesAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -226,15 +226,15 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
             {
                 return null;
             }
-            var id = idMap.TryGetFileId(combined, out var existingId) ? existingId : idMap.Add(combined);
+            var id = _idMap.TryGetFileId(combined, out var existingId) ? existingId : _idMap.Add(combined);
             return await WopiBlobFile.CreateAsync(blobClient, combined, id, cancellationToken).ConfigureAwait(false) as T;
         }
         if (typeof(IWopiFolder).IsAssignableFrom(typeof(T)))
         {
             // Folder exists if any blob shares this prefix.
-            await foreach (var _ in containerClient.GetBlobsAsync(traits: BlobTraits.None, states: BlobStates.None, prefix: combined + "/", cancellationToken: cancellationToken).ConfigureAwait(false))
+            await foreach (var _ in _containerClient.GetBlobsAsync(traits: BlobTraits.None, states: BlobStates.None, prefix: combined + "/", cancellationToken: cancellationToken).ConfigureAwait(false))
             {
-                var id = idMap.TryGetFileId(combined, out var existingId) ? existingId : idMap.Add(combined);
+                var id = _idMap.TryGetFileId(combined, out var existingId) ? existingId : _idMap.Add(combined);
                 return new WopiBlobFolder(combined, id) as T;
             }
             return null;
@@ -272,7 +272,7 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
             throw new ArgumentException("Invalid characters in the name.", nameof(name));
         }
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        if (!idMap.TryGetPath(containerId, out _))
+        if (!_idMap.TryGetPath(containerId, out _))
         {
             throw new DirectoryNotFoundException($"Container '{containerId}' not found.");
         }
@@ -300,7 +300,7 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
     {
         ArgumentNullException.ThrowIfNull(containerId);
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        if (!idMap.TryGetPath(containerId, out var parentPath))
+        if (!_idMap.TryGetPath(containerId, out var parentPath))
         {
             throw new DirectoryNotFoundException($"Container '{containerId}' not found.");
         }
@@ -308,7 +308,7 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
         if (typeof(IWopiFile).IsAssignableFrom(typeof(T)))
         {
             var path = string.IsNullOrEmpty(parentPath) ? name : parentPath + "/" + name;
-            var blobClient = containerClient.GetBlobClient(path);
+            var blobClient = _containerClient.GetBlobClient(path);
             try
             {
                 using var empty = new MemoryStream([], writable: false);
@@ -318,15 +318,15 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
             {
                 throw new ArgumentException($"File '{path}' already exists.", nameof(name));
             }
-            var id = idMap.Add(path);
-            LogFileCreated(logger, id, path);
+            var id = _idMap.Add(path);
+            LogFileCreated(_logger, id, path);
             return await WopiBlobFile.CreateAsync(blobClient, path, id, cancellationToken).ConfigureAwait(false) as T;
         }
         if (typeof(IWopiFolder).IsAssignableFrom(typeof(T)))
         {
             var path = string.IsNullOrEmpty(parentPath) ? name : parentPath + "/" + name;
             var markerPath = path + "/" + BlobIdMap.FolderMarker;
-            var markerClient = containerClient.GetBlobClient(markerPath);
+            var markerClient = _containerClient.GetBlobClient(markerPath);
             try
             {
                 using var empty = new MemoryStream([], writable: false);
@@ -336,8 +336,8 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
             {
                 throw new ArgumentException($"Folder '{path}' already exists.", nameof(name));
             }
-            var id = idMap.Add(path);
-            LogFolderCreated(logger, id, path);
+            var id = _idMap.Add(path);
+            LogFolderCreated(_logger, id, path);
             return new WopiBlobFolder(path, id) as T;
         }
         throw new NotSupportedException($"Unsupported resource type: {typeof(T).Name}");
@@ -348,19 +348,19 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
         where T : class, IWopiResource
     {
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        if (!idMap.TryGetPath(identifier, out var path))
+        if (!_idMap.TryGetPath(identifier, out var path))
         {
             return false;
         }
 
         if (typeof(IWopiFile).IsAssignableFrom(typeof(T)))
         {
-            var blobClient = containerClient.GetBlobClient(path);
+            var blobClient = _containerClient.GetBlobClient(path);
             var deleted = await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             if (deleted.Value)
             {
-                idMap.Remove(identifier);
-                LogFileDeleted(logger, identifier, path);
+                _idMap.Remove(identifier);
+                LogFileDeleted(_logger, identifier, path);
             }
             return deleted.Value;
         }
@@ -373,7 +373,7 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
             var prefix = path + "/";
 
             // Check the folder is empty (other than possibly the marker blob).
-            await foreach (var item in containerClient.GetBlobsAsync(traits: BlobTraits.None, states: BlobStates.None, prefix: prefix, cancellationToken: cancellationToken).ConfigureAwait(false))
+            await foreach (var item in _containerClient.GetBlobsAsync(traits: BlobTraits.None, states: BlobStates.None, prefix: prefix, cancellationToken: cancellationToken).ConfigureAwait(false))
             {
                 if (item.Name != prefix + BlobIdMap.FolderMarker)
                 {
@@ -382,10 +382,10 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
             }
 
             // Delete the marker if present, then drop the id.
-            var markerClient = containerClient.GetBlobClient(prefix + BlobIdMap.FolderMarker);
+            var markerClient = _containerClient.GetBlobClient(prefix + BlobIdMap.FolderMarker);
             await markerClient.DeleteIfExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-            idMap.Remove(identifier);
-            LogFolderDeleted(logger, identifier, path);
+            _idMap.Remove(identifier);
+            LogFolderDeleted(_logger, identifier, path);
             return true;
         }
         throw new NotSupportedException($"Unsupported resource type: {typeof(T).Name}");
@@ -400,7 +400,7 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
             throw new ArgumentException("Invalid characters in the name.", nameof(requestedName));
         }
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        if (!idMap.TryGetPath(identifier, out var oldPath))
+        if (!_idMap.TryGetPath(identifier, out var oldPath))
         {
             return false;
         }
@@ -410,8 +410,8 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
         {
             var newPath = string.IsNullOrEmpty(parent) ? requestedName : parent + "/" + requestedName;
             await CopyAndDeleteBlobAsync(oldPath, newPath, cancellationToken).ConfigureAwait(false);
-            idMap.Update(identifier, newPath);
-            LogFileRenamed(logger, identifier, oldPath, newPath);
+            _idMap.Update(identifier, newPath);
+            LogFileRenamed(_logger, identifier, oldPath, newPath);
             return true;
         }
         if (typeof(IWopiFolder).IsAssignableFrom(typeof(T)))
@@ -427,25 +427,25 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
             // Plain blob storage has no atomic rename — copy each blob then delete the original.
             // Order matters for crash safety: copy first, only delete after the copy succeeded.
             var renamed = new List<(string oldName, string newName, string? oldId)>();
-            await foreach (var item in containerClient.GetBlobsAsync(traits: BlobTraits.None, states: BlobStates.None, prefix: oldPrefix, cancellationToken: cancellationToken).ConfigureAwait(false))
+            await foreach (var item in _containerClient.GetBlobsAsync(traits: BlobTraits.None, states: BlobStates.None, prefix: oldPrefix, cancellationToken: cancellationToken).ConfigureAwait(false))
             {
                 var rel = item.Name[oldPrefix.Length..];
                 var dest = newPrefix + rel;
                 await CopyAndDeleteBlobAsync(item.Name, dest, cancellationToken).ConfigureAwait(false);
-                idMap.TryGetFileId(item.Name, out var blobId);
+                _idMap.TryGetFileId(item.Name, out var blobId);
                 renamed.Add((item.Name, dest, blobId));
             }
 
             // Update the id map: keep the folder identifier stable, re-point children to new paths.
-            idMap.Update(identifier, newPath);
+            _idMap.Update(identifier, newPath);
             foreach (var (_, newName, oldId) in renamed)
             {
                 if (oldId is not null)
                 {
-                    idMap.Update(oldId, newName);
+                    _idMap.Update(oldId, newName);
                 }
             }
-            LogFolderRenamed(logger, identifier, oldPath, newPath, renamed.Count);
+            LogFolderRenamed(_logger, identifier, oldPath, newPath, renamed.Count);
             return true;
         }
         throw new NotSupportedException($"Unsupported resource type: {typeof(T).Name}");
@@ -455,7 +455,7 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
 
     private string ResolveFolderPath(string identifier)
     {
-        if (idMap.TryGetPath(identifier, out var path))
+        if (_idMap.TryGetPath(identifier, out var path))
         {
             return path;
         }
@@ -474,8 +474,8 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
 
     private async Task CopyAndDeleteBlobAsync(string sourcePath, string destPath, CancellationToken cancellationToken)
     {
-        var source = containerClient.GetBlobClient(sourcePath);
-        var dest = containerClient.GetBlobClient(destPath);
+        var source = _containerClient.GetBlobClient(sourcePath);
+        var dest = _containerClient.GetBlobClient(destPath);
 
         if (await dest.ExistsAsync(cancellationToken).ConfigureAwait(false))
         {

--- a/src/WopiHost.AzureStorageProvider/WopiBlobFile.cs
+++ b/src/WopiHost.AzureStorageProvider/WopiBlobFile.cs
@@ -29,13 +29,13 @@ public class WopiBlobFile : IWopiFile
     /// <summary>Blob metadata key that holds the SHA-256 of the blob content as a lowercase hex string.</summary>
     public const string Sha256MetadataKey = "wopi_sha256";
 
-    private readonly BlobClient blobClient;
-    private readonly BlobProperties? properties;
+    private readonly BlobClient _blobClient;
+    private readonly BlobProperties? _properties;
 
     private WopiBlobFile(BlobClient blobClient, string blobPath, string identifier, BlobProperties? properties)
     {
-        this.blobClient = blobClient;
-        this.properties = properties;
+        _blobClient = blobClient;
+        _properties = properties;
         BlobPath = blobPath;
         Identifier = identifier;
     }
@@ -69,23 +69,23 @@ public class WopiBlobFile : IWopiFile
     }
 
     /// <inheritdoc/>
-    public bool Exists => properties is not null;
+    public bool Exists => _properties is not null;
 
     /// <inheritdoc/>
-    public long Length => properties?.ContentLength ?? 0;
+    public long Length => _properties?.ContentLength ?? 0;
 
     /// <inheritdoc/>
-    public DateTime LastWriteTimeUtc => properties?.LastModified.UtcDateTime ?? DateTime.MinValue;
+    public DateTime LastWriteTimeUtc => _properties?.LastModified.UtcDateTime ?? DateTime.MinValue;
 
     /// <inheritdoc/>
-    public string? Version => properties?.ETag.ToString();
+    public string? Version => _properties?.ETag.ToString();
 
     /// <inheritdoc/>
     public string Owner
     {
         get
         {
-            if (properties is { Metadata: { } meta } && meta.TryGetValue(OwnerMetadataKey, out var owner))
+            if (_properties is { Metadata: { } meta } && meta.TryGetValue(OwnerMetadataKey, out var owner))
             {
                 return owner;
             }
@@ -98,7 +98,7 @@ public class WopiBlobFile : IWopiFile
     {
         get
         {
-            if (properties is { Metadata: { } meta } && meta.TryGetValue(Sha256MetadataKey, out var hex) && !string.IsNullOrEmpty(hex))
+            if (_properties is { Metadata: { } meta } && meta.TryGetValue(Sha256MetadataKey, out var hex) && !string.IsNullOrEmpty(hex))
             {
                 return Convert.FromHexString(hex);
             }
@@ -108,7 +108,7 @@ public class WopiBlobFile : IWopiFile
 
     /// <inheritdoc/>
     public async Task<Stream> OpenReadAsync(CancellationToken cancellationToken = default)
-        => await blobClient.OpenReadAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        => await _blobClient.OpenReadAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 
     /// <inheritdoc/>
     /// <remarks>
@@ -119,12 +119,12 @@ public class WopiBlobFile : IWopiFile
     /// </remarks>
     public async Task<Stream> OpenWriteAsync(CancellationToken cancellationToken = default)
     {
-        var preserved = properties?.Metadata is { } existing
+        var preserved = _properties?.Metadata is { } existing
             ? new Dictionary<string, string>(existing, StringComparer.Ordinal)
             : new Dictionary<string, string>(StringComparer.Ordinal);
 
-        var inner = await blobClient.OpenWriteAsync(overwrite: true, cancellationToken: cancellationToken).ConfigureAwait(false);
-        return new HashingBlobWriteStream(inner, blobClient, preserved);
+        var inner = await _blobClient.OpenWriteAsync(overwrite: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return new HashingBlobWriteStream(inner, _blobClient, preserved);
     }
 
     /// <summary>Fetches blob properties (or returns null on 404) and produces a fully-populated <see cref="WopiBlobFile"/>.</summary>

--- a/src/WopiHost.Cobalt/CoauthoringSessionTracker.cs
+++ b/src/WopiHost.Cobalt/CoauthoringSessionTracker.cs
@@ -29,10 +29,10 @@ public partial class CoauthoringSessionTracker(ILogger<CoauthoringSessionTracker
     /// <param name="LastActivity">When this session was last refreshed.</param>
     public record EditorSession(string UserId, string UserName, DateTimeOffset LastActivity);
 
-    private static readonly TimeSpan SessionTimeout = TimeSpan.FromMinutes(30);
+    private static readonly TimeSpan s_sessionTimeout = TimeSpan.FromMinutes(30);
 
     // fileId → (userId → session) — static so state is shared across all CobaltHostLockingStore instances
-    private static readonly ConcurrentDictionary<string, ConcurrentDictionary<string, EditorSession>> Sessions = new();
+    private static readonly ConcurrentDictionary<string, ConcurrentDictionary<string, EditorSession>> s_sessions = new();
 
     /// <summary>
     /// Registers or refreshes a user's editing session for the given file.
@@ -40,9 +40,9 @@ public partial class CoauthoringSessionTracker(ILogger<CoauthoringSessionTracker
     /// </summary>
     public void AddOrRefreshSession(string fileId, string userId, string userName)
     {
-        var fileSessions = Sessions.GetOrAdd(fileId, _ => new ConcurrentDictionary<string, EditorSession>());
-        var added = !fileSessions.ContainsKey(userId);
-        fileSessions[userId] = new EditorSession(userId, userName, DateTimeOffset.UtcNow);
+        var files_sessions = s_sessions.GetOrAdd(fileId, _ => new ConcurrentDictionary<string, EditorSession>());
+        var added = !files_sessions.ContainsKey(userId);
+        files_sessions[userId] = new EditorSession(userId, userName, DateTimeOffset.UtcNow);
         if (added)
         {
             LogEditorJoined(_logger, userId, userName, fileId);
@@ -54,16 +54,16 @@ public partial class CoauthoringSessionTracker(ILogger<CoauthoringSessionTracker
     /// </summary>
     public void RemoveSession(string fileId, string userId)
     {
-        if (Sessions.TryGetValue(fileId, out var fileSessions))
+        if (s_sessions.TryGetValue(fileId, out var files_sessions))
         {
-            if (fileSessions.TryRemove(userId, out _))
+            if (files_sessions.TryRemove(userId, out _))
             {
                 LogEditorLeft(_logger, userId, fileId);
             }
             // Clean up empty file entries
-            if (fileSessions.IsEmpty)
+            if (files_sessions.IsEmpty)
             {
-                Sessions.TryRemove(fileId, out _);
+                s_sessions.TryRemove(fileId, out _);
             }
         }
     }
@@ -73,13 +73,13 @@ public partial class CoauthoringSessionTracker(ILogger<CoauthoringSessionTracker
     /// </summary>
     public int GetActiveEditorCount(string fileId)
     {
-        if (!Sessions.TryGetValue(fileId, out var fileSessions))
+        if (!s_sessions.TryGetValue(fileId, out var files_sessions))
         {
             return 0;
         }
 
-        var cutoff = DateTimeOffset.UtcNow - SessionTimeout;
-        return fileSessions.Values.Count(s => s.LastActivity > cutoff);
+        var cutoff = DateTimeOffset.UtcNow - s_sessionTimeout;
+        return files_sessions.Values.Count(s => s.LastActivity > cutoff);
     }
 
     /// <summary>
@@ -87,13 +87,13 @@ public partial class CoauthoringSessionTracker(ILogger<CoauthoringSessionTracker
     /// </summary>
     public bool IsAlone(string fileId, string userId)
     {
-        if (!Sessions.TryGetValue(fileId, out var fileSessions))
+        if (!s_sessions.TryGetValue(fileId, out var files_sessions))
         {
             return true;
         }
 
-        var cutoff = DateTimeOffset.UtcNow - SessionTimeout;
-        var activeEditors = fileSessions.Values
+        var cutoff = DateTimeOffset.UtcNow - s_sessionTimeout;
+        var activeEditors = files_sessions.Values
             .Where(s => s.LastActivity > cutoff)
             .ToList();
 
@@ -114,17 +114,17 @@ public partial class CoauthoringSessionTracker(ILogger<CoauthoringSessionTracker
     public EditorsTable GetEditorsTable(string fileId)
     {
         var result = new EditorsTable();
-        if (!Sessions.TryGetValue(fileId, out var fileSessions))
+        if (!s_sessions.TryGetValue(fileId, out var files_sessions))
         {
             return result;
         }
 
-        var cutoff = DateTimeOffset.UtcNow - SessionTimeout;
-        foreach (var session in fileSessions.Values.Where(s => s.LastActivity > cutoff))
+        var cutoff = DateTimeOffset.UtcNow - s_sessionTimeout;
+        foreach (var session in files_sessions.Values.Where(s => s.LastActivity > cutoff))
         {
             var clientId = DeriveClientId(session.UserId);
             result[clientId] = new EditorsTableEntryNew(
-                dtTimeout: session.LastActivity.UtcDateTime + SessionTimeout,
+                dtTimeout: session.LastActivity.UtcDateTime + s_sessionTimeout,
                 clientId: clientId,
                 userName: session.UserName,
                 userLogin: session.UserId,

--- a/src/WopiHost.Cobalt/CobaltSession.cs
+++ b/src/WopiHost.Cobalt/CobaltSession.cs
@@ -32,7 +32,7 @@ public sealed partial class CobaltProcessor : ICobaltProcessor, IDisposable
     /// <summary>How long a session may go without traffic before it is disposed.</summary>
     public static TimeSpan SessionIdleTimeout { get; } = TimeSpan.FromMinutes(60);
 
-    private static readonly TimeSpan CleanupInterval = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan s_cleanupInterval = TimeSpan.FromMinutes(5);
 
     private readonly ILogger<CobaltProcessor> _logger;
     private readonly CoauthoringSessionTracker _sessionTracker;
@@ -44,7 +44,7 @@ public sealed partial class CobaltProcessor : ICobaltProcessor, IDisposable
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _sessionTracker = new CoauthoringSessionTracker(trackerLogger ?? throw new ArgumentNullException(nameof(trackerLogger)));
-        _cleanupTimer = new Timer(_ => EvictIdleSessions(), state: null, CleanupInterval, CleanupInterval);
+        _cleanupTimer = new Timer(_ => EvictIdleSessions(), state: null, s_cleanupInterval, s_cleanupInterval);
     }
 
     /// <inheritdoc/>

--- a/src/WopiHost.Core/Controllers/FilesController.cs
+++ b/src/WopiHost.Core/Controllers/FilesController.cs
@@ -44,7 +44,7 @@ public class FilesController(
     ICobaltProcessor? cobaltProcessor = null,
     IWopiLockComparer? lockComparer = null) : ControllerBase
 {
-    private readonly IWopiLockComparer lockComparer = lockComparer ?? OrdinalWopiLockComparer.Instance;
+    private readonly IWopiLockComparer _lockComparer = lockComparer ?? OrdinalWopiLockComparer.Instance;
     private WopiHostCapabilities HostCapabilities => new()
     {
         SupportsCobalt = cobaltProcessor is not null,
@@ -168,7 +168,7 @@ public class FilesController(
         if (lockProvider is not null)
         {
             var existingLock = await lockProvider.GetLockAsync(id, cancellationToken).ConfigureAwait(false);
-            if (existingLock is not null && !lockComparer.AreEqual(existingLock.LockId, lockIdentifier))
+            if (existingLock is not null && !_lockComparer.AreEqual(existingLock.LockId, lockIdentifier))
             {
                 return new LockMismatchResult(Response, existingLock.LockId);
             }
@@ -813,7 +813,7 @@ public class FilesController(
         {
             return new LockMismatchResult(Response, reason: "File not locked");
         }
-        if (!lockComparer.AreEqual(existingLock.LockId, oldLockIdentifier))
+        if (!_lockComparer.AreEqual(existingLock.LockId, oldLockIdentifier))
         {
             return new LockMismatchResult(Response, existingLock.LockId);
         }
@@ -839,7 +839,7 @@ public class FilesController(
         {
             return new LockMismatchResult(Response, reason: "File not locked");
         }
-        if (!lockComparer.AreEqual(existingLock.LockId, newLockIdentifier))
+        if (!_lockComparer.AreEqual(existingLock.LockId, newLockIdentifier))
         {
             return new LockMismatchResult(Response, existingLock.LockId);
         }
@@ -865,7 +865,7 @@ public class FilesController(
     private async Task<IActionResult> LockOrRefresh(string newLock, WopiLockInfo existingLock, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(lockProvider);
-        if (!lockComparer.AreEqual(existingLock.LockId, newLock))
+        if (!_lockComparer.AreEqual(existingLock.LockId, newLock))
         {
             // The existing lock doesn't match the requested one (someone else might have locked the file). Return a lock mismatch error along with the current lock
             return new LockMismatchResult(Response, existingLock.LockId);

--- a/src/WopiHost.Core/Infrastructure/WopiLockAwareWritableStorageProvider.cs
+++ b/src/WopiHost.Core/Infrastructure/WopiLockAwareWritableStorageProvider.cs
@@ -28,8 +28,8 @@ namespace WopiHost.Core.Infrastructure;
 /// </remarks>
 public sealed class WopiLockAwareWritableStorageProvider : IWopiWritableStorageProvider
 {
-    private readonly IWopiWritableStorageProvider inner;
-    private readonly IWopiLockProvider lockProvider;
+    private readonly IWopiWritableStorageProvider _inner;
+    private readonly IWopiLockProvider _lockProvider;
 
     /// <summary>
     /// Creates a new lock-aware decorator over an existing writable storage provider.
@@ -38,27 +38,27 @@ public sealed class WopiLockAwareWritableStorageProvider : IWopiWritableStorageP
     /// <param name="lockProvider">the lock provider consulted before mutating writes.</param>
     public WopiLockAwareWritableStorageProvider(IWopiWritableStorageProvider inner, IWopiLockProvider lockProvider)
     {
-        this.inner = inner ?? throw new ArgumentNullException(nameof(inner));
-        this.lockProvider = lockProvider ?? throw new ArgumentNullException(nameof(lockProvider));
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _lockProvider = lockProvider ?? throw new ArgumentNullException(nameof(lockProvider));
     }
 
     /// <inheritdoc />
-    public int FileNameMaxLength => inner.FileNameMaxLength;
+    public int FileNameMaxLength => _inner.FileNameMaxLength;
 
     /// <inheritdoc />
     public Task<T?> CreateWopiChildResource<T>(string containerId, string name, CancellationToken cancellationToken = default)
         where T : class, IWopiResource
-        => inner.CreateWopiChildResource<T>(containerId, name, cancellationToken);
+        => _inner.CreateWopiChildResource<T>(containerId, name, cancellationToken);
 
     /// <inheritdoc />
     public Task<bool> CheckValidName<T>(string name, CancellationToken cancellationToken = default)
         where T : class, IWopiResource
-        => inner.CheckValidName<T>(name, cancellationToken);
+        => _inner.CheckValidName<T>(name, cancellationToken);
 
     /// <inheritdoc />
     public Task<string> GetSuggestedName<T>(string containerId, string name, CancellationToken cancellationToken = default)
         where T : class, IWopiResource
-        => inner.GetSuggestedName<T>(containerId, name, cancellationToken);
+        => _inner.GetSuggestedName<T>(containerId, name, cancellationToken);
 
     /// <inheritdoc />
     public async Task<bool> DeleteWopiResource<T>(string identifier, CancellationToken cancellationToken = default)
@@ -66,23 +66,23 @@ public sealed class WopiLockAwareWritableStorageProvider : IWopiWritableStorageP
     {
         // Inlined lock probe: pulled out of a private async helper because Infer# can't see
         // through cross-method async calls and flags the returned Task as potentially null.
-        var existing = await lockProvider.GetLockAsync(identifier, cancellationToken).ConfigureAwait(false);
+        var existing = await _lockProvider.GetLockAsync(identifier, cancellationToken).ConfigureAwait(false);
         if (existing is not null)
         {
             throw new WopiResourceLockedException(identifier, existing.LockId);
         }
-        return await inner.DeleteWopiResource<T>(identifier, cancellationToken).ConfigureAwait(false);
+        return await _inner.DeleteWopiResource<T>(identifier, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
     public async Task<bool> RenameWopiResource<T>(string identifier, string requestedName, CancellationToken cancellationToken = default)
         where T : class, IWopiResource
     {
-        var existing = await lockProvider.GetLockAsync(identifier, cancellationToken).ConfigureAwait(false);
+        var existing = await _lockProvider.GetLockAsync(identifier, cancellationToken).ConfigureAwait(false);
         if (existing is not null)
         {
             throw new WopiResourceLockedException(identifier, existing.LockId);
         }
-        return await inner.RenameWopiResource<T>(identifier, requestedName, cancellationToken).ConfigureAwait(false);
+        return await _inner.RenameWopiResource<T>(identifier, requestedName, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/WopiHost.Core/Infrastructure/WopiTelemetry.cs
+++ b/src/WopiHost.Core/Infrastructure/WopiTelemetry.cs
@@ -17,20 +17,20 @@ public static class WopiTelemetry
     /// <summary>Activity source used by the WOPI request pipeline.</summary>
     public static readonly ActivitySource ActivitySource = new(Name);
 
-    private static readonly Meter Meter = new(Name);
+    private static readonly Meter s_meter = new(Name);
 
     /// <summary>Total WOPI operations processed, tagged by <see cref="Tags.Operation"/> and <see cref="Tags.Outcome"/>.</summary>
-    public static readonly Counter<long> Requests = Meter.CreateCounter<long>(
+    public static readonly Counter<long> Requests = s_meter.CreateCounter<long>(
         "wopi.requests", unit: "{request}",
         description: "WOPI operations processed by the host, tagged by operation and outcome.");
 
     /// <summary>Lock-conflict outcomes (HTTP 409 with <c>X-WOPI-Lock</c>). Charted separately so dashboards don't need filter math.</summary>
-    public static readonly Counter<long> LockConflicts = Meter.CreateCounter<long>(
+    public static readonly Counter<long> LockConflicts = s_meter.CreateCounter<long>(
         "wopi.lock_conflicts", unit: "{conflict}",
         description: "WOPI lock conflicts (409 with X-WOPI-Lock) observed by the request pipeline.");
 
     /// <summary>WOPI proof-key signature validation failures.</summary>
-    public static readonly Counter<long> ProofValidationFailures = Meter.CreateCounter<long>(
+    public static readonly Counter<long> ProofValidationFailures = s_meter.CreateCounter<long>(
         "wopi.proof_validation_failures", unit: "{failure}",
         description: "WOPI proof-key signature validation failures.");
 

--- a/src/WopiHost.FileSystemProvider/InMemoryFileIds.cs
+++ b/src/WopiHost.FileSystemProvider/InMemoryFileIds.cs
@@ -11,12 +11,12 @@ namespace WopiHost.FileSystemProvider;
 /// <remarks>very basic in-memory for sample purposes only</remarks>
 public partial class InMemoryFileIds(ILogger<InMemoryFileIds> logger)
 {
-    private readonly Dictionary<string, string> fileIds = [];
+    private readonly Dictionary<string, string> _fileIds = [];
 
     /// <summary>
     /// Gets a value indicating whether any files have been scanned.
     /// </summary>
-    public bool WasScanned => fileIds.Count > 0;
+    public bool WasScanned => _fileIds.Count > 0;
 
     /// <summary>
     /// Gets the file identifier for the specified path.
@@ -26,7 +26,7 @@ public partial class InMemoryFileIds(ILogger<InMemoryFileIds> logger)
     /// <returns></returns>
     public bool TryGetFileId(string path, [NotNullWhen(true)] out string? fileId)
     {
-        fileId = fileIds.FirstOrDefault(x => x.Value == path).Key;
+        fileId = _fileIds.FirstOrDefault(x => x.Value == path).Key;
         return fileId != null;
     }
 
@@ -38,7 +38,7 @@ public partial class InMemoryFileIds(ILogger<InMemoryFileIds> logger)
     /// <returns></returns>
     public bool TryGetPath(string fileId, [NotNullWhen(true)] out string? path)
     {
-        return fileIds.TryGetValue(fileId, out path);
+        return _fileIds.TryGetValue(fileId, out path);
     }
 
     /// <summary>
@@ -64,7 +64,7 @@ public partial class InMemoryFileIds(ILogger<InMemoryFileIds> logger)
     public string AddFile(string path)
     {
         var id = IdFromPath(path);
-        fileIds[id] = path;
+        _fileIds[id] = path;
         return id;
     }
 
@@ -74,7 +74,7 @@ public partial class InMemoryFileIds(ILogger<InMemoryFileIds> logger)
     /// <param name="fileId"></param>
     public void RemoveId(string fileId)
     {
-        fileIds.Remove(fileId);
+        _fileIds.Remove(fileId);
     }
 
     /// <summary>
@@ -84,7 +84,7 @@ public partial class InMemoryFileIds(ILogger<InMemoryFileIds> logger)
     /// <param name="path"></param>
     public void UpdateFile(string id, string path)
     {
-        fileIds[id] = path;
+        _fileIds[id] = path;
     }
 
     /// <summary>
@@ -93,13 +93,13 @@ public partial class InMemoryFileIds(ILogger<InMemoryFileIds> logger)
     /// <param name="rootPath"></param>
     public void ScanAll(string rootPath)
     {
-        fileIds.Clear();
+        _fileIds.Clear();
 
-        fileIds[IdFromPath(rootPath)] = rootPath;
+        _fileIds[IdFromPath(rootPath)] = rootPath;
 
         foreach (var directory in Directory.EnumerateDirectories(rootPath, "*", SearchOption.AllDirectories))
         {
-            fileIds[IdFromPath(directory)] = directory;
+            _fileIds[IdFromPath(directory)] = directory;
         }
 
         foreach (var file in Directory.EnumerateFiles(rootPath, "*", SearchOption.AllDirectories))
@@ -107,10 +107,10 @@ public partial class InMemoryFileIds(ILogger<InMemoryFileIds> logger)
             var newId = file.EndsWith("test.wopitest", StringComparison.OrdinalIgnoreCase)
                 ? "WOPITEST"
                 : IdFromPath(file);
-            fileIds[newId] = file;
+            _fileIds[newId] = file;
         }
 
-        LogScannedItems(logger, fileIds.Count);
+        LogScannedItems(logger, _fileIds.Count);
     }
 
     /// <summary>

--- a/src/WopiHost.FileSystemProvider/WopiFile.cs
+++ b/src/WopiHost.FileSystemProvider/WopiFile.cs
@@ -14,38 +14,38 @@ namespace WopiHost.FileSystemProvider;
 /// <param name="fileIdentifier">Identifier of a file.</param>
 public class WopiFile(string filePath, string fileIdentifier) : IWopiFile
 {
-    private readonly FileInfo fileInfo = new(filePath);
-    private readonly FileVersionInfo fileVersionInfo = FileVersionInfo.GetVersionInfo(filePath);
+    private readonly FileInfo _fileInfo = new(filePath);
+    private readonly FileVersionInfo _fileVersionInfo = FileVersionInfo.GetVersionInfo(filePath);
 
     /// <inheritdoc/>
     public string Identifier { get; } = fileIdentifier;
 
     /// <inheritdoc />
-    public bool Exists => fileInfo.Exists;
+    public bool Exists => _fileInfo.Exists;
 
     /// <inheritdoc/>
-    public string Extension => fileInfo.Extension.TrimStart('.');
+    public string Extension => _fileInfo.Extension.TrimStart('.');
 
     /// <inheritdoc/>
-    public string? Version => fileVersionInfo.FileVersion ?? fileInfo.LastWriteTimeUtc.Ticks.ToString(CultureInfo.InvariantCulture);
+    public string? Version => _fileVersionInfo.FileVersion ?? _fileInfo.LastWriteTimeUtc.Ticks.ToString(CultureInfo.InvariantCulture);
 
     /// <inheritdoc/>
     public ReadOnlyMemory<byte>? Checksum => null;
 
     /// <inheritdoc/>
-    public long Length => fileInfo.Length;
+    public long Length => _fileInfo.Length;
 
     /// <inheritdoc/>
-    public string Name => Path.GetFileNameWithoutExtension(fileInfo.Name);
+    public string Name => Path.GetFileNameWithoutExtension(_fileInfo.Name);
 
     /// <inheritdoc/>
-    public DateTime LastWriteTimeUtc => fileInfo.LastWriteTimeUtc;
+    public DateTime LastWriteTimeUtc => _fileInfo.LastWriteTimeUtc;
 
     /// <inheritdoc/>
-    public Task<Stream> OpenReadAsync(CancellationToken cancellationToken = default) => Task.FromResult<Stream>(fileInfo.OpenRead());
+    public Task<Stream> OpenReadAsync(CancellationToken cancellationToken = default) => Task.FromResult<Stream>(_fileInfo.OpenRead());
 
     /// <inheritdoc/>
-    public Task<Stream> OpenWriteAsync(CancellationToken cancellationToken = default) => Task.FromResult<Stream>(fileInfo.Open(FileMode.Truncate));
+    public Task<Stream> OpenWriteAsync(CancellationToken cancellationToken = default) => Task.FromResult<Stream>(_fileInfo.Open(FileMode.Truncate));
 
     /// <summary>
     /// A string that uniquely identifies the owner of the file.
@@ -61,11 +61,11 @@ public class WopiFile(string filePath, string fileIdentifier) : IWopiFile
         {
             if (OperatingSystem.IsWindows())
             {
-                return fileInfo.GetAccessControl().GetOwner(typeof(NTAccount))?.ToString() ?? string.Empty;
+                return _fileInfo.GetAccessControl().GetOwner(typeof(NTAccount))?.ToString() ?? string.Empty;
             }
             if (OperatingSystem.IsLinux())
             {
-                return LinuxFileOwner.GetOwnerName(fileInfo.FullName);
+                return LinuxFileOwner.GetOwnerName(_fileInfo.FullName);
             }
             throw new PlatformNotSupportedException(
                 "WopiFile.Owner is only supported on Windows and Linux.");

--- a/src/WopiHost.FileSystemProvider/WopiFileSystemProvider.cs
+++ b/src/WopiHost.FileSystemProvider/WopiFileSystemProvider.cs
@@ -12,9 +12,9 @@ namespace WopiHost.FileSystemProvider;
 /// </summary>
 public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritableStorageProvider
 {
-    private readonly InMemoryFileIds fileIds;
-    private readonly string wopiAbsolutePath;
-    private readonly ILogger<WopiFileSystemProvider> logger;
+    private readonly InMemoryFileIds _fileIds;
+    private readonly string _wopiAbsolutePath;
+    private readonly ILogger<WopiFileSystemProvider> _logger;
 
     /// <inheritdoc />
     public IWopiFolder RootContainer { get; }
@@ -33,33 +33,33 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         ILogger<WopiFileSystemProvider> logger)
     {
         ArgumentNullException.ThrowIfNull(configuration);
-        this.fileIds = fileIds ?? throw new ArgumentNullException(nameof(fileIds));
-        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _fileIds = fileIds ?? throw new ArgumentNullException(nameof(fileIds));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         var fileSystemProviderOptions = configuration.GetSection(WopiConfigurationSections.STORAGE_OPTIONS)?
             .Get<WopiFileSystemProviderOptions>() ?? throw new ArgumentNullException(nameof(configuration));
 
         var wopiRootPath = fileSystemProviderOptions.RootPath;
-        wopiAbsolutePath = Path.IsPathRooted(wopiRootPath)
+        _wopiAbsolutePath = Path.IsPathRooted(wopiRootPath)
             ? wopiRootPath
             : new DirectoryInfo(Path.Combine(env.ContentRootPath, wopiRootPath)).FullName;
 
-        if (!fileIds.WasScanned)
+        if (!_fileIds.WasScanned)
         {
-            fileIds.ScanAll(wopiAbsolutePath);
+            _fileIds.ScanAll(_wopiAbsolutePath);
         }
-        if (!fileIds.TryGetFileId(wopiAbsolutePath, out var rootId))
+        if (!_fileIds.TryGetFileId(_wopiAbsolutePath, out var rootId))
         {
             throw new InvalidOperationException("Root directory not found.");
         }
-        RootContainer = new WopiFolder(wopiAbsolutePath, rootId);
-        LogProviderInitialized(this.logger, wopiAbsolutePath);
+        RootContainer = new WopiFolder(_wopiAbsolutePath, rootId);
+        LogProviderInitialized(_logger, _wopiAbsolutePath);
     }
 
     /// <inheritdoc/>
     public Task<T?> GetWopiResource<T>(string identifier, CancellationToken cancellationToken = default)
         where T : class, IWopiResource
     {
-        if (fileIds.TryGetPath(identifier, out var fullPath))
+        if (_fileIds.TryGetPath(identifier, out var fullPath))
         {
             return typeof(T) switch
             {
@@ -78,10 +78,10 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(identifier);
-        var folderPath = fileIds.GetPath(identifier)
+        var folderPath = _fileIds.GetPath(identifier)
             ?? throw new DirectoryNotFoundException($"Directory '{identifier}' not found");
 
-        var absolutePath = Path.Combine(wopiAbsolutePath, folderPath);
+        var absolutePath = Path.Combine(_wopiAbsolutePath, folderPath);
 
         // Push the extension filter into the OS-level enumeration: one Directory.EnumerateFiles
         // call per requested extension, each with its own glob. Distinct extensions produce
@@ -99,7 +99,7 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         foreach (var path in enumeration)
         {
             var filePath = Path.Combine(folderPath, Path.GetFileName(path));
-            if (fileIds.TryGetFileId(filePath, out var fileId))
+            if (_fileIds.TryGetFileId(filePath, out var fileId))
             {
                 var result = await GetWopiResource<IWopiFile>(fileId, cancellationToken).ConfigureAwait(false)
                     ?? throw new FileNotFoundException($"File '{fileId}' not found");
@@ -114,12 +114,12 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(identifier);
-        var folderPath = fileIds.GetPath(identifier)
+        var folderPath = _fileIds.GetPath(identifier)
             ?? throw new DirectoryNotFoundException($"Directory '{identifier}' not found");
 
-        foreach (var directory in Directory.GetDirectories(Path.Combine(wopiAbsolutePath, folderPath)))
+        foreach (var directory in Directory.GetDirectories(Path.Combine(_wopiAbsolutePath, folderPath)))
         {
-            if (fileIds.TryGetFileId(directory, out var folderId))
+            if (_fileIds.TryGetFileId(directory, out var folderId))
             {
                 var result = await GetWopiResource<IWopiFolder>(folderId, cancellationToken).ConfigureAwait(false)
                     ?? throw new DirectoryNotFoundException($"Directory '{folderId}' not found");
@@ -165,11 +165,11 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         string name,
         CancellationToken cancellationToken = default) where T : class, IWopiResource
     {
-        if (!fileIds.TryGetPath(containerId, out var dirPath))
+        if (!_fileIds.TryGetPath(containerId, out var dirPath))
         {
             throw new DirectoryNotFoundException($"Directory '{containerId}' not found.");
         }
-        if (!fileIds.TryGetFileId(Path.Combine(dirPath, name), out var nameId))
+        if (!_fileIds.TryGetFileId(Path.Combine(dirPath, name), out var nameId))
         {
             return default;
         }
@@ -213,7 +213,7 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         {
             throw new ArgumentException(message: "Invalid characters in the name.", paramName: nameof(name));
         }
-        if (!fileIds.TryGetPath(containerId, out var fullPath))
+        if (!_fileIds.TryGetPath(containerId, out var fullPath))
         {
             throw new DirectoryNotFoundException($"Directory '{containerId}' not found.");
         }
@@ -281,7 +281,7 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         string name,
         CancellationToken cancellationToken)
     {
-        if (!fileIds.TryGetPath(containerId, out var fullPath))
+        if (!_fileIds.TryGetPath(containerId, out var fullPath))
         {
             throw new DirectoryNotFoundException($"Directory '{containerId}' not found.");
         }
@@ -297,8 +297,8 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
             // Create a 0-byte file
         }
 
-        var newFileId = fileIds.AddFile(newPath);
-        LogFileCreated(logger, newFileId, newPath);
+        var newFileId = _fileIds.AddFile(newPath);
+        LogFileCreated(_logger, newFileId, newPath);
         return GetWopiResource<IWopiFile>(newFileId, cancellationToken);
     }
 
@@ -307,7 +307,7 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         string name,
         CancellationToken cancellationToken)
     {
-        if (!fileIds.TryGetPath(containerId, out var fullPath))
+        if (!_fileIds.TryGetPath(containerId, out var fullPath))
         {
             throw new DirectoryNotFoundException($"Directory '{containerId}' not found.");
         }
@@ -322,8 +322,8 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         {
             dirInfo.Create();
         }
-        var newId = fileIds.AddFile(dirInfo.FullName);
-        LogFolderCreated(logger, newId, dirInfo.FullName);
+        var newId = _fileIds.AddFile(dirInfo.FullName);
+        LogFolderCreated(_logger, newId, dirInfo.FullName);
         return GetWopiResource<IWopiFolder>(newId, cancellationToken);
     }
 
@@ -342,7 +342,7 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
 
     private bool DeleteWopiContainer(string identifier)
     {
-        if (!fileIds.TryGetPath(identifier, out var fullPath))
+        if (!_fileIds.TryGetPath(identifier, out var fullPath))
         {
             throw new DirectoryNotFoundException($"Directory '{identifier}' not found.");
         }
@@ -355,14 +355,14 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
             throw new InvalidOperationException($"Directory '{fullPath}' is not empty.");
         }
         Directory.Delete(fullPath, true);
-        fileIds.RemoveId(identifier);
-        LogFolderDeleted(logger, identifier, fullPath);
+        _fileIds.RemoveId(identifier);
+        LogFolderDeleted(_logger, identifier, fullPath);
         return true;
     }
 
     private bool DeleteWopiFile(string identifier)
     {
-        if (!fileIds.TryGetPath(identifier, out var fullPath))
+        if (!_fileIds.TryGetPath(identifier, out var fullPath))
         {
             throw new FileNotFoundException($"File '{identifier}' not found.");
         }
@@ -371,8 +371,8 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
             throw new FileNotFoundException($"File '{fullPath}' not found");
         }
         File.Delete(fullPath);
-        fileIds.RemoveId(identifier);
-        LogFileDeleted(logger, identifier, fullPath);
+        _fileIds.RemoveId(identifier);
+        LogFileDeleted(_logger, identifier, fullPath);
         return true;
     }
 
@@ -387,7 +387,7 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
 
         if (typeof(T) == typeof(IWopiFile))
         {
-            if (!fileIds.TryGetPath(identifier, out var fullPath))
+            if (!_fileIds.TryGetPath(identifier, out var fullPath))
             {
                 throw new FileNotFoundException($"File '{identifier}' not found.");
             }
@@ -399,12 +399,12 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
                 throw new InvalidOperationException($"Target File '{newPath}' already exists.");
             }
             File.Move(fullPath, newPath);
-            fileIds.UpdateFile(identifier, newPath);
-            LogFileRenamed(logger, identifier, fullPath, newPath);
+            _fileIds.UpdateFile(identifier, newPath);
+            LogFileRenamed(_logger, identifier, fullPath, newPath);
         }
         else if (typeof(T) == typeof(IWopiFolder))
         {
-            if (!fileIds.TryGetPath(identifier, out var fullPath))
+            if (!_fileIds.TryGetPath(identifier, out var fullPath))
             {
                 throw new DirectoryNotFoundException($"Directory '{identifier}' not found.");
             }
@@ -416,8 +416,8 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
                 throw new InvalidOperationException($"Target Directory '{newPath}' already exists.");
             }
             Directory.Move(fullPath, newPath);
-            fileIds.UpdateFile(identifier, newPath);
-            LogFolderRenamed(logger, identifier, fullPath, newPath);
+            _fileIds.UpdateFile(identifier, newPath);
+            LogFolderRenamed(_logger, identifier, fullPath, newPath);
         }
         else
         {
@@ -430,13 +430,13 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
 
     private string GetFileParentIdentifier(string identifier)
     {
-        if (!fileIds.TryGetPath(identifier, out var filePath))
+        if (!_fileIds.TryGetPath(identifier, out var filePath))
         {
             throw new FileNotFoundException($"File '{identifier}' not found");
         }
         var parentPath = Path.GetDirectoryName(filePath)
             ?? throw new DirectoryNotFoundException("Parent directory not found");
-        if (!fileIds.TryGetFileId(parentPath, out var parentFolderId))
+        if (!_fileIds.TryGetFileId(parentPath, out var parentFolderId))
         {
             throw new DirectoryNotFoundException("Parent directory not found");
         }
@@ -445,14 +445,14 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
 
     private string GetFolderParentIdentifier(string identifier)
     {
-        if (!fileIds.TryGetPath(identifier, out var folderPath))
+        if (!_fileIds.TryGetPath(identifier, out var folderPath))
         {
             throw new DirectoryNotFoundException($"Folder '{identifier}' not found");
         }
         var parentPath = Path.GetDirectoryName(folderPath)
             ?? throw new DirectoryNotFoundException("Parent directory not found");
 
-        if (!fileIds.TryGetFileId(parentPath, out var parentFolderId))
+        if (!_fileIds.TryGetFileId(parentPath, out var parentFolderId))
         {
             throw new DirectoryNotFoundException("Parent directory not found");
         }

--- a/src/WopiHost.FileSystemProvider/WopiFolder.cs
+++ b/src/WopiHost.FileSystemProvider/WopiFolder.cs
@@ -11,10 +11,10 @@ namespace WopiHost.FileSystemProvider;
 public class WopiFolder(string path, string folderIdentifier) : IWopiFolder
 {
     /// <inheritdoc/>
-    private readonly DirectoryInfo FolderInfo = new(path);
+    private readonly DirectoryInfo _folderInfo = new(path);
 
 	/// <inheritdoc/>
-	public string Name => FolderInfo.Name;
+	public string Name => _folderInfo.Name;
 
     /// <inheritdoc/>
     public string Identifier { get; } = folderIdentifier;

--- a/src/WopiHost.MemoryLockProvider/MemoryLockProvider.cs
+++ b/src/WopiHost.MemoryLockProvider/MemoryLockProvider.cs
@@ -17,11 +17,11 @@ public partial class MemoryLockProvider : IWopiLockProvider
     /// <summary>
     /// keyed with fileId
     /// </summary>
-    private static readonly ConcurrentDictionary<string, WopiLockInfo> locks = [];
+    private static readonly ConcurrentDictionary<string, WopiLockInfo> s_locks = [];
 
-    private readonly ILogger<MemoryLockProvider> logger;
-    private readonly IWopiLockComparer lockComparer;
-    private readonly TimeProvider timeProvider;
+    private readonly ILogger<MemoryLockProvider> _logger;
+    private readonly IWopiLockComparer _lockComparer;
+    private readonly TimeProvider _timeProvider;
 
     /// <summary>
     /// Creates the provider.
@@ -42,20 +42,20 @@ public partial class MemoryLockProvider : IWopiLockProvider
         TimeProvider? timeProvider = null,
         IWopiLockComparer? lockComparer = null)
     {
-        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        this.timeProvider = timeProvider ?? TimeProvider.System;
-        this.lockComparer = lockComparer ?? OrdinalWopiLockComparer.Instance;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _lockComparer = lockComparer ?? OrdinalWopiLockComparer.Instance;
     }
 
     /// <inheritdoc />
     public Task<WopiLockInfo?> GetLockAsync(string fileId, CancellationToken cancellationToken = default)
     {
-        if (locks.TryGetValue(fileId, out var lockInfo))
+        if (s_locks.TryGetValue(fileId, out var lockInfo))
         {
-            if (lockInfo.IsExpiredAt(timeProvider.GetUtcNow()))
+            if (lockInfo.IsExpiredAt(_timeProvider.GetUtcNow()))
             {
-                _ = locks.TryRemove(fileId, out _);
-                LogLockExpired(logger, fileId, lockInfo.LockId);
+                _ = s_locks.TryRemove(fileId, out _);
+                LogLockExpired(_logger, fileId, lockInfo.LockId);
                 return Task.FromResult<WopiLockInfo?>(null);
             }
             return Task.FromResult<WopiLockInfo?>(lockInfo);
@@ -70,16 +70,16 @@ public partial class MemoryLockProvider : IWopiLockProvider
         {
             FileId = fileId,
             LockId = lockId,
-            DateCreated = timeProvider.GetUtcNow(),
+            DateCreated = _timeProvider.GetUtcNow(),
         };
-        if (locks.TryAdd(fileId, lockInfo))
+        if (s_locks.TryAdd(fileId, lockInfo))
         {
-            LogLockAcquired(logger, fileId, lockId);
+            LogLockAcquired(_logger, fileId, lockId);
             return Task.FromResult<WopiLockInfo?>(lockInfo);
         }
 
-        var existingLockId = locks.TryGetValue(fileId, out var existing) ? existing.LockId : null;
-        LogLockAddRejected(logger, fileId, lockId, existingLockId);
+        var existingLockId = s_locks.TryGetValue(fileId, out var existing) ? existing.LockId : null;
+        LogLockAddRejected(_logger, fileId, lockId, existingLockId);
         return Task.FromResult<WopiLockInfo?>(null);
     }
 
@@ -93,17 +93,17 @@ public partial class MemoryLockProvider : IWopiLockProvider
         }
         var updated = existing with
         {
-            DateCreated = timeProvider.GetUtcNow(),
+            DateCreated = _timeProvider.GetUtcNow(),
         };
-        return locks.TryUpdate(fileId, updated, existing);
+        return s_locks.TryUpdate(fileId, updated, existing);
     }
 
     /// <inheritdoc />
     public Task<bool> RemoveLockAsync(string fileId, CancellationToken cancellationToken = default)
     {
-        if (locks.TryRemove(fileId, out var removed))
+        if (s_locks.TryRemove(fileId, out var removed))
         {
-            LogLockRemoved(logger, fileId, removed.LockId);
+            LogLockRemoved(_logger, fileId, removed.LockId);
             return Task.FromResult(true);
         }
         return Task.FromResult(false);
@@ -112,29 +112,29 @@ public partial class MemoryLockProvider : IWopiLockProvider
     /// <inheritdoc />
     public Task<bool> TryUnlockAndRelockAsync(string fileId, string newLockId, string expectedExistingLockId, CancellationToken cancellationToken = default)
     {
-        if (!locks.TryGetValue(fileId, out var existing))
+        if (!s_locks.TryGetValue(fileId, out var existing))
         {
             return Task.FromResult(false);
         }
-        if (existing.IsExpiredAt(timeProvider.GetUtcNow()))
+        if (existing.IsExpiredAt(_timeProvider.GetUtcNow()))
         {
             // Best-effort eviction; behave as if no lock exists.
-            _ = locks.TryRemove(fileId, out _);
-            LogLockExpired(logger, fileId, existing.LockId);
+            _ = s_locks.TryRemove(fileId, out _);
+            LogLockExpired(_logger, fileId, existing.LockId);
             return Task.FromResult(false);
         }
-        if (!lockComparer.AreEqual(existing.LockId, expectedExistingLockId))
+        if (!_lockComparer.AreEqual(existing.LockId, expectedExistingLockId))
         {
             return Task.FromResult(false);
         }
         var updated = existing with
         {
-            DateCreated = timeProvider.GetUtcNow(),
+            DateCreated = _timeProvider.GetUtcNow(),
             LockId = newLockId,
         };
         // TryUpdate is the atomic CAS: succeeds only if the dictionary's current value still
         // equals the snapshot we read. Any concurrent mutation (refresh, swap, removal) makes
         // the comparand stale and the swap returns false.
-        return Task.FromResult(locks.TryUpdate(fileId, updated, existing));
+        return Task.FromResult(s_locks.TryUpdate(fileId, updated, existing));
     }
 }

--- a/test/WopiHost.AzureLockProvider.Tests/AzuriteFixture.cs
+++ b/test/WopiHost.AzureLockProvider.Tests/AzuriteFixture.cs
@@ -14,17 +14,17 @@ public sealed class AzuriteFixture : IAsyncLifetime
     /// </summary>
     public const BlobClientOptions.ServiceVersion AzuriteSupportedVersion = BlobClientOptions.ServiceVersion.V2025_11_05;
 
-    private readonly AzuriteContainer container = new AzuriteBuilder(AzuriteImage)
+    private readonly AzuriteContainer _container = new AzuriteBuilder(AzuriteImage)
         .Build();
 
-    public string ConnectionString => container.GetConnectionString();
+    public string ConnectionString => _container.GetConnectionString();
 
     public BlobServiceClient CreateBlobServiceClient()
         => new(ConnectionString, new BlobClientOptions(AzuriteSupportedVersion));
 
-    public ValueTask InitializeAsync() => new(container.StartAsync());
+    public ValueTask InitializeAsync() => new(_container.StartAsync());
 
-    public ValueTask DisposeAsync() => container.DisposeAsync();
+    public ValueTask DisposeAsync() => _container.DisposeAsync();
 }
 
 [CollectionDefinition(Name)]

--- a/test/WopiHost.AzureStorageProvider.Tests/AzuriteFixture.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/AzuriteFixture.cs
@@ -5,7 +5,7 @@ using Xunit;
 namespace WopiHost.AzureStorageProvider.Tests;
 
 /// <summary>
-/// xUnit class fixture that boots an Azurite container once per test class. Tests build clients via
+/// xUnit class fixture that boots an Azurite _container once per test class. Tests build clients via
 /// <see cref="CreateBlobServiceClient"/>. The image tag is pinned to a recent Azurite that supports
 /// the API version the bundled <c>Azure.Storage.Blobs</c> sends — Testcontainers.Azurite's default
 /// image (3.28) lags behind the SDK and is rejected by version-check.
@@ -22,17 +22,17 @@ public sealed class AzuriteFixture : IAsyncLifetime
     /// </summary>
     public const BlobClientOptions.ServiceVersion AzuriteSupportedVersion = BlobClientOptions.ServiceVersion.V2025_11_05;
 
-    private readonly AzuriteContainer container = new AzuriteBuilder(AzuriteImage)
+    private readonly AzuriteContainer _container = new AzuriteBuilder(AzuriteImage)
         .Build();
 
-    public string ConnectionString => container.GetConnectionString();
+    public string ConnectionString => _container.GetConnectionString();
 
     public BlobServiceClient CreateBlobServiceClient()
         => new(ConnectionString, new BlobClientOptions(AzuriteSupportedVersion));
 
-    public ValueTask InitializeAsync() => new(container.StartAsync());
+    public ValueTask InitializeAsync() => new(_container.StartAsync());
 
-    public ValueTask DisposeAsync() => container.DisposeAsync();
+    public ValueTask DisposeAsync() => _container.DisposeAsync();
 }
 
 [CollectionDefinition(Name)]

--- a/test/WopiHost.Core.Tests/Abstractions/WopiLockComparerTests.cs
+++ b/test/WopiHost.Core.Tests/Abstractions/WopiLockComparerTests.cs
@@ -6,29 +6,29 @@ public class WopiLockComparerTests
 {
     public class Ordinal
     {
-        private readonly OrdinalWopiLockComparer sut = new();
+        private readonly OrdinalWopiLockComparer _sut = new();
 
         [Fact]
         public void IdenticalStrings_AreEqual()
-            => Assert.True(sut.AreEqual("abc", "abc"));
+            => Assert.True(_sut.AreEqual("abc", "abc"));
 
         [Fact]
         public void DifferentStrings_AreNotEqual()
-            => Assert.False(sut.AreEqual("abc", "abd"));
+            => Assert.False(_sut.AreEqual("abc", "abd"));
 
         [Fact]
         public void CaseDiffers_AreNotEqual()
-            => Assert.False(sut.AreEqual("abc", "ABC"));
+            => Assert.False(_sut.AreEqual("abc", "ABC"));
 
         [Fact]
         public void BothNull_AreEqual()
-            => Assert.True(sut.AreEqual(null, null));
+            => Assert.True(_sut.AreEqual(null, null));
 
         [Fact]
         public void OneNull_AreNotEqual()
         {
-            Assert.False(sut.AreEqual(null, "abc"));
-            Assert.False(sut.AreEqual("abc", null));
+            Assert.False(_sut.AreEqual(null, "abc"));
+            Assert.False(_sut.AreEqual("abc", null));
         }
 
         [Fact]
@@ -38,11 +38,11 @@ public class WopiLockComparerTests
 
     public class JsonShaped
     {
-        private readonly JsonShapedWopiLockComparer sut = new();
+        private readonly JsonShapedWopiLockComparer _sut = new();
 
         [Fact]
         public void IdenticalStrings_AreEqual()
-            => Assert.True(sut.AreEqual("""{"S":"abc","F":1}""", """{"S":"abc","F":1}"""));
+            => Assert.True(_sut.AreEqual("""{"S":"abc","F":1}""", """{"S":"abc","F":1}"""));
 
         [Fact]
         public void SameSField_DifferentExtraProperties_AreEqual()
@@ -52,7 +52,7 @@ public class WopiLockComparerTests
             var stored = """{"S":"abc-123","F":4}""";
             var fromClient = """{"S":"abc-123","F":4,"V":1}""";
 
-            Assert.True(sut.AreEqual(stored, fromClient));
+            Assert.True(_sut.AreEqual(stored, fromClient));
         }
 
         [Fact]
@@ -61,21 +61,21 @@ public class WopiLockComparerTests
             var stored = """{"S":"abc-123","F":4}""";
             var fromClient = """{"S":"different-session","F":4}""";
 
-            Assert.False(sut.AreEqual(stored, fromClient));
+            Assert.False(_sut.AreEqual(stored, fromClient));
         }
 
         [Fact]
         public void NonJsonInputs_FallBackToOrdinal()
         {
-            Assert.True(sut.AreEqual("plain-token", "plain-token"));
-            Assert.False(sut.AreEqual("plain-token", "different"));
+            Assert.True(_sut.AreEqual("plain-token", "plain-token"));
+            Assert.False(_sut.AreEqual("plain-token", "different"));
         }
 
         [Fact]
         public void OneJsonOneNonJson_AreNotEqual()
         {
             // Asymmetric input: don't accidentally call them equivalent.
-            Assert.False(sut.AreEqual("""{"S":"abc"}""", "abc"));
+            Assert.False(_sut.AreEqual("""{"S":"abc"}""", "abc"));
         }
 
         [Fact]
@@ -83,16 +83,16 @@ public class WopiLockComparerTests
         {
             // Looks like JSON but isn't parseable — must not throw.
             var malformed = "{not really json";
-            Assert.True(sut.AreEqual(malformed, malformed));
-            Assert.False(sut.AreEqual(malformed, "{also broken"));
+            Assert.True(_sut.AreEqual(malformed, malformed));
+            Assert.False(_sut.AreEqual(malformed, "{also broken"));
         }
 
         [Fact]
         public void JsonWithoutSField_FallsBackToOrdinal()
         {
             var noS = """{"F":1}""";
-            Assert.True(sut.AreEqual(noS, noS));
-            Assert.False(sut.AreEqual(noS, """{"F":2}"""));
+            Assert.True(_sut.AreEqual(noS, noS));
+            Assert.False(_sut.AreEqual(noS, """{"F":2}"""));
         }
     }
 }

--- a/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
@@ -16,32 +16,32 @@ namespace WopiHost.Core.Tests.Controllers;
 
 public class ContainersControllerTests
 {
-    private readonly Mock<IWopiStorageProvider> storageProviderMock;
-    private readonly Mock<IWopiLockProvider> lockProviderMock;
-    private readonly Mock<IWopiWritableStorageProvider> writableStorageProviderMock;
-    private readonly Mock<IWopiPermissionProvider> permissionProviderMock;
-    private readonly Mock<IWopiAccessTokenService> accessTokenServiceMock;
-    private readonly Mock<IUrlHelper> urlMock;
+    private readonly Mock<IWopiStorageProvider> _storageProviderMock;
+    private readonly Mock<IWopiLockProvider> _lockProviderMock;
+    private readonly Mock<IWopiWritableStorageProvider> _writableStorageProviderMock;
+    private readonly Mock<IWopiPermissionProvider> _permissionProviderMock;
+    private readonly Mock<IWopiAccessTokenService> _accessTokenServiceMock;
+    private readonly Mock<IUrlHelper> _urlMock;
     private readonly ContainersController _controller;
 
     public ContainersControllerTests()
     {
-        storageProviderMock = new Mock<IWopiStorageProvider>();
-        lockProviderMock = new Mock<IWopiLockProvider>();
-        writableStorageProviderMock = new Mock<IWopiWritableStorageProvider>();
-        permissionProviderMock = new Mock<IWopiPermissionProvider>();
-        permissionProviderMock
+        _storageProviderMock = new Mock<IWopiStorageProvider>();
+        _lockProviderMock = new Mock<IWopiLockProvider>();
+        _writableStorageProviderMock = new Mock<IWopiWritableStorageProvider>();
+        _permissionProviderMock = new Mock<IWopiPermissionProvider>();
+        _permissionProviderMock
             .Setup(_ => _.GetContainerPermissionsAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<IWopiFolder>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(WopiContainerPermissions.UserCanCreateChildContainer | WopiContainerPermissions.UserCanCreateChildFile | WopiContainerPermissions.UserCanDelete | WopiContainerPermissions.UserCanRename);
-        accessTokenServiceMock = new Mock<IWopiAccessTokenService>();
-        accessTokenServiceMock
+        _accessTokenServiceMock = new Mock<IWopiAccessTokenService>();
+        _accessTokenServiceMock
             .Setup(s => s.IssueAsync(It.IsAny<WopiAccessTokenRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new WopiAccessToken("FRESH-TOKEN", DateTimeOffset.UtcNow.AddMinutes(10)));
-        urlMock = new Mock<IUrlHelper>();
-        urlMock
+        _urlMock = new Mock<IUrlHelper>();
+        _urlMock
             .Setup(_ => _.RouteUrl(It.IsAny<UrlRouteContext>()))
             .Returns("https://localhost");
-        urlMock
+        _urlMock
             .Setup(_ => _.ActionContext)
             .Returns(new ActionContext
             {
@@ -51,16 +51,16 @@ public class ContainersControllerTests
                 }
             });
         _controller = new ContainersController(
-            storageProviderMock.Object,
-            lockProviderMock.Object,
-            writableStorageProviderMock.Object)
+            _storageProviderMock.Object,
+            _lockProviderMock.Object,
+            _writableStorageProviderMock.Object)
         {
-            Url = urlMock.Object,
+            Url = _urlMock.Object,
             ControllerContext = new ControllerContext
             {
                 HttpContext = new DefaultHttpContext()
                 {
-                    ServiceScopeFactory = TestUtils.CreateServiceScope(permissionProviderMock.Object),
+                    ServiceScopeFactory = TestUtils.CreateServiceScope(_permissionProviderMock.Object),
                     User = new ClaimsPrincipal(new ClaimsIdentity(
                     [
                         new Claim(ClaimTypes.NameIdentifier, "alice"),
@@ -75,7 +75,7 @@ public class ContainersControllerTests
     [Fact]
     public async Task CheckContainerInfo_ReturnsNotFound_WhenContainerDoesNotExist()
     {
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
 
         var result = await _controller.CheckContainerInfo("nonexistent");
 
@@ -87,7 +87,7 @@ public class ContainersControllerTests
     {
         var container = new Mock<IWopiFolder>();
         container.Setup(c => c.Name).Returns("TestContainer");
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => container.Object);
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => container.Object);
 
         var result = await _controller.CheckContainerInfo("existing");
 
@@ -99,7 +99,7 @@ public class ContainersControllerTests
     [Fact]
     public async Task CreateChildContainer_ReturnsNotFound_WhenContainerDoesNotExist()
     {
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
 
         var result = await _controller.CreateChildContainer("nonexistent");
 
@@ -110,7 +110,7 @@ public class ContainersControllerTests
     public async Task CreateChildContainer_ReturnsNotImplemented_WhenBothHeadersArePresent()
     {
         var containerId = "existing-container";
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
 
         var result = await _controller.CreateChildContainer(containerId, UtfString.FromDecoded("suggestedTarget"), UtfString.FromDecoded("relativeTarget"));
 
@@ -121,7 +121,7 @@ public class ContainersControllerTests
     public async Task CreateChildContainer_ReturnsNotImplemented_WhenBothHeadersAreMissing()
     {
         var containerId = "existing-container";
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
 
         var result = await _controller.CreateChildContainer(containerId);
 
@@ -132,8 +132,8 @@ public class ContainersControllerTests
     public async Task CreateChildContainer_ReturnsBadRequest_WhenNameIsInvalid()
     {
         var containerId = "existing-container";
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
-        writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
+        _writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
 
         var result = await _controller.CreateChildContainer(containerId, UtfString.FromDecoded("suggestedTarget"));
 
@@ -144,9 +144,9 @@ public class ContainersControllerTests
     public async Task CreateChildContainer_ReturnsConflict_WhenContainerAlreadyExists()
     {
         var containerId = "existing-container";
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
-        writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
-        storageProviderMock.Setup(sp => sp.GetWopiResourceByName<IWopiFolder>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
+        _writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _storageProviderMock.Setup(sp => sp.GetWopiResourceByName<IWopiFolder>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
 
         var result = await _controller.CreateChildContainer(containerId, relativeTarget: UtfString.FromDecoded("relativeTarget"));
 
@@ -157,9 +157,9 @@ public class ContainersControllerTests
     public async Task CreateChildContainer_ReturnsInternalServerError_WhenNewFolderIsNull()
     {
         var containerId = "existing-container";
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
-        writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
-        storageProviderMock.Setup(sp => sp.GetWopiResourceByName<IWopiFolder>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
+        _writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _storageProviderMock.Setup(sp => sp.GetWopiResourceByName<IWopiFolder>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
 
         var result = await _controller.CreateChildContainer(containerId, relativeTarget: UtfString.FromDecoded("relativeTarget"));
 
@@ -173,10 +173,10 @@ public class ContainersControllerTests
         var container = new Mock<IWopiFolder>();
         container.Setup(c => c.Name).Returns("container");
         container.Setup(c => c.Identifier).Returns(containerId);
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(container.Object);
-        writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
-        storageProviderMock.Setup(sp => sp.GetWopiResourceByName<IWopiFolder>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
-        writableStorageProviderMock.Setup(_ => _.CreateWopiChildResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(container.Object);
+        _writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _storageProviderMock.Setup(sp => sp.GetWopiResourceByName<IWopiFolder>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
+        _writableStorageProviderMock.Setup(_ => _.CreateWopiChildResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(container.Object);
 
         var result = await _controller.CreateChildContainer(containerId, relativeTarget: UtfString.FromDecoded("relativeTarget"));
@@ -192,10 +192,10 @@ public class ContainersControllerTests
         var container = new Mock<IWopiFolder>();
         container.Setup(c => c.Name).Returns("container");
         container.Setup(c => c.Identifier).Returns(containerId);
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(container.Object);
-        writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
-        writableStorageProviderMock.Setup(wsp => wsp.GetSuggestedName<IWopiFolder>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync("suggestedTarget");
-        writableStorageProviderMock.Setup(_ => _.CreateWopiChildResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(container.Object);
+        _writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _writableStorageProviderMock.Setup(wsp => wsp.GetSuggestedName<IWopiFolder>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync("suggestedTarget");
+        _writableStorageProviderMock.Setup(_ => _.CreateWopiChildResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(container.Object);
 
         var result = await _controller.CreateChildContainer(containerId, suggestedTarget: UtfString.FromDecoded("suggestedTarget"));
@@ -207,7 +207,7 @@ public class ContainersControllerTests
     [Fact]
     public async Task CreateChildFile_ReturnsNotFound_WhenContainerDoesNotExist()
     {
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => null);
 
         var result = await _controller.CreateChildFile("containerId");
@@ -218,7 +218,7 @@ public class ContainersControllerTests
     [Fact]
     public async Task CreateChildFile_ReturnsNotImplemented_WhenBothHeadersArePresent()
     {
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Mock<IWopiFolder>().Object);
 
         var result = await _controller.CreateChildFile("containerId", UtfString.FromDecoded("suggestedTarget"), UtfString.FromDecoded("relativeTarget"));
@@ -229,7 +229,7 @@ public class ContainersControllerTests
     [Fact]
     public async Task CreateChildFile_ReturnsNotImplemented_WhenBothHeadersAreMissing()
     {
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Mock<IWopiFolder>().Object);
 
         var result = await _controller.CreateChildFile("containerId");
@@ -240,9 +240,9 @@ public class ContainersControllerTests
     [Fact]
     public async Task CreateChildFile_ReturnsBadRequest_WhenNameIsInvalid()
     {
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Mock<IWopiFolder>().Object);
-        writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
         var result = await _controller.CreateChildFile("containerId", UtfString.FromDecoded("relativeTarget"));
@@ -254,11 +254,11 @@ public class ContainersControllerTests
     public async Task CreateChildFile_ReturnsConflict_WhenFileAlreadyExistsAndOverwriteIsFalse()
     {
         var existingFile = new Mock<IWopiFile>().Object;
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Mock<IWopiFolder>().Object);
-        storageProviderMock.Setup(sp => sp.GetWopiResourceByName<IWopiFile>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _storageProviderMock.Setup(sp => sp.GetWopiResourceByName<IWopiFile>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(existingFile);
-        writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
         var result = await _controller.CreateChildFile("containerId", relativeTarget: UtfString.FromDecoded("relativeTarget"), overwriteRelativeTarget: false);
@@ -271,13 +271,13 @@ public class ContainersControllerTests
     {
         var existingFile = new Mock<IWopiFile>().Object;
         var lockInfo = new WopiLockInfo { FileId = "any", LockId = "lockId" };
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Mock<IWopiFolder>().Object);
-        storageProviderMock.Setup(sp => sp.GetWopiResourceByName<IWopiFile>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _storageProviderMock.Setup(sp => sp.GetWopiResourceByName<IWopiFile>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(existingFile);
-        writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
-        lockProviderMock.Setup(lp => lp.GetLockAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _lockProviderMock.Setup(lp => lp.GetLockAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(lockInfo);
 
         var result = await _controller.CreateChildFile("containerId", relativeTarget: UtfString.FromDecoded("relativeTarget"), overwriteRelativeTarget: true);
@@ -298,11 +298,11 @@ public class ContainersControllerTests
         // Stub Checksum so GetEncodedSha256 takes the early-return path; avoids the unmocked
         // OpenReadAsync call inside CheckFileInfo composition.
         fileMock.SetupGet(f => f.Checksum).Returns(new ReadOnlyMemory<byte>([0]));
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Mock<IWopiFolder>().Object);
-        writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
-        writableStorageProviderMock.Setup(wsp => wsp.CreateWopiChildResource<IWopiFile>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _writableStorageProviderMock.Setup(wsp => wsp.CreateWopiChildResource<IWopiFile>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
 
         var result = await _controller.CreateChildFile("containerId", relativeTarget: UtfString.FromDecoded("relativeTarget"));
@@ -314,7 +314,7 @@ public class ContainersControllerTests
     [Fact]
     public async Task DeleteContainer_ReturnsNotFound_WhenContainerDoesNotExist()
     {
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
 
         var result = await _controller.DeleteContainer("nonexistent");
 
@@ -326,8 +326,8 @@ public class ContainersControllerTests
     {
         var containerId = "existing-container";
         var container = new Mock<IWopiFolder>();
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(container.Object);
-        writableStorageProviderMock.Setup(_ => _.DeleteWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>()))
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(container.Object);
+        _writableStorageProviderMock.Setup(_ => _.DeleteWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
         var result = await _controller.DeleteContainer(containerId);
@@ -340,8 +340,8 @@ public class ContainersControllerTests
     {
         var containerId = "existing-container";
         var container = new Mock<IWopiFolder>();
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(container.Object);
-        writableStorageProviderMock.Setup(_ => _.DeleteWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>()))
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(container.Object);
+        _writableStorageProviderMock.Setup(_ => _.DeleteWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
         var result = await _controller.DeleteContainer(containerId);
@@ -354,8 +354,8 @@ public class ContainersControllerTests
     {
         var containerId = "existing-container";
         var container = new Mock<IWopiFolder>();
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(container.Object);
-        writableStorageProviderMock.Setup(_ => _.DeleteWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>()))
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(container.Object);
+        _writableStorageProviderMock.Setup(_ => _.DeleteWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new DirectoryNotFoundException());
 
         var result = await _controller.DeleteContainer(containerId);
@@ -368,8 +368,8 @@ public class ContainersControllerTests
     {
         var containerId = "existing-container";
         var container = new Mock<IWopiFolder>();
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(container.Object);
-        writableStorageProviderMock.Setup(_ => _.DeleteWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>()))
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(container.Object);
+        _writableStorageProviderMock.Setup(_ => _.DeleteWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException());
 
         var result = await _controller.DeleteContainer(containerId);
@@ -380,7 +380,7 @@ public class ContainersControllerTests
     [Fact]
     public async Task RenameContainer_ReturnsNotFound_WhenContainerNotFound()
     {
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
 
         var result = await _controller.RenameContainer("id", new UtfString());
 
@@ -390,8 +390,8 @@ public class ContainersControllerTests
     [Fact]
     public async Task RenameContainer_ReturnsBadRequest_WhenRequestedNameIsIllegal()
     {
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
-        writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
+        _writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
 
         var result = await _controller.RenameContainer("containerId", UtfString.FromDecoded("illegalName"));
 
@@ -402,9 +402,9 @@ public class ContainersControllerTests
     [Fact]
     public async Task RenameContainer_ReturnsConflict_WhenRequestedNameAlreadyExists()
     {
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
-        writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
-        writableStorageProviderMock.Setup(wsp => wsp.RenameWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
+        _writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _writableStorageProviderMock.Setup(wsp => wsp.RenameWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException());
 
         var result = await _controller.RenameContainer("containerId", UtfString.FromDecoded("existingName"));
@@ -415,9 +415,9 @@ public class ContainersControllerTests
     [Fact]
     public async Task RenameContainer_ReturnsNotFound_WhenDirectoryNotFoundException()
     {
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
-        writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
-        writableStorageProviderMock.Setup(wsp => wsp.RenameWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
+        _writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _writableStorageProviderMock.Setup(wsp => wsp.RenameWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new DirectoryNotFoundException());
 
         var result = await _controller.RenameContainer("containerId", UtfString.FromDecoded("existingName"));
@@ -428,9 +428,9 @@ public class ContainersControllerTests
     [Fact]
     public async Task RenameContainer_ReturnsInternalServerError_WhenUnexpectedErrorOccurs()
     {
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
-        writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
-        writableStorageProviderMock.Setup(wsp => wsp.RenameWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
+        _writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _writableStorageProviderMock.Setup(wsp => wsp.RenameWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception());
 
         var result = await _controller.RenameContainer("containerId", UtfString.FromDecoded("newName"));
@@ -443,9 +443,9 @@ public class ContainersControllerTests
     {
         var container = new Mock<IWopiFolder>();
         container.SetupGet(c => c.Name).Returns("newName");
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(container.Object);
-        writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
-        writableStorageProviderMock.Setup(wsp => wsp.RenameWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(container.Object);
+        _writableStorageProviderMock.Setup(wsp => wsp.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _writableStorageProviderMock.Setup(wsp => wsp.RenameWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
         var result = await _controller.RenameContainer("containerId", UtfString.FromDecoded("newName"));
@@ -456,12 +456,12 @@ public class ContainersControllerTests
     [Fact]
     public async Task GetEcosystem_ReturnsNotFound_WhenContainerDoesNotExist()
     {
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
 
-        var result = await _controller.GetEcosystem("nonexistent", accessTokenServiceMock.Object);
+        var result = await _controller.GetEcosystem("nonexistent", _accessTokenServiceMock.Object);
 
         Assert.IsType<NotFoundResult>(result);
-        accessTokenServiceMock.Verify(t => t.IssueAsync(It.IsAny<WopiAccessTokenRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+        _accessTokenServiceMock.Verify(t => t.IssueAsync(It.IsAny<WopiAccessTokenRequest>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -470,9 +470,9 @@ public class ContainersControllerTests
         var containerId = "existing-container";
         var folderMock = new Mock<IWopiFolder>();
         folderMock.SetupGet(f => f.Identifier).Returns(containerId);
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(folderMock.Object);
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(folderMock.Object);
 
-        var result = await _controller.GetEcosystem(containerId, accessTokenServiceMock.Object);
+        var result = await _controller.GetEcosystem(containerId, _accessTokenServiceMock.Object);
 
         var jsonResult = Assert.IsType<JsonResult<UrlResponse>>(result);
         Assert.IsType<UrlResponse>(jsonResult.Value);
@@ -488,19 +488,19 @@ public class ContainersControllerTests
         var containerId = "existing-container";
         var folderMock = new Mock<IWopiFolder>();
         folderMock.SetupGet(f => f.Identifier).Returns(containerId);
-        storageProviderMock
+        _storageProviderMock
             .Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(folderMock.Object);
 
         UrlRouteContext? captured = null;
-        urlMock
+        _urlMock
             .Setup(_ => _.RouteUrl(It.IsAny<UrlRouteContext>()))
             .Callback<UrlRouteContext>(rc => captured = rc)
             .Returns("https://localhost/wopi/ecosystem");
 
-        await _controller.GetEcosystem(containerId, accessTokenServiceMock.Object);
+        await _controller.GetEcosystem(containerId, _accessTokenServiceMock.Object);
 
-        accessTokenServiceMock.Verify(t => t.IssueAsync(
+        _accessTokenServiceMock.Verify(t => t.IssueAsync(
             It.Is<WopiAccessTokenRequest>(r =>
                 r.UserId == "alice" &&
                 r.ResourceId == containerId &&
@@ -516,7 +516,7 @@ public class ContainersControllerTests
     [Fact]
     public async Task EnumerateAncestors_ReturnsNotFound_WhenContainerDoesNotExist()
     {
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
 
         var result = await _controller.EnumerateAncestors("nonexistent");
 
@@ -532,8 +532,8 @@ public class ContainersControllerTests
             new Mock<IWopiFolder>().Object,
             new Mock<IWopiFolder>().Object
         ]);
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
-        storageProviderMock.Setup(sp => sp.GetAncestors<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(ancestors);
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
+        _storageProviderMock.Setup(sp => sp.GetAncestors<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(ancestors);
 
         var result = await _controller.EnumerateAncestors(containerId);
 
@@ -545,7 +545,7 @@ public class ContainersControllerTests
     [Fact]
     public async Task EnumerateChildren_ReturnsNotFound_WhenContainerDoesNotExist()
     {
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
 
         var result = await _controller.EnumerateChildren("nonexistent");
 
@@ -556,9 +556,9 @@ public class ContainersControllerTests
     public async Task EnumerateChildren_ReturnsEmptyLists_WhenNoFilesOrContainers()
     {
         var containerId = "container";
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
-        storageProviderMock.Setup(sp => sp.GetWopiFiles(containerId, null, It.IsAny<CancellationToken>())).Returns(AsyncEnumerable.Empty<IWopiFile>());
-        storageProviderMock.Setup(sp => sp.GetWopiContainers(containerId, It.IsAny<CancellationToken>())).Returns(AsyncEnumerable.Empty<IWopiFolder>());
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
+        _storageProviderMock.Setup(sp => sp.GetWopiFiles(containerId, null, It.IsAny<CancellationToken>())).Returns(AsyncEnumerable.Empty<IWopiFile>());
+        _storageProviderMock.Setup(sp => sp.GetWopiContainers(containerId, It.IsAny<CancellationToken>())).Returns(AsyncEnumerable.Empty<IWopiFolder>());
 
         var result = await _controller.EnumerateChildren(containerId) as JsonResult;
 
@@ -582,9 +582,9 @@ public class ContainersControllerTests
         folderMock.Setup(f => f.Name).Returns("folder");
         folderMock.Setup(f => f.Identifier).Returns("folderId");
 
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
-        storageProviderMock.Setup(sp => sp.GetWopiFiles(containerId, null, It.IsAny<CancellationToken>())).Returns(new[] { fileMock.Object }.ToAsyncEnumerable());
-        storageProviderMock.Setup(sp => sp.GetWopiContainers(containerId, It.IsAny<CancellationToken>())).Returns(new[] { folderMock.Object }.ToAsyncEnumerable());
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
+        _storageProviderMock.Setup(sp => sp.GetWopiFiles(containerId, null, It.IsAny<CancellationToken>())).Returns(new[] { fileMock.Object }.ToAsyncEnumerable());
+        _storageProviderMock.Setup(sp => sp.GetWopiContainers(containerId, It.IsAny<CancellationToken>())).Returns(new[] { folderMock.Object }.ToAsyncEnumerable());
 
         var result = await _controller.EnumerateChildren(containerId) as JsonResult;
 
@@ -610,14 +610,14 @@ public class ContainersControllerTests
         fileMock1.Setup(f => f.Length).Returns(123);
         fileMock1.Setup(f => f.Identifier).Returns("fileId1");
 
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
-        storageProviderMock
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFolder>(containerId, It.IsAny<CancellationToken>())).ReturnsAsync(new Mock<IWopiFolder>().Object);
+        _storageProviderMock
             .Setup(sp => sp.GetWopiFiles(
                 containerId,
                 It.Is<IReadOnlyCollection<string>?>(exts => exts != null && exts.SequenceEqual(new[] { ".txt" })),
                 It.IsAny<CancellationToken>()))
             .Returns(new[] { fileMock1.Object }.ToAsyncEnumerable());
-        storageProviderMock.Setup(sp => sp.GetWopiContainers(containerId, It.IsAny<CancellationToken>())).Returns(AsyncEnumerable.Empty<IWopiFolder>());
+        _storageProviderMock.Setup(sp => sp.GetWopiContainers(containerId, It.IsAny<CancellationToken>())).Returns(AsyncEnumerable.Empty<IWopiFolder>());
 
         var result = await _controller.EnumerateChildren(containerId, ".txt") as JsonResult;
 

--- a/test/WopiHost.Core.Tests/Controllers/FilesControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/FilesControllerTests.cs
@@ -21,26 +21,26 @@ namespace WopiHost.Core.Tests.Controllers;
 
 public class FilesControllerTests
 {
-    private readonly Mock<IWopiStorageProvider> storageProviderMock;
-    private readonly Mock<IWopiWritableStorageProvider> writableStorageProviderMock;
-    private readonly Mock<IWopiPermissionProvider> permissionProviderMock;
-    private readonly Mock<IWopiAccessTokenService> accessTokenServiceMock;
-    private readonly Mock<IOptions<WopiHostOptions>> wopiHostOptionsMock;
-    private readonly IMemoryCache memoryCache;
-    private readonly Mock<IWopiLockProvider> lockProviderMock;
-    private readonly Mock<IUrlHelper> urlMock;
-    private FilesController controller;
+    private readonly Mock<IWopiStorageProvider> _storageProviderMock;
+    private readonly Mock<IWopiWritableStorageProvider> _writableStorageProviderMock;
+    private readonly Mock<IWopiPermissionProvider> _permissionProviderMock;
+    private readonly Mock<IWopiAccessTokenService> _accessTokenServiceMock;
+    private readonly Mock<IOptions<WopiHostOptions>> _wopiHostOptionsMock;
+    private readonly IMemoryCache _memoryCache;
+    private readonly Mock<IWopiLockProvider> _lockProviderMock;
+    private readonly Mock<IUrlHelper> _urlMock;
+    private FilesController _controller;
 
     public FilesControllerTests()
     {
-        storageProviderMock = new Mock<IWopiStorageProvider>();
-        writableStorageProviderMock = new Mock<IWopiWritableStorageProvider>();
-        permissionProviderMock = new Mock<IWopiPermissionProvider>();
-        permissionProviderMock
+        _storageProviderMock = new Mock<IWopiStorageProvider>();
+        _writableStorageProviderMock = new Mock<IWopiWritableStorageProvider>();
+        _permissionProviderMock = new Mock<IWopiPermissionProvider>();
+        _permissionProviderMock
             .Setup(_ => _.GetFilePermissionsAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<IWopiFile>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(WopiFilePermissions.UserCanWrite | WopiFilePermissions.UserCanRename | WopiFilePermissions.UserCanAttend | WopiFilePermissions.UserCanPresent);
-        wopiHostOptionsMock = new Mock<IOptions<WopiHostOptions>>();
-        wopiHostOptionsMock
+        _wopiHostOptionsMock = new Mock<IOptions<WopiHostOptions>>();
+        _wopiHostOptionsMock
             .SetupGet(o => o.Value)
             .Returns(new WopiHostOptions()
             {
@@ -49,18 +49,18 @@ public class FilesControllerTests
                 OnCheckFileInfo = o => Task.FromResult(o.CheckFileInfo),
                 ClientUrl = new Uri("http://localhost:5000"),
             });
-        memoryCache = new MemoryCache(new MemoryCacheOptions());
-        lockProviderMock = new Mock<IWopiLockProvider>();
-        accessTokenServiceMock = new Mock<IWopiAccessTokenService>();
-        accessTokenServiceMock
+        _memoryCache = new MemoryCache(new MemoryCacheOptions());
+        _lockProviderMock = new Mock<IWopiLockProvider>();
+        _accessTokenServiceMock = new Mock<IWopiAccessTokenService>();
+        _accessTokenServiceMock
             .Setup(s => s.IssueAsync(It.IsAny<WopiAccessTokenRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new WopiAccessToken("FRESH-TOKEN", DateTimeOffset.UtcNow.AddMinutes(10)));
 
-        urlMock = new Mock<IUrlHelper>();
-        urlMock
+        _urlMock = new Mock<IUrlHelper>();
+        _urlMock
             .Setup(_ => _.RouteUrl(It.IsAny<UrlRouteContext>()))
             .Returns("https://localhost");
-        urlMock
+        _urlMock
             .Setup(_ => _.ActionContext)
             .Returns(new ActionContext
             {
@@ -70,13 +70,13 @@ public class FilesControllerTests
                 }
             });
 
-        controller = new FilesController(
-            storageProviderMock.Object,
-            memoryCache,
-            writableStorageProviderMock.Object,
-            lockProviderMock.Object)
+        _controller = new FilesController(
+            _storageProviderMock.Object,
+            _memoryCache,
+            _writableStorageProviderMock.Object,
+            _lockProviderMock.Object)
         {
-            Url = urlMock.Object,
+            Url = _urlMock.Object,
             ControllerContext = new ControllerContext
             {
                 HttpContext = new DefaultHttpContext()
@@ -109,9 +109,9 @@ public class FilesControllerTests
     public async Task GetCheckFileInfo_FileNotFound_ReturnsNotFound()
     {
         var fileId = "testFileId";
-        storageProviderMock.Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
+        _storageProviderMock.Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
 
-        var result = await controller.CheckFileInfo(fileId);
+        var result = await _controller.CheckFileInfo(fileId);
 
         Assert.IsType<NotFoundResult>(result);
     }
@@ -128,15 +128,15 @@ public class FilesControllerTests
         fileMock.SetupGet(f => f.LastWriteTimeUtc).Returns(DateTime.UtcNow);
         fileMock.SetupGet(f => f.Length).Returns(1024);
         fileMock.Setup(f => f.OpenReadAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new System.IO.MemoryStream());
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => fileMock.Object);
 
-        controller.ControllerContext = new ControllerContext
+        _controller.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext()
             {
-                ServiceScopeFactory = TestUtils.CreateServiceScope(permissionProviderMock.Object),
+                ServiceScopeFactory = TestUtils.CreateServiceScope(_permissionProviderMock.Object),
                 User = new ClaimsPrincipal(
                     new ClaimsIdentity(
                     [
@@ -146,7 +146,7 @@ public class FilesControllerTests
             }
         };
 
-        var result = await controller.CheckFileInfo(fileId);
+        var result = await _controller.CheckFileInfo(fileId);
 
         var contentResult = Assert.IsType<ContentResult>(result);
         Assert.NotNull(contentResult.Content);
@@ -175,15 +175,15 @@ public class FilesControllerTests
         fileMock.SetupGet(f => f.Length).Returns(1024);
         fileMock.Setup(f => f.OpenReadAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new System.IO.MemoryStream());
 
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => fileMock.Object);
 
-        controller.ControllerContext = new ControllerContext
+        _controller.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext()
             {
-                ServiceScopeFactory = TestUtils.CreateServiceScope(permissionProviderMock.Object),
+                ServiceScopeFactory = TestUtils.CreateServiceScope(_permissionProviderMock.Object),
                 User = new ClaimsPrincipal(
                     new ClaimsIdentity(
                     [
@@ -193,7 +193,7 @@ public class FilesControllerTests
             }
         };
 
-        var result = await controller.CheckFileInfo(fileId);
+        var result = await _controller.CheckFileInfo(fileId);
 
         var contentResult = Assert.IsType<ContentResult>(result);
         Assert.NotNull(contentResult.Content);
@@ -214,9 +214,9 @@ public class FilesControllerTests
     [Fact]
     public async Task CheckFileInfo_FileNotFound_ReturnsNotFound()
     {
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
 
-        var result = await controller.CheckFileInfo("file_id");
+        var result = await _controller.CheckFileInfo("file_id");
 
         Assert.IsType<NotFoundResult>(result);
     }
@@ -228,9 +228,9 @@ public class FilesControllerTests
     [Fact]
     public async Task GetFile_FileNotFound_ReturnsNotFound()
     {
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
 
-        var result = await controller.GetFile("file_id");
+        var result = await _controller.GetFile("file_id");
 
         Assert.IsType<NotFoundResult>(result);
     }
@@ -240,11 +240,11 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId, size: 500);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
 
-        var result = await controller.GetFile(fileId, maximumExpectedSize: 1000);
+        var result = await _controller.GetFile(fileId, maximumExpectedSize: 1000);
 
         Assert.IsType<FileStreamResult>(result);
     }
@@ -254,11 +254,11 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId, size: 2000);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
 
-        var result = await controller.GetFile(fileId, maximumExpectedSize: 1000);
+        var result = await _controller.GetFile(fileId, maximumExpectedSize: 1000);
 
         Assert.IsType<PreconditionFailedResult>(result);
     }
@@ -268,14 +268,14 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId, size: 100, version: "v2");
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
 
-        var result = await controller.GetFile(fileId);
+        var result = await _controller.GetFile(fileId);
 
         Assert.IsType<FileStreamResult>(result);
-        Assert.Equal("v2", controller.Response.Headers[WopiHeaders.ITEM_VERSION].ToString());
+        Assert.Equal("v2", _controller.Response.Headers[WopiHeaders.ITEM_VERSION].ToString());
     }
 
     #endregion
@@ -285,12 +285,12 @@ public class FilesControllerTests
     [Fact]
     public async Task GetEcosystem_FileNotFound_ReturnsNotFound()
     {
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
 
-        var result = await controller.GetEcosystem("file_id", accessTokenServiceMock.Object);
+        var result = await _controller.GetEcosystem("file_id", _accessTokenServiceMock.Object);
 
         Assert.IsType<NotFoundResult>(result);
-        accessTokenServiceMock.Verify(t => t.IssueAsync(It.IsAny<WopiAccessTokenRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+        _accessTokenServiceMock.Verify(t => t.IssueAsync(It.IsAny<WopiAccessTokenRequest>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -298,12 +298,12 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
         SetAuthenticatedUser();
 
-        var result = await controller.GetEcosystem(fileId, accessTokenServiceMock.Object);
+        var result = await _controller.GetEcosystem(fileId, _accessTokenServiceMock.Object);
 
         var jsonResult = Assert.IsType<JsonResult<UrlResponse>>(result);
         Assert.NotNull(jsonResult.Value);
@@ -318,20 +318,20 @@ public class FilesControllerTests
         // https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/concepts#preventing-token-trading
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
         SetAuthenticatedUser();
 
         UrlRouteContext? captured = null;
-        urlMock
+        _urlMock
             .Setup(_ => _.RouteUrl(It.IsAny<UrlRouteContext>()))
             .Callback<UrlRouteContext>(rc => captured = rc)
             .Returns("https://localhost/wopi/ecosystem");
 
-        await controller.GetEcosystem(fileId, accessTokenServiceMock.Object);
+        await _controller.GetEcosystem(fileId, _accessTokenServiceMock.Object);
 
-        accessTokenServiceMock.Verify(t => t.IssueAsync(
+        _accessTokenServiceMock.Verify(t => t.IssueAsync(
             It.Is<WopiAccessTokenRequest>(r =>
                 r.UserId == "alice" &&
                 r.ResourceId == fileId &&
@@ -346,11 +346,11 @@ public class FilesControllerTests
 
     private void SetAuthenticatedUser()
     {
-        controller.ControllerContext = new ControllerContext
+        _controller.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext
             {
-                ServiceScopeFactory = TestUtils.CreateServiceScope(permissionProviderMock.Object),
+                ServiceScopeFactory = TestUtils.CreateServiceScope(_permissionProviderMock.Object),
                 User = new ClaimsPrincipal(new ClaimsIdentity(
                 [
                     new Claim(ClaimTypes.NameIdentifier, "alice"),
@@ -368,9 +368,9 @@ public class FilesControllerTests
     [Fact]
     public async Task EnumerateAncestors_FileNotFound_ReturnsNotFound()
     {
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
 
-        var result = await controller.EnumerateAncestors("file_id");
+        var result = await _controller.EnumerateAncestors("file_id");
 
         Assert.IsType<NotFoundResult>(result);
     }
@@ -385,14 +385,14 @@ public class FilesControllerTests
         folderMock.SetupGet(f => f.Identifier).Returns("parentFolderId");
         var ancestors = new ReadOnlyCollection<IWopiFolder>([folderMock.Object]);
 
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetAncestors<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(ancestors);
 
-        var result = await controller.EnumerateAncestors(fileId);
+        var result = await _controller.EnumerateAncestors(fileId);
 
         var jsonResult = Assert.IsType<JsonResult>(result);
         var response = Assert.IsType<EnumerateAncestorsResponse>(jsonResult.Value);
@@ -406,9 +406,9 @@ public class FilesControllerTests
     [Fact]
     public async Task PutUserInfo_FileNotFound_ReturnsNotFound()
     {
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
 
-        var result = await controller.PutUserInfo("file_id", "user_info");
+        var result = await _controller.PutUserInfo("file_id", "user_info");
 
         Assert.IsType<NotFoundResult>(result);
     }
@@ -426,11 +426,11 @@ public class FilesControllerTests
         fileMock.SetupGet(f => f.Length).Returns(1024);
         fileMock.Setup(f => f.OpenReadAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new System.IO.MemoryStream());
 
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => fileMock.Object);
 
-        controller.ControllerContext = new ControllerContext
+        _controller.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext()
             {
@@ -443,10 +443,10 @@ public class FilesControllerTests
             }
         };
 
-        var result = await controller.PutUserInfo(fileId, "custom user info");
+        var result = await _controller.PutUserInfo(fileId, "custom user info");
 
         Assert.IsType<OkResult>(result);
-        Assert.Equal("custom user info", memoryCache.Get("UserInfo-nameId"));
+        Assert.Equal("custom user info", _memoryCache.Get("UserInfo-nameId"));
     }
 
     #endregion
@@ -456,8 +456,8 @@ public class FilesControllerTests
     [Fact]
     public async Task DeleteFile_FileNotFound_ReturnsNotFound()
     {
-        storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
-        var result = await controller.DeleteFile("file_id");
+        _storageProviderMock.Setup(sp => sp.GetWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);
+        var result = await _controller.DeleteFile("file_id");
         Assert.IsType<NotFoundResult>(result);
     }
 
@@ -474,13 +474,13 @@ public class FilesControllerTests
         fileMock.SetupGet(f => f.Length).Returns(1024);
         fileMock.Setup(f => f.OpenReadAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new System.IO.MemoryStream());
 
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => fileMock.Object);
         var wopiLockInfo = new WopiLockInfo() { LockId = "lockId", FileId = fileId };
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(wopiLockInfo);
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(wopiLockInfo);
 
-        var result = await controller.DeleteFile(fileId);
+        var result = await _controller.DeleteFile(fileId);
 
         Assert.IsType<LockMismatchResult>(result);
     }
@@ -490,18 +490,18 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
-        writableStorageProviderMock
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
-        writableStorageProviderMock
+        _writableStorageProviderMock
             .Setup(w => w.DeleteWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
-        var result = await controller.DeleteFile(fileId);
+        var result = await _controller.DeleteFile(fileId);
 
         Assert.IsType<OkResult>(result);
     }
@@ -511,18 +511,18 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
-        writableStorageProviderMock
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
-        writableStorageProviderMock
+        _writableStorageProviderMock
             .Setup(w => w.DeleteWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
-        var result = await controller.DeleteFile(fileId);
+        var result = await _controller.DeleteFile(fileId);
 
         Assert.IsType<InternalServerErrorResult>(result);
     }
@@ -534,11 +534,11 @@ public class FilesControllerTests
     [Fact]
     public async Task RenameFile_FileNotFound_ReturnsNotFound()
     {
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => null);
 
-        var result = await controller.RenameFile("file_id", UtfString.FromDecoded("newName"));
+        var result = await _controller.RenameFile("file_id", UtfString.FromDecoded("newName"));
 
         Assert.IsType<NotFoundResult>(result);
     }
@@ -548,13 +548,13 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
         var existingLock = new WopiLockInfo { LockId = "differentLockId", FileId = fileId };
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(existingLock);
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(existingLock);
 
-        var result = await controller.RenameFile(fileId, UtfString.FromDecoded("newName"), lockIdentifier: "myLockId");
+        var result = await _controller.RenameFile(fileId, UtfString.FromDecoded("newName"), lockIdentifier: "myLockId");
 
         Assert.IsType<LockMismatchResult>(result);
     }
@@ -564,18 +564,18 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
-        writableStorageProviderMock
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
-        var result = await controller.RenameFile(fileId, UtfString.FromDecoded("invalid|name"));
+        var result = await _controller.RenameFile(fileId, UtfString.FromDecoded("invalid|name"));
 
         Assert.IsType<BadRequestResult>(result);
-        Assert.Equal("Specified name is illegal", controller.Response.Headers[WopiHeaders.INVALID_FILE_NAME].ToString());
+        Assert.Equal("Specified name is illegal", _controller.Response.Headers[WopiHeaders.INVALID_FILE_NAME].ToString());
     }
 
     [Fact]
@@ -583,21 +583,21 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
-        writableStorageProviderMock
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
-        writableStorageProviderMock
+        _writableStorageProviderMock
             .Setup(w => w.GetSuggestedName<IWopiFile>(fileId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync("newName.txt");
-        writableStorageProviderMock
+        _writableStorageProviderMock
             .Setup(w => w.RenameWopiResource<IWopiFile>(fileId, "newName.txt", It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
-        var result = await controller.RenameFile(fileId, UtfString.FromDecoded("newName"));
+        var result = await _controller.RenameFile(fileId, UtfString.FromDecoded("newName"));
 
         var jsonResult = Assert.IsType<JsonResult>(result);
         Assert.NotNull(jsonResult.Value);
@@ -608,21 +608,21 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
-        writableStorageProviderMock
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
-        writableStorageProviderMock
+        _writableStorageProviderMock
             .Setup(w => w.GetSuggestedName<IWopiFile>(fileId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync("newName.txt");
-        writableStorageProviderMock
+        _writableStorageProviderMock
             .Setup(w => w.RenameWopiResource<IWopiFile>(fileId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
-        var result = await controller.RenameFile(fileId, UtfString.FromDecoded("newName"));
+        var result = await _controller.RenameFile(fileId, UtfString.FromDecoded("newName"));
 
         Assert.IsType<InternalServerErrorResult>(result);
     }
@@ -632,21 +632,21 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
-        writableStorageProviderMock
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
-        writableStorageProviderMock
+        _writableStorageProviderMock
             .Setup(w => w.GetSuggestedName<IWopiFile>(fileId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new ArgumentException("invalid", "requestedName"));
 
-        var result = await controller.RenameFile(fileId, UtfString.FromDecoded("newName"));
+        var result = await _controller.RenameFile(fileId, UtfString.FromDecoded("newName"));
 
         Assert.IsType<BadRequestResult>(result);
-        Assert.Equal("Specified name is illegal", controller.Response.Headers[WopiHeaders.INVALID_FILE_NAME].ToString());
+        Assert.Equal("Specified name is illegal", _controller.Response.Headers[WopiHeaders.INVALID_FILE_NAME].ToString());
     }
 
     [Fact]
@@ -654,18 +654,18 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
-        writableStorageProviderMock
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
-        writableStorageProviderMock
+        _writableStorageProviderMock
             .Setup(w => w.GetSuggestedName<IWopiFile>(fileId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new FileNotFoundException());
 
-        var result = await controller.RenameFile(fileId, UtfString.FromDecoded("newName"));
+        var result = await _controller.RenameFile(fileId, UtfString.FromDecoded("newName"));
 
         Assert.IsType<NotFoundResult>(result);
     }
@@ -675,18 +675,18 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
-        writableStorageProviderMock
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
-        writableStorageProviderMock
+        _writableStorageProviderMock
             .Setup(w => w.GetSuggestedName<IWopiFile>(fileId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException());
 
-        var result = await controller.RenameFile(fileId, UtfString.FromDecoded("newName"));
+        var result = await _controller.RenameFile(fileId, UtfString.FromDecoded("newName"));
 
         Assert.IsType<ConflictResult>(result);
     }
@@ -696,18 +696,18 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
-        writableStorageProviderMock
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
-        writableStorageProviderMock
+        _writableStorageProviderMock
             .Setup(w => w.GetSuggestedName<IWopiFile>(fileId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("unexpected"));
 
-        var result = await controller.RenameFile(fileId, UtfString.FromDecoded("newName"));
+        var result = await _controller.RenameFile(fileId, UtfString.FromDecoded("newName"));
 
         Assert.IsType<InternalServerErrorResult>(result);
     }
@@ -719,11 +719,11 @@ public class FilesControllerTests
     [Fact]
     public async Task PutFile_FileNotFound_ReturnsNotFound()
     {
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => null);
 
-        var result = await controller.PutFile("file_id");
+        var result = await _controller.PutFile("file_id");
 
         Assert.IsType<NotFoundResult>(result);
     }
@@ -733,11 +733,11 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId, size: 0);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
 
-        controller.ControllerContext = new ControllerContext
+        _controller.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext()
             {
@@ -745,7 +745,7 @@ public class FilesControllerTests
             }
         };
 
-        var result = await controller.PutFile(fileId, newLockIdentifier: null);
+        var result = await _controller.PutFile(fileId, newLockIdentifier: null);
 
         Assert.IsType<OkResult>(result);
     }
@@ -755,16 +755,16 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId, size: 1024);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
 
-        var result = await controller.PutFile(fileId, newLockIdentifier: null);
+        var result = await _controller.PutFile(fileId, newLockIdentifier: null);
 
         // Spec (PutFile): non-empty unlocked file must respond 409 with X-WOPI-Lock set to the empty string.
         Assert.IsType<LockMismatchResult>(result);
-        Assert.True(controller.Response.Headers.ContainsKey(WopiHeaders.LOCK));
-        Assert.Equal(string.Empty, controller.Response.Headers[WopiHeaders.LOCK].ToString());
+        Assert.True(_controller.Response.Headers.ContainsKey(WopiHeaders.LOCK));
+        Assert.Equal(string.Empty, _controller.Response.Headers[WopiHeaders.LOCK].ToString());
     }
 
     [Fact]
@@ -772,17 +772,17 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
 
-        controller = new FilesController(storageProviderMock.Object, memoryCache)
+        _controller = new FilesController(_storageProviderMock.Object, _memoryCache)
         {
-            Url = urlMock.Object,
+            Url = _urlMock.Object,
             ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
         };
 
-        var result = await controller.PutFile(fileId, newLockIdentifier: "lock-id");
+        var result = await _controller.PutFile(fileId, newLockIdentifier: "lock-id");
 
         Assert.IsType<LockMismatchResult>(result);
     }
@@ -793,15 +793,15 @@ public class FilesControllerTests
         var fileId = "testFileId";
         var lockId = "lock-id";
         var fileMock = CreateFileMock(fileId);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
-        lockProviderMock
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _lockProviderMock
             .Setup(x => x.AddLockAsync(fileId, lockId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new WopiLockInfo { LockId = lockId, FileId = fileId });
 
-        controller.ControllerContext = new ControllerContext
+        _controller.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext()
             {
@@ -809,7 +809,7 @@ public class FilesControllerTests
             }
         };
 
-        var result = await controller.PutFile(fileId, newLockIdentifier: lockId);
+        var result = await _controller.PutFile(fileId, newLockIdentifier: lockId);
 
         Assert.IsType<OkResult>(result);
     }
@@ -819,7 +819,7 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId, size: 0);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
 
@@ -831,7 +831,7 @@ public class FilesControllerTests
             OnPutFile = ctx => { captured = ctx; return Task.CompletedTask; },
         });
 
-        controller.ControllerContext = new ControllerContext
+        _controller.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext
             {
@@ -839,7 +839,7 @@ public class FilesControllerTests
             }
         };
 
-        var result = await controller.PutFile(fileId, newLockIdentifier: null, editors: " alice , bob ,, charlie");
+        var result = await _controller.PutFile(fileId, newLockIdentifier: null, editors: " alice , bob ,, charlie");
 
         Assert.IsType<OkResult>(result);
         Assert.NotNull(captured);
@@ -854,7 +854,7 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId, size: 0);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
 
@@ -866,7 +866,7 @@ public class FilesControllerTests
             OnPutFile = ctx => { captured = ctx; return Task.CompletedTask; },
         });
 
-        controller.ControllerContext = new ControllerContext
+        _controller.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext
             {
@@ -874,7 +874,7 @@ public class FilesControllerTests
             }
         };
 
-        var result = await controller.PutFile(fileId, newLockIdentifier: null, editors: null);
+        var result = await _controller.PutFile(fileId, newLockIdentifier: null, editors: null);
 
         Assert.IsType<OkResult>(result);
         Assert.NotNull(captured);
@@ -886,7 +886,7 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId, size: 0);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
 
@@ -903,9 +903,9 @@ public class FilesControllerTests
         };
         httpContext.Request.ContentLength = 4096;
 
-        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        _controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
 
-        var result = await controller.PutFile(fileId, newLockIdentifier: null);
+        var result = await _controller.PutFile(fileId, newLockIdentifier: null);
 
         var status = Assert.IsType<StatusCodeResult>(result);
         Assert.Equal(StatusCodes.Status413PayloadTooLarge, status.StatusCode);
@@ -916,18 +916,18 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
         var existingLock = new WopiLockInfo { LockId = "other-lock", FileId = fileId };
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(existingLock);
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(existingLock);
 
-        controller.ControllerContext = new ControllerContext
+        _controller.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext()
         };
 
-        var result = await controller.PutFile(fileId, newLockIdentifier: "my-lock");
+        var result = await _controller.PutFile(fileId, newLockIdentifier: "my-lock");
 
         Assert.IsType<LockMismatchResult>(result);
     }
@@ -939,11 +939,11 @@ public class FilesControllerTests
     [Fact]
     public async Task PutRelativeFile_FileNotFound_ReturnsNotFound()
     {
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => null);
 
-        var result = await controller.PutRelativeFile("file_id", relativeTarget: UtfString.FromDecoded("file.txt"));
+        var result = await _controller.PutRelativeFile("file_id", relativeTarget: UtfString.FromDecoded("file.txt"));
 
         Assert.IsType<NotFoundResult>(result);
     }
@@ -953,11 +953,11 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
 
-        var result = await controller.PutRelativeFile(
+        var result = await _controller.PutRelativeFile(
             fileId,
             suggestedTarget: UtfString.FromDecoded("file.txt"),
             relativeTarget: UtfString.FromDecoded("file.txt"));
@@ -970,11 +970,11 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
 
-        var result = await controller.PutRelativeFile(fileId);
+        var result = await _controller.PutRelativeFile(fileId);
 
         Assert.IsType<NotImplementedResult>(result);
     }
@@ -988,17 +988,17 @@ public class FilesControllerTests
         parentFolder.SetupGet(f => f.Identifier).Returns("parentId");
         var ancestors = new ReadOnlyCollection<IWopiFolder>([parentFolder.Object]);
 
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetAncestors<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(ancestors);
-        writableStorageProviderMock
+        _writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
-        var result = await controller.PutRelativeFile(fileId, relativeTarget: UtfString.FromDecoded("invalid|name.txt"));
+        var result = await _controller.PutRelativeFile(fileId, relativeTarget: UtfString.FromDecoded("invalid|name.txt"));
 
         Assert.IsType<BadRequestResult>(result);
     }
@@ -1013,23 +1013,23 @@ public class FilesControllerTests
         var ancestors = new ReadOnlyCollection<IWopiFolder>([parentFolder.Object]);
         var existingFile = CreateFileMock("existingFileId");
 
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetAncestors<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(ancestors);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResourceByName<IWopiFile>("parentId", It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(existingFile.Object);
-        writableStorageProviderMock
+        _writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
-        writableStorageProviderMock
+        _writableStorageProviderMock
             .Setup(w => w.GetSuggestedName<IWopiFile>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync("file_copy.txt");
 
-        var result = await controller.PutRelativeFile(
+        var result = await _controller.PutRelativeFile(
             fileId,
             relativeTarget: UtfString.FromDecoded("file.txt"),
             overwriteRelativeTarget: false);
@@ -1048,23 +1048,23 @@ public class FilesControllerTests
         var existingFile = CreateFileMock("existingFileId");
         var lockInfo = new WopiLockInfo { LockId = "existingLock", FileId = "existingFileId" };
 
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetAncestors<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(ancestors);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResourceByName<IWopiFile>("parentId", It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(existingFile.Object);
-        writableStorageProviderMock
+        _writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
-        lockProviderMock
+        _lockProviderMock
             .Setup(x => x.GetLockAsync("existingFileId", It.IsAny<CancellationToken>()))
             .ReturnsAsync(lockInfo);
 
-        var result = await controller.PutRelativeFile(
+        var result = await _controller.PutRelativeFile(
             fileId,
             relativeTarget: UtfString.FromDecoded("file.txt"),
             overwriteRelativeTarget: true);
@@ -1082,23 +1082,23 @@ public class FilesControllerTests
         var ancestors = new ReadOnlyCollection<IWopiFolder>([parentFolder.Object]);
         var newFileMock = CreateFileMock("newFileId");
 
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetAncestors<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(ancestors);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResourceByName<IWopiFile>("parentId", It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => null);
-        writableStorageProviderMock
+        _writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
-        writableStorageProviderMock
+        _writableStorageProviderMock
             .Setup(w => w.CreateWopiChildResource<IWopiFile>("parentId", It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(newFileMock.Object);
 
-        controller.ControllerContext = new ControllerContext
+        _controller.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext()
             {
@@ -1106,7 +1106,7 @@ public class FilesControllerTests
             }
         };
 
-        var result = await controller.PutRelativeFile(
+        var result = await _controller.PutRelativeFile(
             fileId,
             relativeTarget: UtfString.FromDecoded("newfile.txt"));
 
@@ -1119,7 +1119,7 @@ public class FilesControllerTests
     {
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
 
@@ -1130,7 +1130,7 @@ public class FilesControllerTests
             MaxFileSize = 1024,
         });
 
-        controller.ControllerContext = new ControllerContext
+        _controller.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext
             {
@@ -1139,7 +1139,7 @@ public class FilesControllerTests
         };
 
         // X-WOPI-Size declares 4096, MaxFileSize is 1024 → 413 short-circuits before write.
-        var result = await controller.PutRelativeFile(
+        var result = await _controller.PutRelativeFile(
             fileId,
             relativeTarget: UtfString.FromDecoded("newfile.txt"),
             declaredSize: 4096);
@@ -1158,19 +1158,19 @@ public class FilesControllerTests
         var ancestors = new ReadOnlyCollection<IWopiFolder>([parentFolder.Object]);
         var newFileMock = CreateFileMock("newFileId");
 
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetAncestors<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(ancestors);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResourceByName<IWopiFile>("parentId", It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => null);
-        writableStorageProviderMock
+        _writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
-        writableStorageProviderMock
+        _writableStorageProviderMock
             .Setup(w => w.CreateWopiChildResource<IWopiFile>("parentId", It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(newFileMock.Object);
 
@@ -1182,7 +1182,7 @@ public class FilesControllerTests
             OnPutRelativeFile = ctx => { captured = ctx; return Task.CompletedTask; },
         });
 
-        controller.ControllerContext = new ControllerContext
+        _controller.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext
             {
@@ -1190,7 +1190,7 @@ public class FilesControllerTests
             }
         };
 
-        var result = await controller.PutRelativeFile(
+        var result = await _controller.PutRelativeFile(
             fileId,
             relativeTarget: UtfString.FromDecoded("newfile.txt"),
             fileConversion: "true",
@@ -1214,19 +1214,19 @@ public class FilesControllerTests
         var ancestors = new ReadOnlyCollection<IWopiFolder>([parentFolder.Object]);
         var newFileMock = CreateFileMock("newFileId");
 
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetAncestors<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(ancestors);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResourceByName<IWopiFile>("parentId", It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => null);
-        writableStorageProviderMock
+        _writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
-        writableStorageProviderMock
+        _writableStorageProviderMock
             .Setup(w => w.CreateWopiChildResource<IWopiFile>("parentId", It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(newFileMock.Object);
 
@@ -1238,7 +1238,7 @@ public class FilesControllerTests
             OnPutRelativeFile = ctx => { captured = ctx; return Task.CompletedTask; },
         });
 
-        controller.ControllerContext = new ControllerContext
+        _controller.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext
             {
@@ -1246,7 +1246,7 @@ public class FilesControllerTests
             }
         };
 
-        var result = await controller.PutRelativeFile(
+        var result = await _controller.PutRelativeFile(
             fileId,
             relativeTarget: UtfString.FromDecoded("newfile.txt"));
 
@@ -1266,20 +1266,20 @@ public class FilesControllerTests
         var ancestors = new ReadOnlyCollection<IWopiFolder>([parentFolder.Object]);
         var newFileMock = CreateFileMock("newFileId");
 
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetAncestors<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(ancestors);
-        writableStorageProviderMock
+        _writableStorageProviderMock
             .Setup(w => w.GetSuggestedName<IWopiFile>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync("test.docx");
-        writableStorageProviderMock
+        _writableStorageProviderMock
             .Setup(w => w.CreateWopiChildResource<IWopiFile>("parentId", It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(newFileMock.Object);
 
-        controller.ControllerContext = new ControllerContext
+        _controller.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext()
             {
@@ -1288,7 +1288,7 @@ public class FilesControllerTests
         };
 
         // suggestedTarget starting with "." → extension-only mode
-        var result = await controller.PutRelativeFile(
+        var result = await _controller.PutRelativeFile(
             fileId,
             suggestedTarget: UtfString.FromDecoded(".docx"));
 
@@ -1305,17 +1305,17 @@ public class FilesControllerTests
         parentFolder.SetupGet(f => f.Identifier).Returns("parentId");
         var ancestors = new ReadOnlyCollection<IWopiFolder>([parentFolder.Object]);
 
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetAncestors<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(ancestors);
-        writableStorageProviderMock
+        _writableStorageProviderMock
             .Setup(w => w.CheckValidName<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
-        var result = await controller.PutRelativeFile(
+        var result = await _controller.PutRelativeFile(
             fileId,
             suggestedTarget: UtfString.FromDecoded("invalid|file.txt"));
 
@@ -1332,7 +1332,7 @@ public class FilesControllerTests
         var fileMock = new Mock<IWopiFile>();
         fileMock.SetupGet(f => f.Version).Returns(version);
 
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
     }
@@ -1343,9 +1343,9 @@ public class FilesControllerTests
         var fileId = "test-file-id";
         SetupFileMock(fileId);
 
-        controller = new FilesController(
-            storageProviderMock.Object,
-            memoryCache)
+        _controller = new FilesController(
+            _storageProviderMock.Object,
+            _memoryCache)
         {
             ControllerContext = new ControllerContext
             {
@@ -1355,7 +1355,7 @@ public class FilesControllerTests
 
         var wopiOverrideHeader = WopiFileOperations.Lock;
 
-        var result = await controller.ProcessLock(fileId, wopiOverrideHeader);
+        var result = await _controller.ProcessLock(fileId, wopiOverrideHeader);
 
         var lockMismatchResult = Assert.IsType<LockMismatchResult>(result);
         Assert.Equal("Locking is not supported", lockMismatchResult.Reason);
@@ -1369,15 +1369,15 @@ public class FilesControllerTests
 
         var oversized = new string('a', WopiLockInfo.MaxLockIdLength + 1);
 
-        var result = await controller.ProcessLock(
+        var result = await _controller.ProcessLock(
             fileId,
             wopiOverrideHeader: WopiFileOperations.Lock,
             newLockIdentifier: oversized);
 
         Assert.IsType<BadRequestResult>(result);
-        Assert.True(controller.Response.Headers.ContainsKey(WopiHeaders.LOCK_FAILURE_REASON));
+        Assert.True(_controller.Response.Headers.ContainsKey(WopiHeaders.LOCK_FAILURE_REASON));
         Assert.Contains(WopiLockInfo.MaxLockIdLength.ToString(System.Globalization.CultureInfo.InvariantCulture),
-            controller.Response.Headers[WopiHeaders.LOCK_FAILURE_REASON].ToString());
+            _controller.Response.Headers[WopiHeaders.LOCK_FAILURE_REASON].ToString());
     }
 
     [Fact]
@@ -1388,7 +1388,7 @@ public class FilesControllerTests
 
         var oversized = new string('z', WopiLockInfo.MaxLockIdLength + 1);
 
-        var result = await controller.ProcessLock(
+        var result = await _controller.ProcessLock(
             fileId,
             wopiOverrideHeader: WopiFileOperations.Lock,
             oldLockIdentifier: oversized,
@@ -1404,11 +1404,11 @@ public class FilesControllerTests
         SetupFileMock(fileId);
         // exactly at the cap - must NOT be rejected.
         var atCap = new string('x', WopiLockInfo.MaxLockIdLength);
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
-        lockProviderMock.Setup(x => x.AddLockAsync(fileId, atCap, It.IsAny<CancellationToken>()))
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _lockProviderMock.Setup(x => x.AddLockAsync(fileId, atCap, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new WopiLockInfo { LockId = atCap, FileId = fileId });
 
-        var result = await controller.ProcessLock(
+        var result = await _controller.ProcessLock(
             fileId,
             wopiOverrideHeader: WopiFileOperations.Lock,
             newLockIdentifier: atCap);
@@ -1424,12 +1424,12 @@ public class FilesControllerTests
 
         var wopiOverrideHeader = WopiFileOperations.GetLock;
         var lockInfo = new WopiLockInfo { LockId = "existing-lock-id", FileId = fileId };
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
 
-        var result = await controller.ProcessLock(fileId, wopiOverrideHeader);
+        var result = await _controller.ProcessLock(fileId, wopiOverrideHeader);
 
         Assert.IsType<OkResult>(result);
-        Assert.Equal("existing-lock-id", controller.Response.Headers[WopiHeaders.LOCK]);
+        Assert.Equal("existing-lock-id", _controller.Response.Headers[WopiHeaders.LOCK]);
     }
 
     [Fact]
@@ -1439,12 +1439,12 @@ public class FilesControllerTests
         SetupFileMock(fileId);
 
         var wopiOverrideHeader = WopiFileOperations.GetLock;
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
 
-        var result = await controller.ProcessLock(fileId, wopiOverrideHeader);
+        var result = await _controller.ProcessLock(fileId, wopiOverrideHeader);
 
         Assert.IsType<OkResult>(result);
-        Assert.Equal(WopiHeaders.EMPTY_LOCK_VALUE, controller.Response.Headers[WopiHeaders.LOCK]);
+        Assert.Equal(WopiHeaders.EMPTY_LOCK_VALUE, _controller.Response.Headers[WopiHeaders.LOCK]);
         // Spec (GetLock): "the host must return a 200 OK and include an X-WOPI-Lock response header
         // set to the empty string." Pinning the literal value guards against a regression to the
         // pre-#359 IIS-workaround behavior where this constant was a single space.
@@ -1459,7 +1459,7 @@ public class FilesControllerTests
         // flows through HandleGetLock at request time.
         var fileId = "test-file-id";
         SetupFileMock(fileId);
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
 
         var customOptions = Options.Create(new WopiHostOptions
         {
@@ -1467,7 +1467,7 @@ public class FilesControllerTests
             ClientUrl = new Uri("http://localhost:5000"),
             EmptyLockHeaderValue = " ",
         });
-        controller.ControllerContext = new ControllerContext
+        _controller.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext
             {
@@ -1475,10 +1475,10 @@ public class FilesControllerTests
             }
         };
 
-        var result = await controller.ProcessLock(fileId, WopiFileOperations.GetLock);
+        var result = await _controller.ProcessLock(fileId, WopiFileOperations.GetLock);
 
         Assert.IsType<OkResult>(result);
-        Assert.Equal(" ", controller.Response.Headers[WopiHeaders.LOCK]);
+        Assert.Equal(" ", _controller.Response.Headers[WopiHeaders.LOCK]);
     }
 
     [Fact]
@@ -1487,7 +1487,7 @@ public class FilesControllerTests
         // Same option flow on the PutFile 409-with-empty-lock path (via LockMismatchResult).
         var fileId = "testFileId";
         var fileMock = CreateFileMock(fileId, size: 1024);
-        storageProviderMock
+        _storageProviderMock
             .Setup(s => s.GetWopiResource<IWopiFile>(fileId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fileMock.Object);
 
@@ -1497,7 +1497,7 @@ public class FilesControllerTests
             ClientUrl = new Uri("http://localhost:5000"),
             EmptyLockHeaderValue = " ",
         });
-        controller.ControllerContext = new ControllerContext
+        _controller.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext
             {
@@ -1505,10 +1505,10 @@ public class FilesControllerTests
             }
         };
 
-        var result = await controller.PutFile(fileId, newLockIdentifier: null);
+        var result = await _controller.PutFile(fileId, newLockIdentifier: null);
 
         Assert.IsType<LockMismatchResult>(result);
-        Assert.Equal(" ", controller.Response.Headers[WopiHeaders.LOCK].ToString());
+        Assert.Equal(" ", _controller.Response.Headers[WopiHeaders.LOCK].ToString());
     }
 
     [Fact]
@@ -1519,10 +1519,10 @@ public class FilesControllerTests
 
         var wopiOverrideHeader = WopiFileOperations.Lock;
         var newLockIdentifier = "new-lock-id";
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
-        lockProviderMock.Setup(x => x.AddLockAsync(fileId, newLockIdentifier, It.IsAny<CancellationToken>())).ReturnsAsync(new WopiLockInfo { LockId = newLockIdentifier, FileId = fileId });
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _lockProviderMock.Setup(x => x.AddLockAsync(fileId, newLockIdentifier, It.IsAny<CancellationToken>())).ReturnsAsync(new WopiLockInfo { LockId = newLockIdentifier, FileId = fileId });
 
-        var result = await controller.ProcessLock(fileId, wopiOverrideHeader, newLockIdentifier: newLockIdentifier);
+        var result = await _controller.ProcessLock(fileId, wopiOverrideHeader, newLockIdentifier: newLockIdentifier);
 
         Assert.IsType<OkResult>(result);
     }
@@ -1536,10 +1536,10 @@ public class FilesControllerTests
         var wopiOverrideHeader = WopiFileOperations.Unlock;
         var newLockIdentifier = "existing-lock-id";
         var lockInfo = new WopiLockInfo { LockId = newLockIdentifier, FileId = fileId };
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
-        lockProviderMock.Setup(x => x.RemoveLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
+        _lockProviderMock.Setup(x => x.RemoveLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
-        var result = await controller.ProcessLock(fileId, wopiOverrideHeader, newLockIdentifier: newLockIdentifier);
+        var result = await _controller.ProcessLock(fileId, wopiOverrideHeader, newLockIdentifier: newLockIdentifier);
 
         Assert.IsType<OkResult>(result);
     }
@@ -1553,10 +1553,10 @@ public class FilesControllerTests
         var wopiOverrideHeader = WopiFileOperations.RefreshLock;
         var newLockIdentifier = "existing-lock-id";
         var lockInfo = new WopiLockInfo { LockId = newLockIdentifier, FileId = fileId };
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
-        lockProviderMock.Setup(x => x.RefreshLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
+        _lockProviderMock.Setup(x => x.RefreshLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
-        var result = await controller.ProcessLock(fileId, wopiOverrideHeader, newLockIdentifier: newLockIdentifier);
+        var result = await _controller.ProcessLock(fileId, wopiOverrideHeader, newLockIdentifier: newLockIdentifier);
 
         Assert.IsType<OkResult>(result);
     }
@@ -1566,9 +1566,9 @@ public class FilesControllerTests
     {
         var fileId = "test-file-id";
         SetupFileMock(fileId);
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
 
-        var result = await controller.ProcessLock(fileId, WopiFileOperations.Lock, newLockIdentifier: null);
+        var result = await _controller.ProcessLock(fileId, WopiFileOperations.Lock, newLockIdentifier: null);
 
         var lockMismatch = Assert.IsType<LockMismatchResult>(result);
         Assert.Equal("Missing new lock identifier", lockMismatch.Reason);
@@ -1581,10 +1581,10 @@ public class FilesControllerTests
         var lockId = "same-lock-id";
         SetupFileMock(fileId);
         var lockInfo = new WopiLockInfo { LockId = lockId, FileId = fileId };
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
-        lockProviderMock.Setup(x => x.RefreshLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
+        _lockProviderMock.Setup(x => x.RefreshLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
-        var result = await controller.ProcessLock(fileId, WopiFileOperations.Lock, newLockIdentifier: lockId);
+        var result = await _controller.ProcessLock(fileId, WopiFileOperations.Lock, newLockIdentifier: lockId);
 
         Assert.IsType<OkResult>(result);
     }
@@ -1595,9 +1595,9 @@ public class FilesControllerTests
         var fileId = "test-file-id";
         SetupFileMock(fileId);
         var lockInfo = new WopiLockInfo { LockId = "existing-lock", FileId = fileId };
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
 
-        var result = await controller.ProcessLock(fileId, WopiFileOperations.Lock, newLockIdentifier: "different-lock");
+        var result = await _controller.ProcessLock(fileId, WopiFileOperations.Lock, newLockIdentifier: "different-lock");
 
         Assert.IsType<LockMismatchResult>(result);
     }
@@ -1607,10 +1607,10 @@ public class FilesControllerTests
     {
         var fileId = "test-file-id";
         SetupFileMock(fileId);
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
-        lockProviderMock.Setup(x => x.AddLockAsync(fileId, It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _lockProviderMock.Setup(x => x.AddLockAsync(fileId, It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
 
-        var result = await controller.ProcessLock(fileId, WopiFileOperations.Lock, newLockIdentifier: "new-lock");
+        var result = await _controller.ProcessLock(fileId, WopiFileOperations.Lock, newLockIdentifier: "new-lock");
 
         Assert.IsType<LockMismatchResult>(result);
     }
@@ -1622,9 +1622,9 @@ public class FilesControllerTests
         var oldLockId = "old-lock-id";
         SetupFileMock(fileId);
         var lockInfo = new WopiLockInfo { LockId = oldLockId, FileId = fileId };
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
 
-        var result = await controller.ProcessLock(
+        var result = await _controller.ProcessLock(
             fileId,
             WopiFileOperations.Put,
             oldLockIdentifier: oldLockId,
@@ -1642,12 +1642,12 @@ public class FilesControllerTests
         var newLockId = "new-lock-id";
         SetupFileMock(fileId);
         var lockInfo = new WopiLockInfo { LockId = oldLockId, FileId = fileId };
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
-        lockProviderMock
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
+        _lockProviderMock
             .Setup(x => x.TryUnlockAndRelockAsync(fileId, newLockId, oldLockId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
-        var result = await controller.ProcessLock(
+        var result = await _controller.ProcessLock(
             fileId,
             WopiFileOperations.Put,
             oldLockIdentifier: oldLockId,
@@ -1662,9 +1662,9 @@ public class FilesControllerTests
         var fileId = "test-file-id";
         SetupFileMock(fileId);
         var lockInfo = new WopiLockInfo { LockId = "actual-lock", FileId = fileId };
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
 
-        var result = await controller.ProcessLock(
+        var result = await _controller.ProcessLock(
             fileId,
             WopiFileOperations.Put,
             oldLockIdentifier: "wrong-old-lock",
@@ -1678,9 +1678,9 @@ public class FilesControllerTests
     {
         var fileId = "test-file-id";
         SetupFileMock(fileId);
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
 
-        var result = await controller.ProcessLock(
+        var result = await _controller.ProcessLock(
             fileId,
             WopiFileOperations.Put,
             oldLockIdentifier: "old-lock",
@@ -1696,9 +1696,9 @@ public class FilesControllerTests
         var fileId = "test-file-id";
         SetupFileMock(fileId);
         var lockInfo = new WopiLockInfo { LockId = "actual-lock", FileId = fileId };
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
 
-        var result = await controller.ProcessLock(
+        var result = await _controller.ProcessLock(
             fileId,
             WopiFileOperations.Unlock,
             newLockIdentifier: "wrong-lock");
@@ -1711,9 +1711,9 @@ public class FilesControllerTests
     {
         var fileId = "test-file-id";
         SetupFileMock(fileId);
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
 
-        var result = await controller.ProcessLock(
+        var result = await _controller.ProcessLock(
             fileId,
             WopiFileOperations.Unlock,
             newLockIdentifier: "some-lock");
@@ -1729,10 +1729,10 @@ public class FilesControllerTests
         var lockId = "lock-id";
         SetupFileMock(fileId);
         var lockInfo = new WopiLockInfo { LockId = lockId, FileId = fileId };
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
-        lockProviderMock.Setup(x => x.RemoveLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
+        _lockProviderMock.Setup(x => x.RemoveLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(false);
 
-        var result = await controller.ProcessLock(
+        var result = await _controller.ProcessLock(
             fileId,
             WopiFileOperations.Unlock,
             newLockIdentifier: lockId);
@@ -1745,9 +1745,9 @@ public class FilesControllerTests
     {
         var fileId = "test-file-id";
         SetupFileMock(fileId);
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
 
-        var result = await controller.ProcessLock(
+        var result = await _controller.ProcessLock(
             fileId,
             WopiFileOperations.RefreshLock,
             newLockIdentifier: "some-lock");
@@ -1763,9 +1763,9 @@ public class FilesControllerTests
         var lockId = "lock-id";
         SetupFileMock(fileId);
         var lockInfo = new WopiLockInfo { LockId = lockId, FileId = fileId };
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
 
-        var result = await controller.ProcessLock(
+        var result = await _controller.ProcessLock(
             fileId,
             WopiFileOperations.RefreshLock,
             newLockIdentifier: null);
@@ -1780,9 +1780,9 @@ public class FilesControllerTests
         var fileId = "test-file-id";
         SetupFileMock(fileId);
         var lockInfo = new WopiLockInfo { LockId = "actual-lock", FileId = fileId };
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
 
-        var result = await controller.ProcessLock(
+        var result = await _controller.ProcessLock(
             fileId,
             WopiFileOperations.RefreshLock,
             newLockIdentifier: "different-lock");
@@ -1797,10 +1797,10 @@ public class FilesControllerTests
         var lockId = "lock-id";
         SetupFileMock(fileId);
         var lockInfo = new WopiLockInfo { LockId = lockId, FileId = fileId };
-        lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
-        lockProviderMock.Setup(x => x.RefreshLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        _lockProviderMock.Setup(x => x.GetLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(lockInfo);
+        _lockProviderMock.Setup(x => x.RefreshLockAsync(fileId, It.IsAny<CancellationToken>())).ReturnsAsync(false);
 
-        var result = await controller.ProcessLock(
+        var result = await _controller.ProcessLock(
             fileId,
             WopiFileOperations.RefreshLock,
             newLockIdentifier: lockId);
@@ -1814,7 +1814,7 @@ public class FilesControllerTests
         var fileId = "test-file-id";
         SetupFileMock(fileId);
 
-        var result = await controller.ProcessLock(fileId, "UNKNOWN_OVERRIDE");
+        var result = await _controller.ProcessLock(fileId, "UNKNOWN_OVERRIDE");
 
         Assert.IsType<NotImplementedResult>(result);
     }

--- a/test/WopiHost.Core.Tests/Controllers/FoldersControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/FoldersControllerTests.cs
@@ -13,12 +13,12 @@ namespace WopiHost.Core.Tests.Controllers;
 
 public class FoldersControllerTests
 {
-    private readonly Mock<IWopiStorageProvider> storageProviderMock;
+    private readonly Mock<IWopiStorageProvider> _storageProviderMock;
     private readonly FoldersController _controller;
 
     public FoldersControllerTests()
     {
-        storageProviderMock = new Mock<IWopiStorageProvider>();
+        _storageProviderMock = new Mock<IWopiStorageProvider>();
         var url = new Mock<IUrlHelper>();
         url
             .Setup(_ => _.RouteUrl(It.IsAny<UrlRouteContext>()))
@@ -32,7 +32,7 @@ public class FoldersControllerTests
                     ServiceScopeFactory = TestUtils.CreateServiceScope(new Mock<IAuthenticationService>().Object),
                 }
             });
-        _controller = new FoldersController(storageProviderMock.Object)
+        _controller = new FoldersController(_storageProviderMock.Object)
         {
             Url = url.Object,
             ControllerContext = new ControllerContext
@@ -48,7 +48,7 @@ public class FoldersControllerTests
     [Fact]
     public async Task CheckFolderInfo_ReturnsNotFound_WhenFolderDoesNotExist()
     {
-        storageProviderMock
+        _storageProviderMock
             .Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => null);
 
@@ -62,7 +62,7 @@ public class FoldersControllerTests
     {
         var folder = new Mock<IWopiFolder>();
         folder.Setup(f => f.Name).Returns("TestFolder");
-        storageProviderMock
+        _storageProviderMock
             .Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => folder.Object);
 
@@ -81,7 +81,7 @@ public class FoldersControllerTests
         // controller as part of resolving #363.
         var folder = new Mock<IWopiFolder>();
         folder.Setup(f => f.Name).Returns("MyFolder");
-        storageProviderMock
+        _storageProviderMock
             .Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => folder.Object);
 
@@ -147,7 +147,7 @@ public class FoldersControllerTests
     [Fact]
     public async Task EnumerateChildren_ReturnsNotFound_WhenFolderDoesNotExist()
     {
-        storageProviderMock
+        _storageProviderMock
             .Setup(sp => sp.GetWopiResource<IWopiFolder>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => null);
 
@@ -160,10 +160,10 @@ public class FoldersControllerTests
     public async Task EnumerateChildren_ReturnsEmptyList_WhenNoFiles()
     {
         var folderId = "folder";
-        storageProviderMock
+        _storageProviderMock
             .Setup(sp => sp.GetWopiResource<IWopiFolder>(folderId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Mock<IWopiFolder>().Object);
-        storageProviderMock
+        _storageProviderMock
             .Setup(sp => sp.GetWopiFiles(folderId, null, It.IsAny<CancellationToken>()))
             .Returns(AsyncEnumerable.Empty<IWopiFile>());
 
@@ -187,10 +187,10 @@ public class FoldersControllerTests
         fileMock.Setup(f => f.Length).Returns(1024);
         fileMock.Setup(f => f.Identifier).Returns("fileId");
 
-        storageProviderMock
+        _storageProviderMock
             .Setup(sp => sp.GetWopiResource<IWopiFolder>(folderId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Mock<IWopiFolder>().Object);
-        storageProviderMock
+        _storageProviderMock
             .Setup(sp => sp.GetWopiFiles(folderId, null, It.IsAny<CancellationToken>()))
             .Returns(new[] { fileMock.Object }.ToAsyncEnumerable());
 
@@ -218,10 +218,10 @@ public class FoldersControllerTests
         fileMock1.Setup(f => f.Length).Returns(1024);
         fileMock1.Setup(f => f.Identifier).Returns("fileId1");
 
-        storageProviderMock
+        _storageProviderMock
             .Setup(sp => sp.GetWopiResource<IWopiFolder>(folderId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Mock<IWopiFolder>().Object);
-        storageProviderMock
+        _storageProviderMock
             .Setup(sp => sp.GetWopiFiles(
                 folderId,
                 It.Is<IReadOnlyCollection<string>?>(exts => exts != null && exts.SequenceEqual(new[] { ".one" })),

--- a/test/WopiHost.Core.Tests/Infrastructure/UtfStringTests.cs
+++ b/test/WopiHost.Core.Tests/Infrastructure/UtfStringTests.cs
@@ -4,44 +4,44 @@ namespace WopiHost.Core.Tests.Infrastructure;
 
 public class UtfStringTests
 {
-    const string encodedValue = "madeup+AF8-name.wopitestx";
-    const string decodedValue = "madeup_name.wopitestx";
+    const string EncodedValue = "madeup+AF8-name.wopitestx";
+    const string DecodedValue = "madeup_name.wopitestx";
 
     [Fact]
     public void FromDecoded_ShouldReturnCorrectEncodedValue()
     {
-        UtfString utfString = UtfString.FromDecoded(decodedValue);
+        UtfString utfString = UtfString.FromDecoded(DecodedValue);
 
-        Assert.Equal(encodedValue, utfString.ToString(true));
-        Assert.Equal(decodedValue, utfString.ToString(false));
+        Assert.Equal(EncodedValue, utfString.ToString(true));
+        Assert.Equal(DecodedValue, utfString.ToString(false));
     }
 
     [Fact]
     public void FromEncoded_ShouldReturnCorrectDecodedValue()
     {
-        UtfString utfString = UtfString.FromEncoded(encodedValue);
+        UtfString utfString = UtfString.FromEncoded(EncodedValue);
 
-        Assert.Equal(encodedValue, utfString.ToString(true));
-        Assert.Equal(decodedValue, utfString.ToString(false));
+        Assert.Equal(EncodedValue, utfString.ToString(true));
+        Assert.Equal(DecodedValue, utfString.ToString(false));
     }
 
     [Fact]
     public void Parse_ShouldReturnCorrectUtfString()
     {
-        UtfString utfString = UtfString.Parse(encodedValue, null);
+        UtfString utfString = UtfString.Parse(EncodedValue, null);
 
-        Assert.Equal(encodedValue, utfString.ToString(true));
-        Assert.Equal(decodedValue, utfString.ToString(false));
+        Assert.Equal(EncodedValue, utfString.ToString(true));
+        Assert.Equal(DecodedValue, utfString.ToString(false));
     }
 
     [Fact]
     public void TryParse_ShouldReturnTrueForValidString()
     {
-        bool result = UtfString.TryParse(encodedValue, null, out UtfString utfString);
+        bool result = UtfString.TryParse(EncodedValue, null, out UtfString utfString);
 
         Assert.True(result);
-        Assert.Equal(encodedValue, utfString.ToString(true));
-        Assert.Equal(decodedValue, utfString.ToString(false));
+        Assert.Equal(EncodedValue, utfString.ToString(true));
+        Assert.Equal(DecodedValue, utfString.ToString(false));
     }
 
     [Fact]
@@ -57,10 +57,10 @@ public class UtfStringTests
     [Fact]
     public void ImplicitConversion_ShouldReturnDecodedValue()
     {
-        UtfString utfString = UtfString.FromDecoded(decodedValue);
+        UtfString utfString = UtfString.FromDecoded(DecodedValue);
 
         string result = utfString;
 
-        Assert.Equal(decodedValue, result);
+        Assert.Equal(DecodedValue, result);
     }
 }

--- a/test/WopiHost.Core.Tests/Infrastructure/WopiLockAwareWritableStorageProviderTests.cs
+++ b/test/WopiHost.Core.Tests/Infrastructure/WopiLockAwareWritableStorageProviderTests.cs
@@ -8,62 +8,62 @@ namespace WopiHost.Core.Tests.Infrastructure;
 
 public class WopiLockAwareWritableStorageProviderTests
 {
-    private readonly Mock<IWopiWritableStorageProvider> innerMock = new();
-    private readonly Mock<IWopiLockProvider> lockProviderMock = new();
+    private readonly Mock<IWopiWritableStorageProvider> _innerMock = new();
+    private readonly Mock<IWopiLockProvider> _lockProviderMock = new();
 
     private WopiLockAwareWritableStorageProvider CreateDecorator()
-        => new(innerMock.Object, lockProviderMock.Object);
+        => new(_innerMock.Object, _lockProviderMock.Object);
 
     [Fact]
     public async Task DeleteWopiResource_NoLock_DelegatesToInner()
     {
-        lockProviderMock.Setup(x => x.GetLockAsync("file-1", It.IsAny<CancellationToken>()))
+        _lockProviderMock.Setup(x => x.GetLockAsync("file-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync((WopiLockInfo?)null);
-        innerMock.Setup(x => x.DeleteWopiResource<IWopiFile>("file-1", It.IsAny<CancellationToken>()))
+        _innerMock.Setup(x => x.DeleteWopiResource<IWopiFile>("file-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
         var result = await CreateDecorator().DeleteWopiResource<IWopiFile>("file-1");
 
         Assert.True(result);
-        innerMock.Verify(x => x.DeleteWopiResource<IWopiFile>("file-1", It.IsAny<CancellationToken>()), Times.Once);
+        _innerMock.Verify(x => x.DeleteWopiResource<IWopiFile>("file-1", It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task DeleteWopiResource_Locked_ThrowsAndDoesNotDelegate()
     {
-        lockProviderMock.Setup(x => x.GetLockAsync("file-1", It.IsAny<CancellationToken>()))
+        _lockProviderMock.Setup(x => x.GetLockAsync("file-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new WopiLockInfo { FileId = "file-1", LockId = "active-lock" });
 
         var ex = await Assert.ThrowsAsync<WopiResourceLockedException>(
             () => CreateDecorator().DeleteWopiResource<IWopiFile>("file-1"));
         Assert.Equal("file-1", ex.ResourceIdentifier);
         Assert.Equal("active-lock", ex.LockId);
-        innerMock.Verify(x => x.DeleteWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _innerMock.Verify(x => x.DeleteWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
     public async Task RenameWopiResource_NoLock_DelegatesToInner()
     {
-        lockProviderMock.Setup(x => x.GetLockAsync("file-2", It.IsAny<CancellationToken>()))
+        _lockProviderMock.Setup(x => x.GetLockAsync("file-2", It.IsAny<CancellationToken>()))
             .ReturnsAsync((WopiLockInfo?)null);
-        innerMock.Setup(x => x.RenameWopiResource<IWopiFile>("file-2", "renamed", It.IsAny<CancellationToken>()))
+        _innerMock.Setup(x => x.RenameWopiResource<IWopiFile>("file-2", "renamed", It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
         var result = await CreateDecorator().RenameWopiResource<IWopiFile>("file-2", "renamed");
 
         Assert.True(result);
-        innerMock.Verify(x => x.RenameWopiResource<IWopiFile>("file-2", "renamed", It.IsAny<CancellationToken>()), Times.Once);
+        _innerMock.Verify(x => x.RenameWopiResource<IWopiFile>("file-2", "renamed", It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task RenameWopiResource_Locked_ThrowsAndDoesNotDelegate()
     {
-        lockProviderMock.Setup(x => x.GetLockAsync("file-2", It.IsAny<CancellationToken>()))
+        _lockProviderMock.Setup(x => x.GetLockAsync("file-2", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new WopiLockInfo { FileId = "file-2", LockId = "lock-x" });
 
         await Assert.ThrowsAsync<WopiResourceLockedException>(
             () => CreateDecorator().RenameWopiResource<IWopiFile>("file-2", "renamed"));
-        innerMock.Verify(x => x.RenameWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _innerMock.Verify(x => x.RenameWopiResource<IWopiFile>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -72,28 +72,28 @@ public class WopiLockAwareWritableStorageProviderTests
         // The new resource doesn't have a prior lock; lock check is unnecessary and we should
         // pass straight through. (Verifies the decorator doesn't accidentally guard creation.)
         var newFile = new Mock<IWopiFile>().Object;
-        innerMock.Setup(x => x.CreateWopiChildResource<IWopiFile>("parent", "newfile.txt", It.IsAny<CancellationToken>()))
+        _innerMock.Setup(x => x.CreateWopiChildResource<IWopiFile>("parent", "newfile.txt", It.IsAny<CancellationToken>()))
             .ReturnsAsync(newFile);
 
         var result = await CreateDecorator().CreateWopiChildResource<IWopiFile>("parent", "newfile.txt");
 
         Assert.Same(newFile, result);
-        lockProviderMock.Verify(x => x.GetLockAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _lockProviderMock.Verify(x => x.GetLockAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
     public async Task ReadOnlyMethods_DoNotConsultLockProvider()
     {
-        innerMock.Setup(x => x.CheckValidName<IWopiFile>("name", It.IsAny<CancellationToken>())).ReturnsAsync(true);
-        innerMock.Setup(x => x.GetSuggestedName<IWopiFile>("parent", "name", It.IsAny<CancellationToken>())).ReturnsAsync("suggested");
-        innerMock.SetupGet(x => x.FileNameMaxLength).Returns(123);
+        _innerMock.Setup(x => x.CheckValidName<IWopiFile>("name", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _innerMock.Setup(x => x.GetSuggestedName<IWopiFile>("parent", "name", It.IsAny<CancellationToken>())).ReturnsAsync("suggested");
+        _innerMock.SetupGet(x => x.FileNameMaxLength).Returns(123);
 
         var decorator = CreateDecorator();
         Assert.True(await decorator.CheckValidName<IWopiFile>("name"));
         Assert.Equal("suggested", await decorator.GetSuggestedName<IWopiFile>("parent", "name"));
         Assert.Equal(123, decorator.FileNameMaxLength);
 
-        lockProviderMock.Verify(x => x.GetLockAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _lockProviderMock.Verify(x => x.GetLockAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -109,13 +109,13 @@ public class WopiLockAwareWritableStorageProviderTests
     public async Task AddWopiLockAwareWritableStorage_DecoratesExistingRegistration()
     {
         var services = new ServiceCollection();
-        services.AddSingleton(innerMock.Object);
-        services.AddSingleton(lockProviderMock.Object);
+        services.AddSingleton(_innerMock.Object);
+        services.AddSingleton(_lockProviderMock.Object);
         services.AddWopiLockAwareWritableStorage();
 
         // Existing test rig: when the resource is locked the resolved (decorated) writable
         // provider must throw rather than silently delegate to the inner.
-        lockProviderMock.Setup(x => x.GetLockAsync("file-x", It.IsAny<CancellationToken>()))
+        _lockProviderMock.Setup(x => x.GetLockAsync("file-x", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new WopiLockInfo { FileId = "file-x", LockId = "L" });
 
         using var sp = services.BuildServiceProvider();

--- a/test/WopiHost.Core.Tests/Infrastructure/WopiRouteNamesTests.cs
+++ b/test/WopiHost.Core.Tests/Infrastructure/WopiRouteNamesTests.cs
@@ -9,7 +9,7 @@ namespace WopiHost.Core.Tests.Infrastructure;
 
 public class WopiRouteNamesTests
 {
-    private readonly IReadOnlyList<ActionDescriptor> actionDescriptors;
+    private readonly IReadOnlyList<ActionDescriptor> _actionDescriptors;
 
     public WopiRouteNamesTests()
     {
@@ -20,7 +20,7 @@ public class WopiRouteNamesTests
         services.AddRouting();
 
         var provider = services.BuildServiceProvider();
-        actionDescriptors = provider.GetRequiredService<IActionDescriptorCollectionProvider>()
+        _actionDescriptors = provider.GetRequiredService<IActionDescriptorCollectionProvider>()
             .ActionDescriptors.Items;
     }
 
@@ -31,7 +31,7 @@ public class WopiRouteNamesTests
     [InlineData(WopiRouteNames.CheckEcosystem, "wopi/Ecosystem")]
     public void NamedRoute_HasExpectedTemplate(string routeName, string expectedTemplate)
     {
-        var descriptor = actionDescriptors
+        var descriptor = _actionDescriptors
             .FirstOrDefault(d => d.AttributeRouteInfo?.Name == routeName);
 
         Assert.NotNull(descriptor);

--- a/test/WopiHost.Core.Tests/Security/Authentication/WopiBootstrapChallengeTests.cs
+++ b/test/WopiHost.Core.Tests/Security/Authentication/WopiBootstrapChallengeTests.cs
@@ -5,13 +5,13 @@ namespace WopiHost.Core.Tests.Security.Authentication;
 
 public class WopiBootstrapChallengeTests
 {
-    private static readonly Uri AuthUri = new("https://idp.contoso.com/oauth2/authorize");
-    private static readonly Uri TokenUri = new("https://idp.contoso.com/oauth2/token");
+    private static readonly Uri s_authUri = new("https://idp.contoso.com/oauth2/authorize");
+    private static readonly Uri s_tokenUri = new("https://idp.contoso.com/oauth2/token");
 
     [Fact]
     public void Build_RequiredParametersOnly_EmitsBearerWithBothUris()
     {
-        var header = WopiBootstrapChallenge.Build(AuthUri, TokenUri);
+        var header = WopiBootstrapChallenge.Build(s_authUri, s_tokenUri);
 
         Assert.Equal(
             "Bearer authorization_uri=\"https://idp.contoso.com/oauth2/authorize\", tokenIssuance_uri=\"https://idp.contoso.com/oauth2/token\"",
@@ -21,7 +21,7 @@ public class WopiBootstrapChallengeTests
     [Fact]
     public void Build_WithProviderId_AppendsParameter()
     {
-        var header = WopiBootstrapChallenge.Build(AuthUri, TokenUri, providerId: "tpcontoso");
+        var header = WopiBootstrapChallenge.Build(s_authUri, s_tokenUri, providerId: "tpcontoso");
 
         Assert.EndsWith(", providerId=\"tpcontoso\"", header);
     }
@@ -31,7 +31,7 @@ public class WopiBootstrapChallengeTests
     {
         // Spec: hosts pre-URL-encode the JSON. The helper must not re-encode.
         var encoded = "%7B%22iOS%22%3A%5B%22contoso%22%5D%7D";
-        var header = WopiBootstrapChallenge.Build(AuthUri, TokenUri, urlSchemes: encoded);
+        var header = WopiBootstrapChallenge.Build(s_authUri, s_tokenUri, urlSchemes: encoded);
 
         Assert.EndsWith($", UrlSchemes=\"{encoded}\"", header);
     }
@@ -40,8 +40,8 @@ public class WopiBootstrapChallengeTests
     public void Build_AllParameters_EmitsThemInSpecOrder()
     {
         var header = WopiBootstrapChallenge.Build(
-            AuthUri,
-            TokenUri,
+            s_authUri,
+            s_tokenUri,
             providerId: "tpcontoso",
             urlSchemes: "abc");
 
@@ -59,7 +59,7 @@ public class WopiBootstrapChallengeTests
     public void Build_InvalidProviderId_Throws(string providerId)
     {
         Assert.Throws<ArgumentException>(() =>
-            WopiBootstrapChallenge.Build(AuthUri, TokenUri, providerId: providerId));
+            WopiBootstrapChallenge.Build(s_authUri, s_tokenUri, providerId: providerId));
     }
 
     [Theory]
@@ -69,7 +69,7 @@ public class WopiBootstrapChallengeTests
     [InlineData("ABCXYZ")]
     public void Build_ValidProviderId_Accepted(string providerId)
     {
-        var ex = Record.Exception(() => WopiBootstrapChallenge.Build(AuthUri, TokenUri, providerId: providerId));
+        var ex = Record.Exception(() => WopiBootstrapChallenge.Build(s_authUri, s_tokenUri, providerId: providerId));
 
         Assert.Null(ex);
     }
@@ -78,14 +78,14 @@ public class WopiBootstrapChallengeTests
     public void Build_NullAuthorizationUri_Throws()
     {
         Assert.Throws<ArgumentNullException>(() =>
-            WopiBootstrapChallenge.Build(authorizationUri: null!, tokenIssuanceUri: TokenUri));
+            WopiBootstrapChallenge.Build(authorizationUri: null!, tokenIssuanceUri: s_tokenUri));
     }
 
     [Fact]
     public void Build_NullTokenIssuanceUri_Throws()
     {
         Assert.Throws<ArgumentNullException>(() =>
-            WopiBootstrapChallenge.Build(authorizationUri: AuthUri, tokenIssuanceUri: null!));
+            WopiBootstrapChallenge.Build(authorizationUri: s_authUri, tokenIssuanceUri: null!));
     }
 
     [Fact]
@@ -93,7 +93,7 @@ public class WopiBootstrapChallengeTests
     {
         var ctx = new DefaultHttpContext();
 
-        WopiBootstrapChallenge.Apply(ctx.Response, AuthUri, TokenUri, providerId: "tpcontoso");
+        WopiBootstrapChallenge.Apply(ctx.Response, s_authUri, s_tokenUri, providerId: "tpcontoso");
 
         Assert.Equal(StatusCodes.Status401Unauthorized, ctx.Response.StatusCode);
         var header = Assert.Single(ctx.Response.Headers.WWWAuthenticate!);
@@ -107,6 +107,6 @@ public class WopiBootstrapChallengeTests
     public void Apply_NullResponse_Throws()
     {
         Assert.Throws<ArgumentNullException>(() =>
-            WopiBootstrapChallenge.Apply(response: null!, AuthUri, TokenUri));
+            WopiBootstrapChallenge.Apply(response: null!, s_authUri, s_tokenUri));
     }
 }

--- a/test/WopiHost.IntegrationTests/WopiAccessTokenMinterTests.cs
+++ b/test/WopiHost.IntegrationTests/WopiAccessTokenMinterTests.cs
@@ -16,7 +16,7 @@ public class WopiAccessTokenMinterTests
     // ReadJwtToken returns claims with their raw JWT payload names. The OutboundClaimTypeMap
     // converts ClaimTypes.NameIdentifier → "nameid", ClaimTypes.Email → "email",
     // ClaimTypes.Name → "unique_name" at minting time; the wopi:* names pass through as-is.
-    private static readonly JwtSecurityTokenHandler Handler = new();
+    private static readonly JwtSecurityTokenHandler s_handler = new();
 
     private static WopiTokenMintRequest StandardRequest(WopiFilePermissions permissions = WopiFilePermissions.UserCanWrite) => new()
     {
@@ -33,7 +33,7 @@ public class WopiAccessTokenMinterTests
         var minter = WopiAccessTokenMinter.FromSecret("test-secret");
         var (token, _) = minter.Mint(StandardRequest());
 
-        var jwt = Handler.ReadJwtToken(token);
+        var jwt = s_handler.ReadJwtToken(token);
 
         Assert.Equal("user-1", jwt.Claims.First(c => c.Type == "nameid").Value);
         Assert.Equal("Alice", jwt.Claims.First(c => c.Type == WopiClaimTypes.UserDisplayName).Value);
@@ -50,7 +50,7 @@ public class WopiAccessTokenMinterTests
         var minter = WopiAccessTokenMinter.FromSecret("test-secret");
         var (token, _) = minter.Mint(StandardRequest() with { UserEmail = null });
 
-        var jwt = Handler.ReadJwtToken(token);
+        var jwt = s_handler.ReadJwtToken(token);
         Assert.DoesNotContain(jwt.Claims, c => c.Type == "email");
     }
 
@@ -60,7 +60,7 @@ public class WopiAccessTokenMinterTests
         var minter = WopiAccessTokenMinter.FromSecret("test-secret");
         var (token, _) = minter.Mint(StandardRequest(WopiFilePermissions.None));
 
-        var jwt = Handler.ReadJwtToken(token);
+        var jwt = s_handler.ReadJwtToken(token);
         Assert.DoesNotContain(jwt.Claims, c => c.Type == WopiClaimTypes.FilePermissions);
     }
 

--- a/test/WopiHost.MemoryLockProvider.Tests/MemoryLockProviderTests.cs
+++ b/test/WopiHost.MemoryLockProvider.Tests/MemoryLockProviderTests.cs
@@ -288,8 +288,8 @@ public class MemoryLockProviderTests
     private static ConcurrentDictionary<string, WopiLockInfo> GetSharedLockDictionary()
     {
         var field = typeof(MemoryLockProvider)
-            .GetField("locks", BindingFlags.Static | BindingFlags.NonPublic)
-            ?? throw new InvalidOperationException("MemoryLockProvider.locks field not found");
+            .GetField("s_locks", BindingFlags.Static | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("MemoryLockProvider.s_locks field not found");
         return (ConcurrentDictionary<string, WopiLockInfo>)field.GetValue(null)!;
     }
 


### PR DESCRIPTION
## Summary

Picks the dotnet/runtime BCL field-naming convention and enforces it as a build warning across the whole repo:

- private instance fields: `_camelCase`
- private static fields: `s_camelCase`
- const fields: `PascalCase`

The convention is encoded as IDE1006 naming rules in the root `.editorconfig` (severity escalated from `suggestion` → `warning`), so the analyzer flags any future drift on every build. With `TreatWarningsAsErrors=true` already on globally, drift fails CI rather than slipping in.

Before the change, the codebase mixed at least four styles for private fields: bare `camelCase`, `_camelCase`, `s_camelCase`, and `PascalCase`. Picking one and letting the analyzer enforce it is cheaper than periodically re-tidying by hand.

## Notes on the rename

- Mechanical refactor, no behavior changes — only private identifiers move.
- Public API is unchanged.
- `MemoryLockProvider`'s internal lock dictionary field renames `locks` → `s_locks`. The `MemoryLockProviderTests.GetSharedLockDictionary` test that peeks into it via reflection is updated in lockstep — anyone else reaching into that field with reflection would need the same one-line update.

## Test plan

- [x] `dotnet build WOPI.slnx` — 0 warnings, 0 errors
- [x] `dotnet test WOPI.slnx` — green across net8/net9/net10
- [x] Spot-checked the four substring-matching hazards encountered during the rename (`_wopiAbsolutePath` not becoming `__wopiAbsolutePath`, `Testcontainers` namespace, `JwtSecurityTokenHandler` type)

Part of #380 — addresses 3.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)