### PR TITLE
chore(deps): Bump Microsoft.AspNetCore.* and Microsoft.Extensions.* to 10.0.8

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,15 +9,15 @@
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.28.0" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.10" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.14.11" />
     <PackageVersion Include="Scrutor" Version="7.0.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -12,9 +12,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
     <PackageVersion Include="FakeItEasy" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.59.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />


### PR DESCRIPTION
## Summary

Consolidates dependabot PRs that individually fail to build because each one bumps a single `Microsoft.Extensions.*` or `Microsoft.AspNetCore.*` package from `10.0.7` to `10.0.8`, but transitive dependencies already require the *other* 10.0.8 peers — triggering `NU1605` (warning-as-error) package downgrades.

For example, `Microsoft.AspNetCore.Authorization 10.0.8` transitively pulls `Microsoft.Extensions.Diagnostics 10.0.8`, which requires `Microsoft.Extensions.Options.ConfigurationExtensions >= 10.0.8`. So bumping Authorization alone fails until ConfigurationExtensions is bumped in lockstep.

Moving the whole family as one batch in `Directory.Packages.props` and `test/Directory.Packages.props` resolves it.

### Packages bumped (10.0.7 → 10.0.8)

Root `Directory.Packages.props`:
- `Microsoft.AspNetCore.Authorization` (closes #387)
- `Microsoft.Extensions.Configuration.Abstractions` (closes #396)
- `Microsoft.Extensions.Hosting.Abstractions` (closes #396)
- `Microsoft.Extensions.Http` (closes #397)
- `Microsoft.Extensions.Options` (closes #397, #400)
- `Microsoft.Extensions.Options.ConfigurationExtensions` (closes #401)
- `Microsoft.Extensions.Configuration.Binder` (transitively required, not in any dependabot PR)

`test/Directory.Packages.props`:
- `Microsoft.AspNetCore.Mvc.Testing`
- `Microsoft.Extensions.Configuration`
- `Microsoft.Extensions.Logging.Abstractions` (closes #399)

## Test plan

- [x] `dotnet restore WOPI.slnx` succeeds (no NU1605)
- [x] `dotnet build WOPI.slnx` succeeds with 0 warnings, 0 errors
- [ ] CI: build, API compatibility, validator, static analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)