### PR TITLE
Hash blob paths case-sensitively + extract WopiResourceId helper (#380 3.7)

### DIFF
--- a/src/WopiHost.Abstractions/WopiResourceId.cs
+++ b/src/WopiHost.Abstractions/WopiResourceId.cs
@@ -1,0 +1,57 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace WopiHost.Abstractions;
+
+/// <summary>
+/// Helpers for deriving deterministic, opaque WOPI resource identifiers from a path.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Storage providers shipping with WopiHost (<c>WopiHost.FileSystemProvider</c>,
+/// <c>WopiHost.AzureStorageProvider</c>) use this to compute resource ids so the same logical
+/// resource always produces the same id — across process restarts and across multiple host
+/// instances pointing at the same backing store. Third-party providers should follow the same
+/// pattern for consistency.
+/// </para>
+/// <para>
+/// <b>Contract:</b> the caller passes a <i>canonical</i> path — a string that already encodes
+/// whatever case/separator/normalization rules the underlying store uses to compare names.
+/// This helper does the hash step only; it never folds case or rewrites separators.
+/// </para>
+/// <list type="bullet">
+///   <item><description>
+///     <c>WopiHost.FileSystemProvider</c> canonicalizes via <c>Path.GetFullPath(...).ToUpperInvariant()</c>
+///     because Windows/macOS filesystems are case-insensitive — two casings refer to the same
+///     file and must produce the same id.
+///   </description></item>
+///   <item><description>
+///     <c>WopiHost.AzureStorageProvider</c> passes the blob path unchanged because Azure blob
+///     names are case-sensitive — <c>Folder/file.txt</c> and <c>folder/file.txt</c> are
+///     distinct blobs and must get distinct ids.
+///   </description></item>
+/// </list>
+/// <para>
+/// The hash is SHA-256 (not MD5) so the id-minting path is FIPS-compatible and silent under the
+/// <c>CA5351</c> analyzer. Cryptographic strength is not required — these are opaque keys — but
+/// a non-weak primitive avoids policy/compliance friction on hosts that disable broken algorithms.
+/// </para>
+/// </remarks>
+public static class WopiResourceId
+{
+    /// <summary>
+    /// Computes a deterministic, opaque WOPI resource id from an already-canonicalized path.
+    /// </summary>
+    /// <param name="canonicalPath">
+    /// The path in the form the underlying store uses for name equality. The caller is
+    /// responsible for any case-folding / separator normalization. Pass an empty string for the
+    /// root container if the store uses an empty-string sentinel.
+    /// </param>
+    /// <returns>A lower-case hex SHA-256 digest (64 characters).</returns>
+    public static string FromCanonicalPath(string canonicalPath)
+    {
+        ArgumentNullException.ThrowIfNull(canonicalPath);
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonicalPath)))
+            .ToLowerInvariant();
+    }
+}

--- a/src/WopiHost.AzureStorageProvider/BlobIdMap.cs
+++ b/src/WopiHost.AzureStorageProvider/BlobIdMap.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Security.Cryptography;
-using System.Text;
 using Microsoft.Extensions.Logging;
+using WopiHost.Abstractions;
 
 namespace WopiHost.AzureStorageProvider;
 
@@ -10,13 +9,17 @@ namespace WopiHost.AzureStorageProvider;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Identifiers are deterministic hex-SHA-256 hashes of the lowercased blob path so the same blob
-/// always produces the same ID across process restarts and separate WopiHost instances. The
-/// mapping itself is held in memory and is rebuilt by <see cref="ScanAll"/> at startup; this
-/// matches the pattern used by <c>WopiHost.FileSystemProvider</c>'s <c>InMemoryFileIds</c>.
-/// SHA-256 is used (not MD5) so the id-minting path is FIPS-compatible and silent under the
-/// <c>CA5351</c> analyzer; the id is just an opaque key, cryptographic strength isn't needed,
-/// but a non-weak primitive avoids policy friction on hosts that disable broken algorithms.
+/// Identifiers are deterministic hex-SHA-256 hashes of the blob path (see
+/// <see cref="WopiResourceId.FromCanonicalPath"/>) so the same blob always produces the same id
+/// across process restarts and separate WopiHost instances. The mapping itself is held in memory
+/// and is rebuilt by <see cref="ScanAll"/> at startup; this matches the pattern used by
+/// <c>WopiHost.FileSystemProvider</c>'s <c>InMemoryFileIds</c>.
+/// </para>
+/// <para>
+/// <strong>Blob paths are hashed as-is, without case-folding.</strong> Azure Blob Storage treats
+/// blob names case-sensitively — <c>Folder/file.txt</c> and <c>folder/file.txt</c> are distinct
+/// blobs — so case-folding before hashing would silently merge two distinct blobs onto a single
+/// id, with the second's mapping overwriting the first in the in-memory dictionary.
 /// </para>
 /// <para>
 /// Folders are virtual: a path with no extension and no marker blob still appears in the map if any
@@ -122,7 +125,10 @@ public sealed partial class BlobIdMap(ILogger<BlobIdMap> logger)
         }
     }
 
-    /// <summary>Returns the deterministic id for a blob path.</summary>
-    public static string IdFromPath(string path)
-        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(path.ToLowerInvariant()))).ToLowerInvariant();
+    /// <summary>
+    /// Returns the deterministic id for a blob path. The path is hashed as-is — Azure blob
+    /// names are case-sensitive, so two casings of the same name are <em>different</em> blobs
+    /// and must produce different ids.
+    /// </summary>
+    public static string IdFromPath(string path) => WopiResourceId.FromCanonicalPath(path);
 }

--- a/src/WopiHost.FileSystemProvider/InMemoryFileIds.cs
+++ b/src/WopiHost.FileSystemProvider/InMemoryFileIds.cs
@@ -1,7 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Security.Cryptography;
-using System.Text;
 using Microsoft.Extensions.Logging;
+using WopiHost.Abstractions;
 
 namespace WopiHost.FileSystemProvider;
 
@@ -118,12 +117,12 @@ public partial class InMemoryFileIds(ILogger<InMemoryFileIds> logger)
     /// produces the same identifier, even across process restarts or separate services.
     /// </summary>
     /// <remarks>
-    /// Uses SHA-256 (not MD5) so the id-minting path is FIPS-compatible and silent under the
-    /// <c>CA5351</c> analyzer. The id is purely an opaque key; cryptographic strength isn't
-    /// required, but a non-weak primitive avoids policy/compliance friction on hosts that
-    /// disable broken algorithms entirely.
+    /// Case-folds with <see cref="string.ToUpperInvariant"/> before delegating to
+    /// <see cref="WopiResourceId.FromCanonicalPath"/>: Windows and macOS filesystems compare
+    /// names case-insensitively, so two casings of the same file must produce one stable id.
+    /// On case-sensitive Linux filesystems this is conservative but harmless — the same path
+    /// still hashes to the same id.
     /// </remarks>
     private static string IdFromPath(string path) =>
-        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(
-            Path.GetFullPath(path).ToUpperInvariant()))).ToLowerInvariant();
+        WopiResourceId.FromCanonicalPath(Path.GetFullPath(path).ToUpperInvariant());
 }

--- a/test/WopiHost.AzureStorageProvider.Tests/BlobIdMapTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/BlobIdMapTests.cs
@@ -8,15 +8,35 @@ public class BlobIdMapTests
     private static BlobIdMap NewMap() => new(NullLogger<BlobIdMap>.Instance);
 
     [Fact]
-    public void IdFromPath_DeterministicAndCaseInsensitive()
+    public void IdFromPath_DeterministicAndCaseSensitive()
     {
         var lower = BlobIdMap.IdFromPath("a/b/file.txt");
         var upper = BlobIdMap.IdFromPath("A/B/FILE.TXT");
 
-        Assert.Equal(lower, upper);
+        // Azure blob names are case-sensitive — distinct casings must produce distinct ids,
+        // otherwise the in-memory map would silently merge two real blobs onto a single id.
+        Assert.NotEqual(lower, upper);
+
+        // Same path twice still hashes to the same id (determinism).
+        Assert.Equal(lower, BlobIdMap.IdFromPath("a/b/file.txt"));
+
         // Hex SHA-256 — 64 lowercase hex chars.
         Assert.Equal(64, lower.Length);
         Assert.All(lower, c => Assert.True(char.IsAsciiHexDigitLower(c)));
+    }
+
+    [Fact]
+    public void ScanAll_BlobsDifferingOnlyByCase_RegistersBoth()
+    {
+        // Regression test: previously BlobIdMap case-folded the path before hashing, which
+        // collapsed Foo/file.txt and foo/file.txt onto the same id and silently dropped one
+        // from the map. Azure stores them as distinct blobs — the provider must too.
+        var map = NewMap();
+        map.ScanAll(["Foo/file.txt", "foo/file.txt"]);
+
+        Assert.True(map.TryGetFileId("Foo/file.txt", out var upperId));
+        Assert.True(map.TryGetFileId("foo/file.txt", out var lowerId));
+        Assert.NotEqual(upperId, lowerId);
     }
 
     [Fact]

--- a/test/WopiHost.Core.Tests/Abstractions/WopiResourceIdTests.cs
+++ b/test/WopiHost.Core.Tests/Abstractions/WopiResourceIdTests.cs
@@ -1,0 +1,54 @@
+using WopiHost.Abstractions;
+
+namespace WopiHost.Core.Tests.Abstractions;
+
+public class WopiResourceIdTests
+{
+    [Fact]
+    public void FromCanonicalPath_NullPath_Throws()
+        => Assert.Throws<ArgumentNullException>(() => WopiResourceId.FromCanonicalPath(null!));
+
+    [Fact]
+    public void FromCanonicalPath_EmptyPath_ReturnsStableHash()
+    {
+        // Empty-string sentinel is how the Azure provider denotes the root container; the
+        // helper must accept it and produce a deterministic 64-char lowercase hex SHA-256.
+        var id1 = WopiResourceId.FromCanonicalPath(string.Empty);
+        var id2 = WopiResourceId.FromCanonicalPath(string.Empty);
+
+        Assert.Equal(id1, id2);
+        Assert.Equal(64, id1.Length);
+        Assert.All(id1, c => Assert.True(char.IsAsciiHexDigitLower(c)));
+    }
+
+    [Fact]
+    public void FromCanonicalPath_IsDeterministic()
+    {
+        var first = WopiResourceId.FromCanonicalPath("docs/report.docx");
+        var second = WopiResourceId.FromCanonicalPath("docs/report.docx");
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void FromCanonicalPath_DoesNotCaseFold()
+    {
+        // The contract is that the *caller* applies case-folding when the underlying store
+        // compares names case-insensitively. The helper hashes the bytes it was given,
+        // unchanged. Two casings of the same path must produce different ids, otherwise
+        // case-sensitive stores (like Azure Blob Storage) lose data.
+        var lower = WopiResourceId.FromCanonicalPath("Foo/file.txt");
+        var upper = WopiResourceId.FromCanonicalPath("FOO/FILE.TXT");
+
+        Assert.NotEqual(lower, upper);
+    }
+
+    [Fact]
+    public void FromCanonicalPath_OutputIsLowercaseHex()
+    {
+        var id = WopiResourceId.FromCanonicalPath("any/path/will/do.txt");
+
+        Assert.Equal(64, id.Length);
+        Assert.All(id, c => Assert.True(char.IsAsciiHexDigitLower(c)));
+    }
+}


### PR DESCRIPTION
## Summary

Item 3.7 in #380 flagged that the two storage providers case-folded paths in opposite directions before hashing (`FS: ToUpperInvariant`, `Azure: ToLowerInvariant`). Digging in revealed the inconsistency was hiding a real bug, not just a smell.

### The bug

Azure Blob Storage treats blob names **case-sensitively** — `Folder/file.txt` and `folder/file.txt` are distinct blobs. But `BlobIdMap.IdFromPath` case-folded the path before hashing, so both casings collapsed onto the same WOPI id. The in-memory `Dictionary<string, string>` then let the second's path overwrite the first's, leaving the first blob still in storage but unreachable through WOPI's id-keyed lookups.

The FS provider's case-folding is correct (Windows/macOS filesystems compare names case-insensitively); Azure's wasn't.

### Fix

New `WopiHost.Abstractions.WopiResourceId.FromCanonicalPath(string)` helper holds the hash step ("deterministic SHA-256 of canonical path, lower-case hex"). The helper deliberately **doesn't** case-fold — that's the caller's job, because case-equality semantics depend on the underlying store:

- **FileSystemProvider** keeps `Path.GetFullPath(...).ToUpperInvariant()` before calling the helper. No behavior change; FS IDs unchanged.
- **AzureStorageProvider** drops the `ToLowerInvariant` and passes the blob path raw. **One-time ID change** for any pre-existing Azure deployment — acceptable per CLAUDE.md's "the two newest packages opt out of package validation until they have a prior release to validate against."

### Why the helper helps

Even though both providers already had `IdFromPath` static methods, the *convention* lived in two places and was easy to copy wrong. Future provider authors (S3, GCS, ...) now have one well-documented seam: "canonicalize the path the way your store compares names, then hash with `WopiResourceId.FromCanonicalPath`."

## Test plan

- [x] `dotnet build WOPI.slnx` — 0 warnings, 0 errors
- [x] `dotnet test WOPI.slnx` — green across net8/net9/net10
- [x] New `WopiResourceIdTests` (Abstractions, in Core.Tests) — 5 tests: determinism, null guard, empty-path, no-case-folding contract, hex output.
- [x] `BlobIdMapTests.IdFromPath_DeterministicAndCaseInsensitive` **inverted** to `_CaseSensitive` (the old test asserted the bug).
- [x] New `BlobIdMapTests.ScanAll_BlobsDifferingOnlyByCase_RegistersBoth` regression test.

## Breaking changes

`WopiHost.AzureStorageProvider` resource ids change one time. Bookmarked WOPI URLs from pre-upgrade deployments stop resolving after restart; tokens are 10-minute-TTL so live sessions self-heal. The package is pre-stable per CLAUDE.md, so this is the right time to make the correctness fix.

`WopiHost.FileSystemProvider` ids are unchanged.

Part of #380 — addresses 3.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)