### PR TITLE
Make WopiOriginValidationActionFilter's auth-ordering dependency explicit (#380 4.1)

### DIFF
--- a/src/WopiHost.Core/Security/Authentication/WopiOriginValidationActionFilter.Logging.cs
+++ b/src/WopiHost.Core/Security/Authentication/WopiOriginValidationActionFilter.Logging.cs
@@ -16,4 +16,11 @@ public partial class WopiOriginValidationActionFilter
         Level = LogLevel.Warning,
         Message = "WOPI request rejected: proof-key validation failed")]
     private static partial void LogProofRejected(ILogger logger);
+
+    // Logged at Error (not Warning) because reaching this filter without an authenticated
+    // principal means the host's auth pipeline is misconfigured — operator action required.
+    [LoggerMessage(
+        Level = LogLevel.Error,
+        Message = "WOPI proof filter reached on an unauthenticated request — auth pipeline misconfigured ([Authorize] missing, scheme misregistered, or middleware reordered). Returning 401.")]
+    private static partial void LogUnauthenticatedRequestReached(ILogger logger);
 }

--- a/src/WopiHost.Core/Security/Authentication/WopiOriginValidationActionFilter.cs
+++ b/src/WopiHost.Core/Security/Authentication/WopiOriginValidationActionFilter.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -10,10 +9,30 @@ using WopiHost.Core.Infrastructure;
 namespace WopiHost.Core.Security.Authentication;
 
 /// <summary>
-/// Action Filter running on Core /wopi Controllers, that validates the origin of WOPI requests by checking proof keys.
+/// Action filter that validates the WOPI proof-key signature on incoming requests, asserting
+/// that the request originated from a legitimate WOPI client (Microsoft 365 for the web, Office
+/// Online Server, etc.).
 /// </summary>
 /// <remarks>
-/// Creates a new instance of the <see cref="WopiOriginValidationActionFilter"/> class.
+/// <para>
+/// <strong>Pipeline ordering — load-bearing.</strong> The proof signature is computed over the
+/// validated <c>access_token</c>, so this filter <em>must</em> run after the authentication
+/// middleware (which materializes the <see cref="System.Security.Claims.ClaimsPrincipal"/>) and
+/// after <c>[Authorize]</c>. MVC's filter pipeline guarantees this by construction —
+/// authentication is middleware, authorization filters run before action filters, and this
+/// filter is an action filter. The first defensive check below makes the dependency explicit
+/// so a future refactor that moves things around fails loudly instead of silently letting
+/// proof-validated-but-unauthenticated requests through.
+/// </para>
+/// <para>
+/// <strong>Response codes.</strong> The WOPI proof-keys spec mandates 500 Internal Server Error
+/// when a signature fails verification (see
+/// <see href="https://learn.microsoft.com/en-us/microsoft-365/cloud-storage-partner-program/online/scenarios/proofkeys">
+/// Verify that requests originate from Microsoft 365 for the web by using proof keys</see>).
+/// That 500 is specifically for "the signature is invalid" — pipeline-misconfiguration paths
+/// (unauthenticated request reaching this filter) return 401 because there is no validated
+/// principal at all, which is a different failure mode than "valid principal, bad signature."
+/// </para>
 /// </remarks>
 /// <param name="proofValidator">The service used to validate WOPI proof keys.</param>
 /// <param name="logger">Logger instance.</param>
@@ -21,14 +40,24 @@ namespace WopiHost.Core.Security.Authentication;
 public partial class WopiOriginValidationActionFilter(IWopiProofValidator proofValidator, ILogger<WopiOriginValidationActionFilter> logger) : Attribute, IAsyncActionFilter
 {
     /// <summary>
-    /// Execute pipeline before any Controller for /wopi endpoints
+    /// Validates the WOPI proof-key signature before letting the request reach the controller.
     /// </summary>
-    /// <param name="context"></param>
-    /// <param name="next"></param>
     public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(next);
+
+        // Defense-in-depth against pipeline misconfiguration: reaching this filter without an
+        // authenticated principal means [Authorize] was removed, the auth scheme is misregistered,
+        // or the filter was attached to a controller that doesn't authenticate at all. The 500
+        // mandated by the proof-keys spec only applies to invalid signatures — this is a
+        // different failure (no validated principal), so 401 is correct.
+        if (context.HttpContext.User.Identity?.IsAuthenticated != true)
+        {
+            LogUnauthenticatedRequestReached(logger);
+            context.Result = new UnauthorizedResult();
+            return;
+        }
 
         string accessToken = context.HttpContext.Request.GetAccessToken();
         if (string.IsNullOrEmpty(accessToken))
@@ -36,7 +65,7 @@ public partial class WopiOriginValidationActionFilter(IWopiProofValidator proofV
             LogAccessTokenMissing(logger);
             WopiTelemetry.ProofValidationFailures.Add(1,
                 new KeyValuePair<string, object?>("reason", "access_token_missing"));
-            context.HttpContext.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+            context.Result = new StatusCodeResult(StatusCodes.Status500InternalServerError);
             return;
         }
 

--- a/test/WopiHost.Core.Tests/Security/Authentication/WopiOriginValidationActionFilterTests.cs
+++ b/test/WopiHost.Core.Tests/Security/Authentication/WopiOriginValidationActionFilterTests.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
@@ -27,26 +28,60 @@ public class WopiOriginValidationActionFilterTests
             controller: new object());
     }
 
+    /// <summary>
+    /// Constructs an HttpContext with an authenticated principal so the filter's pipeline-order
+    /// guard passes and the test can exercise the post-auth code paths (access token, proof).
+    /// </summary>
+    private static DefaultHttpContext BuildAuthenticatedHttpContext()
+    {
+        var http = new DefaultHttpContext
+        {
+            // Identity authentication requires a non-null AuthenticationType for IsAuthenticated
+            // to be true — DefaultHttpContext starts with an unauthenticated empty ClaimsIdentity.
+            User = new ClaimsPrincipal(new ClaimsIdentity(authenticationType: "test")),
+        };
+        return http;
+    }
+
     private WopiOriginValidationActionFilter BuildSut() =>
         new(_validator.Object, NullLogger<WopiOriginValidationActionFilter>.Instance);
 
     [Fact]
-    public async Task OnActionExecutionAsync_NoAccessToken_SetsInternalServerError()
+    public async Task OnActionExecutionAsync_Unauthenticated_ReturnsUnauthorizedAndShortCircuits()
     {
-        var ctx = BuildContext(new DefaultHttpContext());
+        // Regression test for the pipeline-order invariant: if [Authorize] was removed or the
+        // auth scheme is misregistered, the proof filter must reject — it has no validated
+        // principal to anchor the proof signature against.
+        var ctx = BuildContext(new DefaultHttpContext()); // unauthenticated by default
         var nextCalled = false;
         Task<ActionExecutedContext> Next() { nextCalled = true; return Task.FromResult<ActionExecutedContext>(null!); }
 
         await BuildSut().OnActionExecutionAsync(ctx, Next);
 
-        Assert.Equal(StatusCodes.Status500InternalServerError, ctx.HttpContext.Response.StatusCode);
+        Assert.IsType<UnauthorizedResult>(ctx.Result);
+        Assert.False(nextCalled);
+        // Proof validator must never be called for an unauthenticated request — the guard runs first.
+        _validator.Verify(v => v.ValidateProofAsync(It.IsAny<HttpContext>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task OnActionExecutionAsync_NoAccessToken_SetsInternalServerError()
+    {
+        var ctx = BuildContext(BuildAuthenticatedHttpContext());
+        var nextCalled = false;
+        Task<ActionExecutedContext> Next() { nextCalled = true; return Task.FromResult<ActionExecutedContext>(null!); }
+
+        await BuildSut().OnActionExecutionAsync(ctx, Next);
+
+        var statusResult = Assert.IsType<StatusCodeResult>(ctx.Result);
+        Assert.Equal(StatusCodes.Status500InternalServerError, statusResult.StatusCode);
         Assert.False(nextCalled);
     }
 
     [Fact]
     public async Task OnActionExecutionAsync_ProofInvalid_SetsResultToInternalServerError()
     {
-        var http = new DefaultHttpContext();
+        var http = BuildAuthenticatedHttpContext();
         http.Request.QueryString = new QueryString("?access_token=abc");
         _validator
             .Setup(v => v.ValidateProofAsync(http, "abc"))
@@ -65,7 +100,7 @@ public class WopiOriginValidationActionFilterTests
     [Fact]
     public async Task OnActionExecutionAsync_ProofValid_CallsNext()
     {
-        var http = new DefaultHttpContext();
+        var http = BuildAuthenticatedHttpContext();
         http.Request.QueryString = new QueryString("?access_token=abc");
         _validator
             .Setup(v => v.ValidateProofAsync(http, "abc"))


### PR DESCRIPTION
## Summary

The proof-key filter is correct today only because MVC's pipeline orders authentication middleware → authorization filters → action filters by construction. Nothing in the code asserts it. Audit #380 4.1 flagged the risk: a future refactor that drops `[Authorize]`, misregisters the auth scheme, or moves the filter could silently let proof-validated-but-unauthenticated requests reach controllers.

## Approach

Lightest-touch fix that converts the implicit ordering invariant into an explicit, self-checking one:

1. **Runtime guard** at the top of `OnActionExecutionAsync`: when `HttpContext.User.Identity?.IsAuthenticated != true`, log at `Error` level (operator action required), return `UnauthorizedResult`, short-circuit. The proof validator is never called.
2. **Type-level XML doc** spells out the ordering requirement and the response-code split.
3. **New unit test** locks in the invariant.

## Why not Option B (promote to `IAuthorizationHandler`)?

Initial draft had this as the recommendation. Then I checked the WOPI proof-keys spec to verify the "this also fixes audit item 2.6 — 500→401" bonus I'd assumed:

> "When validating proof keys, if a request isn't signed properly, the host must return a 500 Internal Server Error."
>
> — [Verify that requests originate from Microsoft 365 for the web by using proof keys](https://learn.microsoft.com/en-us/microsoft-365/cloud-storage-partner-program/online/scenarios/proofkeys)

500 is spec-mandated. The audit's 2.6 (called the 500 a bug) actually contradicts the spec — separately marked as won't-fix in #380. With 2.6 off the table, Option B (authorization handler) becomes a fight with the framework: authorization handlers produce 401/403, not 500, so we'd be wiring a custom `IAuthorizationMiddlewareResultHandler` just to coerce it back. Action filter is the natural shape for "produce 500 on failure" and the explicit-guard variant is enough to fix 4.1.

## Response-code split

| Failure | Status | Source |
|---|---|---|
| Invalid proof signature | 500 | WOPI proof-keys spec |
| Access token missing | 500 | Spec-aligned (telemetry-tagged as `access_token_missing`) |
| Unauthenticated request reaches filter | **401 (new)** | Defense-in-depth — pipeline misconfiguration, not a proof failure |

## Adjacent tidy-up

The previous `access_token_missing` branch wrote status 500 directly to `HttpContext.Response.StatusCode` and returned, instead of setting `context.Result`. Normalized to `context.Result = StatusCodeResult(500)` to match the proof-rejected branch and the rest of the action-filter conventions in the codebase. Test updated accordingly.

## Test plan

- [x] `dotnet build WOPI.slnx` — 0 warnings, 0 errors
- [x] `dotnet test WOPI.slnx` — green across net8/net9/net10 (~2200 tests)
- [x] New test `OnActionExecutionAsync_Unauthenticated_ReturnsUnauthorizedAndShortCircuits` asserts both the 401 and that the proof validator is never invoked
- [x] Existing three tests updated to seed an authenticated principal so they continue to exercise the post-auth paths

Part of #380 — addresses 4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)