### PR TITLE
Drop ResourceId from auth requirement — eliminates shared-state race (#380 2.5 + 5.3)

### DIFF
--- a/src/WopiHost.Abstractions/IWopiAuthorizationRequirement.cs
+++ b/src/WopiHost.Abstractions/IWopiAuthorizationRequirement.cs
@@ -16,15 +16,21 @@ public enum WopiResourceType
 }
 
 /// <summary>
-/// Represents an authorization requirement for a given combination of resource, user, and action.
+/// Static policy declaration: the resource-type and permission combination an authenticated
+/// caller must hold to invoke a given endpoint. Implementations live as MVC attributes
+/// (typically <c>WopiAuthorizeAttribute</c>) and are cached on the action descriptor — they
+/// must therefore be immutable and free of any per-request state.
 /// </summary>
 /// <remarks>
-/// Creates an instance of <see cref="IWopiAuthorizationRequirement"/> initialized
+/// The per-request resource id is <em>not</em> part of this requirement. It belongs to the
+/// authorization handler, which derives it from <c>HttpContext.Request.RouteValues["id"]</c>
+/// when needed. Mixing per-request state into the (shared) requirement was the cause of the
+/// race fixed alongside this contract — see #380 items 2.5 and 5.3.
 /// </remarks>
 public interface IWopiAuthorizationRequirement
 {
     /// <summary>
-    /// Gets a permissions required for a given combination of resource, user, and action.
+    /// Gets the permission required for a given combination of resource, user, and action.
     /// </summary>
     Permission Permission { get; }
 
@@ -32,9 +38,4 @@ public interface IWopiAuthorizationRequirement
     /// Gets the type of the resource.
     /// </summary>
     WopiResourceType ResourceType { get; }
-
-    /// <summary>
-    /// Gets or sets the identifier of the resource.
-    /// </summary>
-    string? ResourceId { get; set; }
 }

--- a/src/WopiHost.Core/Security/Authorization/WopiAuthorizationHandler.cs
+++ b/src/WopiHost.Core/Security/Authorization/WopiAuthorizationHandler.cs
@@ -22,8 +22,13 @@ namespace WopiHost.Core.Security.Authorization;
 /// </para>
 /// <para>
 /// If you need stricter per-resource enforcement (e.g. compliance), register an additional
-/// <see cref="IAuthorizationHandler"/> that compares the route id with the claim and fails
-/// the requirement on mismatch.
+/// <see cref="IAuthorizationHandler"/> that fails the requirement on mismatch. Read the
+/// per-request resource id from the resource <see cref="HttpContext"/> the framework hands
+/// to your handler — specifically <c>httpContext.Request.RouteValues["id"]</c> — and compare
+/// it against the <see cref="WopiClaimTypes.ResourceId"/> claim on the principal. Do not read
+/// it from the requirement: requirements are policy declarations cached on the action
+/// descriptor and shared across all concurrent requests, so they must never carry
+/// per-request state.
 /// </para>
 /// </remarks>
 public partial class WopiAuthorizationHandler(ILogger<WopiAuthorizationHandler> logger)
@@ -32,10 +37,11 @@ public partial class WopiAuthorizationHandler(ILogger<WopiAuthorizationHandler> 
     /// <inheritdoc/>
     protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, WopiAuthorizeAttribute requirement, HttpContext resource)
     {
-        if (resource.Request.RouteValues.TryGetValue("id", out var fileIdRaw) && fileIdRaw is not null)
-        {
-            requirement.ResourceId = fileIdRaw.ToString();
-        }
+        // Per-request resource id stays in a local — never written onto the (shared) requirement.
+        // See class doc and #380 items 2.5 / 5.3.
+        var routeResourceId = resource.Request.RouteValues.TryGetValue("id", out var fileIdRaw)
+            ? fileIdRaw?.ToString()
+            : null;
 
         var user = context.User;
         if (user.Identity?.IsAuthenticated != true)
@@ -44,7 +50,7 @@ public partial class WopiAuthorizationHandler(ILogger<WopiAuthorizationHandler> 
             return Task.CompletedTask;
         }
 
-        WarnIfResourceBindingMismatch(user, requirement);
+        WarnIfResourceBindingMismatch(user, routeResourceId);
 
         if (!HasRequiredPermission(user, requirement))
         {
@@ -56,13 +62,13 @@ public partial class WopiAuthorizationHandler(ILogger<WopiAuthorizationHandler> 
         return Task.CompletedTask;
     }
 
-    private void WarnIfResourceBindingMismatch(ClaimsPrincipal user, WopiAuthorizeAttribute requirement)
+    private void WarnIfResourceBindingMismatch(ClaimsPrincipal user, string? routeResourceId)
     {
-        if (string.IsNullOrEmpty(requirement.ResourceId)) return;
+        if (string.IsNullOrEmpty(routeResourceId)) return;
         var ridClaim = user.FindFirstValue(WopiClaimTypes.ResourceId);
-        if (!string.IsNullOrEmpty(ridClaim) && !string.Equals(ridClaim, requirement.ResourceId, StringComparison.Ordinal))
+        if (!string.IsNullOrEmpty(ridClaim) && !string.Equals(ridClaim, routeResourceId, StringComparison.Ordinal))
         {
-            LogResourceBindingMismatch(logger, ridClaim, requirement.ResourceId);
+            LogResourceBindingMismatch(logger, ridClaim, routeResourceId);
         }
     }
 

--- a/src/WopiHost.Core/Security/Authorization/WopiAuthorizeAttribute.cs
+++ b/src/WopiHost.Core/Security/Authorization/WopiAuthorizeAttribute.cs
@@ -14,10 +14,10 @@ namespace WopiHost.Core.Security.Authorization;
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
 public class WopiAuthorizeAttribute(
     WopiResourceType resourceType,
-    Permission permission) : AuthorizeAttribute, IWopiAuthorizationRequirement,  IAuthorizationRequirement, IAuthorizationRequirementData
+    Permission permission) : AuthorizeAttribute, IWopiAuthorizationRequirement, IAuthorizationRequirement, IAuthorizationRequirementData
 {
     /// <summary>
-    /// Gets a permissions required for a given combination of resource, user, and action.
+    /// Gets the permission required for a given combination of resource, user, and action.
     /// </summary>
     public Permission Permission { get; } = permission;
 
@@ -27,14 +27,8 @@ public class WopiAuthorizeAttribute(
     public WopiResourceType ResourceType { get; } = resourceType;
 
     /// <summary>
-    /// Gets or sets the identifier of the resource.
-    /// </summary>
-    public string? ResourceId { get; set; }
-    
-    /// <summary>
     /// Gets the requirements.
     /// </summary>
-    /// <returns></returns>
     public IEnumerable<IAuthorizationRequirement> GetRequirements()
     {
         yield return this;

--- a/test/WopiHost.Core.Tests/Security/Authorization/WopiAuthorizationHandlerTests.cs
+++ b/test/WopiHost.Core.Tests/Security/Authorization/WopiAuthorizationHandlerTests.cs
@@ -1,6 +1,8 @@
+using System.Collections.Concurrent;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using WopiHost.Abstractions;
 using WopiHost.Core.Security.Authorization;
@@ -61,8 +63,73 @@ public class WopiAuthorizationHandlerTests
         await _handler.HandleAsync(ctx);
 
         Assert.True(ctx.HasSucceeded);
-        // The handler also assigns the route id onto the requirement for downstream consumers.
-        Assert.Equal("fileId", requirement.ResourceId);
+    }
+
+    [Fact]
+    public async Task Concurrent_Requests_Sharing_Attribute_Do_Not_Race_On_Audit_Log()
+    {
+        // Regression test for #380 items 2.5 / 5.3: [Authorize] attribute instances are cached
+        // on the action descriptor and shared by every concurrent request hitting the endpoint.
+        // The previous handler wrote requirement.ResourceId = routeId, then read it back into
+        // an audit log — two interleaved requests would cross-contaminate, logging the wrong
+        // file id (and inviting any custom handler that read the property to make wrong
+        // authorization decisions). After the fix the route id stays in a local; this test
+        // hammers the same shared requirement from many concurrent tasks with distinct route
+        // ids and asserts every captured log line pairs the right route id with the right
+        // claim id.
+        var requirement = new WopiAuthorizeAttribute(WopiResourceType.File, Permission.Read);
+        var captures = new ConcurrentBag<(string TokenRid, string? RouteId)>();
+        var handler = new WopiAuthorizationHandler(new CapturingLogger(captures));
+
+        const int parallelism = 64;
+        await Task.WhenAll(Enumerable.Range(0, parallelism).Select(i => Task.Run(async () =>
+        {
+            var routeId = $"file-{i}";
+            var tokenRid = $"token-rid-{i}"; // distinct from routeId — triggers the mismatch log
+            var ctx = BuildContext(requirement, routeId,
+                Authenticated(new Claim(WopiClaimTypes.ResourceId, tokenRid)));
+            await handler.HandleAsync(ctx);
+            Assert.True(ctx.HasSucceeded); // mismatch is logged-only, never fails the requirement
+        })));
+
+        Assert.Equal(parallelism, captures.Count);
+        foreach (var (tokenRid, routeId) in captures)
+        {
+            // The {tokenRid} log argument is "token-rid-N" and the {routeId} argument is
+            // "file-N" — they must agree on N. Pre-fix this would fail because both fields
+            // could be plucked from any in-flight request.
+            var tokenIndex = tokenRid["token-rid-".Length..];
+            var routeIndex = routeId!["file-".Length..];
+            Assert.Equal(tokenIndex, routeIndex);
+        }
+    }
+
+    /// <summary>
+    /// Test-only logger that captures the two structured arguments passed to
+    /// <c>LogResourceBindingMismatch</c> (tokenRid, routeId). Lets the regression test verify
+    /// that the two fields are read coherently — never crossed between in-flight requests.
+    /// </summary>
+    private sealed class CapturingLogger(ConcurrentBag<(string TokenRid, string? RouteId)> bag)
+        : ILogger<WopiAuthorizationHandler>
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+            Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            // LoggerMessage source generator yields IReadOnlyList<KeyValuePair<string, object?>>.
+            if (state is IReadOnlyList<KeyValuePair<string, object?>> kvps)
+            {
+                string? tokenRid = null;
+                string? routeId = null;
+                foreach (var kv in kvps)
+                {
+                    if (kv.Key == "tokenRid") tokenRid = kv.Value?.ToString();
+                    else if (kv.Key == "routeId") routeId = kv.Value?.ToString();
+                }
+                if (tokenRid is not null) bag.Add((tokenRid, routeId));
+            }
+        }
     }
 
     [Fact]

--- a/test/WopiHost.Core.Tests/Security/Authorization/WopiAuthorizeAttributeTests.cs
+++ b/test/WopiHost.Core.Tests/Security/Authorization/WopiAuthorizeAttributeTests.cs
@@ -24,15 +24,4 @@ public class WopiAuthorizeAttributeTests
         Assert.Single(reqs);
         Assert.Same(sut, reqs[0]);
     }
-
-    [Fact]
-    public void ResourceId_RoundTrips()
-    {
-        var sut = new WopiAuthorizeAttribute(WopiResourceType.File, Permission.Read)
-        {
-            ResourceId = "abc",
-        };
-
-        Assert.Equal("abc", sut.ResourceId);
-    }
 }


### PR DESCRIPTION
## Summary

Combined fix for #380 items **2.5** (handler mutates shared attribute state — race) and **5.3** (the requirement type carries per-request state it shouldn't have in the first place). 5.3 is the structural cause; 2.5 is the symptom. Fixing them together removes a public API wart in one go.

## The bug

`[Authorize]` attribute instances are **cached on the `ActionDescriptor`** and shared by every concurrent request hitting the endpoint. `WopiAuthorizationHandler.HandleRequirementAsync` did:

```csharp
requirement.ResourceId = fileIdRaw.ToString();   // ← writes to a SHARED instance
...
WarnIfResourceBindingMismatch(user, requirement); // ← reads requirement.ResourceId
```

Two interleaved requests for different file ids cross-contaminate — audit logs get the wrong file id paired against a claim. Any custom handler reading `requirement.ResourceId` (the existing doc explicitly invites custom handlers for stricter per-resource binding) would race the same way and could authorize the wrong resource under load.

The root cause: `IWopiAuthorizationRequirement` mixed two unrelated concepts on one type:

- **Static policy** (declaration): "this endpoint requires File + Update permission" — same for every request.
- **Dynamic context** (resolution): the resource id, derived per-request from the route.

Mixing per-request state into a shared singleton is the structural mistake.

## Fix

Remove `ResourceId` from the requirement entirely; route id flows as a local through the handler.

| File | Change |
|---|---|
| `src/WopiHost.Abstractions/IWopiAuthorizationRequirement.cs` | Remove `string? ResourceId { get; set; }`; updated XML doc explains the immutability invariant |
| `src/WopiHost.Core/Security/Authorization/WopiAuthorizeAttribute.cs` | Remove the corresponding property |
| `src/WopiHost.Core/Security/Authorization/WopiAuthorizationHandler.cs` | Derive `routeResourceId` into a local; pass to `WarnIfResourceBindingMismatch(user, routeResourceId)`; updated XML doc steers custom-handler authors at `HttpContext.Request.RouteValues["id"]` |

## Authorization decision path: untouched

The decision was never `ResourceId`-dependent. `HasRequiredPermission` only reads `requirement.ResourceType` + `requirement.Permission` + the user's `wopi:fperms` / `wopi:cperms` claims. The removed property was only feeding an audit log line — the same log line still fires, just with a race-free local instead of the shared property.

End-to-end coverage confirms it:

- **`WopiHost.IntegrationTests`** — 25 tests through the real MVC pipeline with JWT-validated principals and real `[WopiAuthorize]` attributes — green.
- **`WopiHost.SmokeTests`** — 5 tests through Kestrel-hosted samples — green.
- **`WopiHost.Core.Tests`** authorization suite (18 handler tests covering Read/Update/Rename/Delete/Create/CreateChildFile × File/Container) — green.

## Tests

- **Dropped** `WopiAuthorizeAttributeTests.ResourceId_RoundTrips` — covers a property that no longer exists.
- **Dropped** the stale `Assert.Equal("fileId", requirement.ResourceId)` in `Succeeds_For_Read_When_Bound_To_Same_File` — was locking in the buggy write.
- **Added** `Concurrent_Requests_Sharing_Attribute_Do_Not_Race_On_Audit_Log`: 64 concurrent tasks share one `WopiAuthorizeAttribute` instance with distinct route ids + claim ids, structured-args-aware test logger captures `(tokenRid, routeId)` pairs, assertion checks every pair matches on request index. Pre-fix this would have caught the race.

## Breaking change

`IWopiAuthorizationRequirement.ResourceId` was public API in `WopiHost.Abstractions` (NuGet-baselined at 6.0.0). Removing the property is binary-breaking. Acceptable for the current pre-stable window per the precedent on PR #406 (Azure-provider id case-fold drop).

**Consumer migration is mechanical:** custom authorization handlers replace `requirement.ResourceId` with `httpContext.Request.RouteValues["id"]`. The `HttpContext` resource is already in scope — it's the second parameter the framework passes to `AuthorizationHandler<TRequirement, HttpContext>.HandleRequirementAsync`.

## What we deliberately don't touch

`WopiAccessTokenRequest.ResourceId` is unrelated — that's the token's claim about which resource it was minted for, not an authorization requirement field. Stays exactly as it was.

Part of #380 — addresses 2.5 and 5.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)