### PR TITLE
style: clear analyzer messages (IDE0290/0300/0301, CA1056/1859/1861)

### DIFF
--- a/src/WopiHost.Abstractions/WopiResourceLockedException.cs
+++ b/src/WopiHost.Abstractions/WopiResourceLockedException.cs
@@ -8,25 +8,18 @@ namespace WopiHost.Abstractions;
 /// layer, so this exception only surfaces when a non-WOPI code path or future controller
 /// regression bypasses that check.
 /// </summary>
-public class WopiResourceLockedException : InvalidOperationException
+/// <param name="resourceIdentifier">Identifier of the resource the caller tried to mutate.</param>
+/// <param name="lockId">The lock id currently held on the resource.</param>
+public class WopiResourceLockedException(string resourceIdentifier, string lockId)
+    : InvalidOperationException($"Resource '{resourceIdentifier}' is locked (lock id '{lockId}'); refusing write through lock-aware storage decorator.")
 {
     /// <summary>
     /// Identifier of the resource the caller tried to mutate.
     /// </summary>
-    public string ResourceIdentifier { get; }
+    public string ResourceIdentifier { get; } = resourceIdentifier;
 
     /// <summary>
     /// The lock id currently held on the resource.
     /// </summary>
-    public string LockId { get; }
-
-    /// <summary>
-    /// Creates a new <see cref="WopiResourceLockedException"/>.
-    /// </summary>
-    public WopiResourceLockedException(string resourceIdentifier, string lockId)
-        : base($"Resource '{resourceIdentifier}' is locked (lock id '{lockId}'); refusing write through lock-aware storage decorator.")
-    {
-        ResourceIdentifier = resourceIdentifier;
-        LockId = lockId;
-    }
+    public string LockId { get; } = lockId;
 }

--- a/src/WopiHost.AzureLockProvider/WopiAzureLockProvider.cs
+++ b/src/WopiHost.AzureLockProvider/WopiAzureLockProvider.cs
@@ -28,46 +28,34 @@ namespace WopiHost.AzureLockProvider;
 /// observes the WOPI-expiry has passed and explicitly breaks the lease in <see cref="GetLockAsync"/>.
 /// </para>
 /// </remarks>
-/// <summary>Create the provider from a configured <see cref="BlobContainerClient"/>.</summary>
-public partial class WopiAzureLockProvider : IWopiLockProvider
+/// <param name="containerClient">Blob container that holds the per-fileId lock placeholders.</param>
+/// <param name="logger">Logger.</param>
+/// <param name="timeProvider">
+/// Clock source for lock timestamps and expiry. Defaults to <see cref="TimeProvider.System"/>
+/// when not supplied via DI; inject a <c>FakeTimeProvider</c> (or any custom
+/// <see cref="TimeProvider"/>) in tests to make expiry deterministic.
+/// </param>
+/// <param name="lockComparer">
+/// Lock-id comparer. Defaults to <see cref="OrdinalWopiLockComparer"/> when not supplied
+/// via DI; replace with a custom comparer (e.g. <see cref="JsonShapedWopiLockComparer"/>)
+/// to absorb known WOPI-client lock-id mutations.
+/// </param>
+public partial class WopiAzureLockProvider(
+    BlobContainerClient containerClient,
+    ILogger<WopiAzureLockProvider> logger,
+    TimeProvider? timeProvider = null,
+    IWopiLockComparer? lockComparer = null) : IWopiLockProvider
 {
     internal const string LockIdKey = "wopi_lock_id";
     internal const string LeaseIdKey = "wopi_lease_id";
     internal const string CreatedKey = "wopi_created";
 
-    private readonly BlobContainerClient _containerClient;
-    private readonly ILogger<WopiAzureLockProvider> _logger;
-    private readonly IWopiLockComparer _lockComparer;
-    private readonly TimeProvider _timeProvider;
+    private readonly BlobContainerClient _containerClient = containerClient ?? throw new ArgumentNullException(nameof(containerClient));
+    private readonly ILogger<WopiAzureLockProvider> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly IWopiLockComparer _lockComparer = lockComparer ?? OrdinalWopiLockComparer.Instance;
+    private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
     private readonly SemaphoreSlim _initLock = new(1, 1);
     private bool _initialized;
-
-    /// <summary>
-    /// Creates the provider.
-    /// </summary>
-    /// <param name="containerClient">Blob container that holds the per-fileId lock placeholders.</param>
-    /// <param name="logger">Logger.</param>
-    /// <param name="timeProvider">
-    /// Clock source for lock timestamps and expiry. Defaults to <see cref="TimeProvider.System"/>
-    /// when not supplied via DI; inject a <c>FakeTimeProvider</c> (or any custom
-    /// <see cref="TimeProvider"/>) in tests to make expiry deterministic.
-    /// </param>
-    /// <param name="lockComparer">
-    /// Lock-id comparer. Defaults to <see cref="OrdinalWopiLockComparer"/> when not supplied
-    /// via DI; replace with a custom comparer (e.g. <see cref="JsonShapedWopiLockComparer"/>)
-    /// to absorb known WOPI-client lock-id mutations.
-    /// </param>
-    public WopiAzureLockProvider(
-        BlobContainerClient containerClient,
-        ILogger<WopiAzureLockProvider> logger,
-        TimeProvider? timeProvider = null,
-        IWopiLockComparer? lockComparer = null)
-    {
-        _containerClient = containerClient ?? throw new ArgumentNullException(nameof(containerClient));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _timeProvider = timeProvider ?? TimeProvider.System;
-        _lockComparer = lockComparer ?? OrdinalWopiLockComparer.Instance;
-    }
 
     /// <inheritdoc />
     public async Task<WopiLockInfo?> GetLockAsync(string fileId, CancellationToken cancellationToken = default)

--- a/src/WopiHost.Core/Controllers/FilesController.cs
+++ b/src/WopiHost.Core/Controllers/FilesController.cs
@@ -403,7 +403,7 @@ public class FilesController(
     /// limit; whichever is largest decides. Returns <see langword="null"/> when the request is
     /// within budget or no limit is configured.
     /// </summary>
-    private IActionResult? CheckMaxFileSize(long? declaredSize = null)
+    private StatusCodeResult? CheckMaxFileSize(long? declaredSize = null)
     {
         // RequestServices can be null when the controller is invoked without a configured
         // ServiceProvidersFeature (some unit-test paths). Treat that as "no options resolved" so

--- a/src/WopiHost.Core/Infrastructure/WopiLockAwareWritableStorageProvider.cs
+++ b/src/WopiHost.Core/Infrastructure/WopiLockAwareWritableStorageProvider.cs
@@ -26,21 +26,14 @@ namespace WopiHost.Core.Infrastructure;
 /// and <see cref="GetSuggestedName{T}"/> are read-only.
 /// </para>
 /// </remarks>
-public sealed class WopiLockAwareWritableStorageProvider : IWopiWritableStorageProvider
+/// <param name="inner">the underlying writable storage provider being decorated.</param>
+/// <param name="lockProvider">the lock provider consulted before mutating writes.</param>
+public sealed class WopiLockAwareWritableStorageProvider(
+    IWopiWritableStorageProvider inner,
+    IWopiLockProvider lockProvider) : IWopiWritableStorageProvider
 {
-    private readonly IWopiWritableStorageProvider _inner;
-    private readonly IWopiLockProvider _lockProvider;
-
-    /// <summary>
-    /// Creates a new lock-aware decorator over an existing writable storage provider.
-    /// </summary>
-    /// <param name="inner">the underlying writable storage provider being decorated.</param>
-    /// <param name="lockProvider">the lock provider consulted before mutating writes.</param>
-    public WopiLockAwareWritableStorageProvider(IWopiWritableStorageProvider inner, IWopiLockProvider lockProvider)
-    {
-        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
-        _lockProvider = lockProvider ?? throw new ArgumentNullException(nameof(lockProvider));
-    }
+    private readonly IWopiWritableStorageProvider _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+    private readonly IWopiLockProvider _lockProvider = lockProvider ?? throw new ArgumentNullException(nameof(lockProvider));
 
     /// <inheritdoc />
     public int FileNameMaxLength => _inner.FileNameMaxLength;

--- a/src/WopiHost.MemoryLockProvider/MemoryLockProvider.cs
+++ b/src/WopiHost.MemoryLockProvider/MemoryLockProvider.cs
@@ -12,40 +12,30 @@ namespace WopiHost.MemoryLockProvider;
 /// the lifetime of the process but not multi-instance deployments or restarts. Operations are
 /// inherently synchronous and are wrapped in <see cref="Task.FromResult{T}"/> to satisfy the async contract.
 /// </remarks>
-public partial class MemoryLockProvider : IWopiLockProvider
+/// <param name="logger">Logger.</param>
+/// <param name="timeProvider">
+/// Clock source for lock timestamps and expiry. Defaults to <see cref="TimeProvider.System"/>
+/// when not supplied via DI; inject a <c>FakeTimeProvider</c> (or any custom
+/// <see cref="TimeProvider"/>) in tests to make expiry deterministic.
+/// </param>
+/// <param name="lockComparer">
+/// Lock-id comparer. Defaults to <see cref="OrdinalWopiLockComparer"/> when not supplied
+/// via DI; replace with a custom comparer (e.g. <see cref="JsonShapedWopiLockComparer"/>)
+/// to absorb known WOPI-client lock-id mutations.
+/// </param>
+public partial class MemoryLockProvider(
+    ILogger<MemoryLockProvider> logger,
+    TimeProvider? timeProvider = null,
+    IWopiLockComparer? lockComparer = null) : IWopiLockProvider
 {
     /// <summary>
     /// keyed with fileId
     /// </summary>
     private static readonly ConcurrentDictionary<string, WopiLockInfo> s_locks = [];
 
-    private readonly ILogger<MemoryLockProvider> _logger;
-    private readonly IWopiLockComparer _lockComparer;
-    private readonly TimeProvider _timeProvider;
-
-    /// <summary>
-    /// Creates the provider.
-    /// </summary>
-    /// <param name="logger">Logger.</param>
-    /// <param name="timeProvider">
-    /// Clock source for lock timestamps and expiry. Defaults to <see cref="TimeProvider.System"/>
-    /// when not supplied via DI; inject a <c>FakeTimeProvider</c> (or any custom
-    /// <see cref="TimeProvider"/>) in tests to make expiry deterministic.
-    /// </param>
-    /// <param name="lockComparer">
-    /// Lock-id comparer. Defaults to <see cref="OrdinalWopiLockComparer"/> when not supplied
-    /// via DI; replace with a custom comparer (e.g. <see cref="JsonShapedWopiLockComparer"/>)
-    /// to absorb known WOPI-client lock-id mutations.
-    /// </param>
-    public MemoryLockProvider(
-        ILogger<MemoryLockProvider> logger,
-        TimeProvider? timeProvider = null,
-        IWopiLockComparer? lockComparer = null)
-    {
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _timeProvider = timeProvider ?? TimeProvider.System;
-        _lockComparer = lockComparer ?? OrdinalWopiLockComparer.Instance;
-    }
+    private readonly ILogger<MemoryLockProvider> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly IWopiLockComparer _lockComparer = lockComparer ?? OrdinalWopiLockComparer.Instance;
+    private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
 
     /// <inheritdoc />
     public Task<WopiLockInfo?> GetLockAsync(string fileId, CancellationToken cancellationToken = default)

--- a/test/WopiHost.AzureStorageProvider.Tests/WopiAzureStorageProviderEdgeCaseTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/WopiAzureStorageProviderEdgeCaseTests.cs
@@ -12,6 +12,12 @@ namespace WopiHost.AzureStorageProvider.Tests;
 [Collection(AzuriteCollection.Name)]
 public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
 {
+    // Filter arrays hoisted to static readonly to satisfy CA1861 (single allocation reused across
+    // Theory iterations) and IDE0300 (collection-expression initializer).
+    private static readonly string[] s_docxFilter = [".docx"];
+    private static readonly string[] s_docxAndTxtFilter = [".docx", ".txt"];
+    private static readonly string[] s_wildcardDocxFilter = ["*.docx"];
+
     private async Task<(WopiAzureStorageProvider provider, BlobContainerClient container)> CreateProviderAsync()
     {
         var serviceClient = azurite.CreateBlobServiceClient();
@@ -130,7 +136,7 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
         await UploadAsync(container, "notes.txt");
 
         var matched = new List<string>();
-        await foreach (var f in provider.GetWopiFiles(provider.RootContainer.Identifier, new[] { ".docx" }))
+        await foreach (var f in provider.GetWopiFiles(provider.RootContainer.Identifier, s_docxFilter))
         {
             matched.Add(f.Name + "." + f.Extension);
         }
@@ -148,7 +154,7 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
         await UploadAsync(container, "notes.txt");
 
         var matched = new List<string>();
-        await foreach (var f in provider.GetWopiFiles(provider.RootContainer.Identifier, new[] { ".docx", ".txt" }))
+        await foreach (var f in provider.GetWopiFiles(provider.RootContainer.Identifier, s_docxAndTxtFilter))
         {
             matched.Add(f.Name + "." + f.Extension);
         }
@@ -166,7 +172,7 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
         await UploadAsync(container, "notes.txt");
 
         var matched = new List<string>();
-        await foreach (var f in provider.GetWopiFiles(provider.RootContainer.Identifier, new[] { ".docx" }))
+        await foreach (var f in provider.GetWopiFiles(provider.RootContainer.Identifier, s_docxFilter))
         {
             matched.Add(f.Name + "." + f.Extension);
         }
@@ -186,7 +192,7 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
         await UploadAsync(container, "doc.docx");
 
         var matched = new List<string>();
-        await foreach (var f in provider.GetWopiFiles(provider.RootContainer.Identifier, new[] { "*.docx" }))
+        await foreach (var f in provider.GetWopiFiles(provider.RootContainer.Identifier, s_wildcardDocxFilter))
         {
             matched.Add(f.Name + "." + f.Extension);
         }
@@ -207,7 +213,7 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
             nullCount++;
         }
         var emptyCount = 0;
-        await foreach (var _ in provider.GetWopiFiles(provider.RootContainer.Identifier, Array.Empty<string>()))
+        await foreach (var _ in provider.GetWopiFiles(provider.RootContainer.Identifier, []))
         {
             emptyCount++;
         }

--- a/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
@@ -16,6 +16,10 @@ namespace WopiHost.Core.Tests.Controllers;
 
 public class ContainersControllerTests
 {
+    // Hoisted to satisfy CA1861 — the Moq predicate captures this array every time the test runs;
+    // a single static instance avoids per-invocation allocation and keeps the SequenceEqual stable.
+    private static readonly string[] s_txtFilter = [".txt"];
+
     private readonly Mock<IWopiStorageProvider> _storageProviderMock;
     private readonly Mock<IWopiLockProvider> _lockProviderMock;
     private readonly Mock<IWopiWritableStorageProvider> _writableStorageProviderMock;
@@ -614,7 +618,7 @@ public class ContainersControllerTests
         _storageProviderMock
             .Setup(sp => sp.GetWopiFiles(
                 containerId,
-                It.Is<IReadOnlyCollection<string>?>(exts => exts != null && exts.SequenceEqual(new[] { ".txt" })),
+                It.Is<IReadOnlyCollection<string>?>(exts => exts != null && exts.SequenceEqual(s_txtFilter)),
                 It.IsAny<CancellationToken>()))
             .Returns(new[] { fileMock1.Object }.ToAsyncEnumerable());
         _storageProviderMock.Setup(sp => sp.GetWopiContainers(containerId, It.IsAny<CancellationToken>())).Returns(AsyncEnumerable.Empty<IWopiFolder>());

--- a/test/WopiHost.Core.Tests/Controllers/FoldersControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/FoldersControllerTests.cs
@@ -13,6 +13,10 @@ namespace WopiHost.Core.Tests.Controllers;
 
 public class FoldersControllerTests
 {
+    // Hoisted to satisfy CA1861 — the Moq predicate captures this array every time the test runs;
+    // a single static instance avoids per-invocation allocation and keeps the SequenceEqual stable.
+    private static readonly string[] s_oneFilter = [".one"];
+
     private readonly Mock<IWopiStorageProvider> _storageProviderMock;
     private readonly FoldersController _controller;
 
@@ -224,7 +228,7 @@ public class FoldersControllerTests
         _storageProviderMock
             .Setup(sp => sp.GetWopiFiles(
                 folderId,
-                It.Is<IReadOnlyCollection<string>?>(exts => exts != null && exts.SequenceEqual(new[] { ".one" })),
+                It.Is<IReadOnlyCollection<string>?>(exts => exts != null && exts.SequenceEqual(s_oneFilter)),
                 It.IsAny<CancellationToken>()))
             .Returns(new[] { fileMock1.Object }.ToAsyncEnumerable());
 

--- a/test/WopiHost.FileSystemProvider.Tests/WopiFileSystemProviderTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/WopiFileSystemProviderTests.cs
@@ -8,6 +8,12 @@ namespace WopiHost.FileSystemProvider.Tests;
 
 public class WopiFileSystemProviderTests : IDisposable
 {
+    // Filter arrays hoisted to static readonly to satisfy CA1861 (single allocation reused across
+    // Theory iterations) and IDE0300 (collection-expression initializer).
+    private static readonly string[] s_docxFilter = [".docx"];
+    private static readonly string[] s_docxAndTxtFilter = [".docx", ".txt"];
+    private static readonly string[] s_docxUpperFilter = [".DOCX"];
+
     private readonly DirectoryInfo _root;
     private readonly DirectoryInfo _sub;
     private readonly DirectoryInfo _empty;
@@ -187,7 +193,7 @@ public class WopiFileSystemProviderTests : IDisposable
     public async Task GetWopiFiles_WithSingleExtensionFilter_FiltersByExtension()
     {
         var files = new List<IWopiFile>();
-        await foreach (var f in _sut.GetWopiFiles(_sut.RootContainer.Identifier, new[] { ".docx" }))
+        await foreach (var f in _sut.GetWopiFiles(_sut.RootContainer.Identifier, s_docxFilter))
         {
             files.Add(f);
         }
@@ -203,7 +209,7 @@ public class WopiFileSystemProviderTests : IDisposable
         // are requested. Confirms the SelectMany-over-extensions plumbing emits disjoint
         // result sets without dropping any.
         var files = new List<IWopiFile>();
-        await foreach (var f in _sut.GetWopiFiles(_sut.RootContainer.Identifier, new[] { ".docx", ".txt" }))
+        await foreach (var f in _sut.GetWopiFiles(_sut.RootContainer.Identifier, s_docxAndTxtFilter))
         {
             files.Add(f);
         }
@@ -219,7 +225,7 @@ public class WopiFileSystemProviderTests : IDisposable
         // explicitly via EnumerationOptions.MatchCasing — without it, Linux hosts would
         // case-sensitively miss a request for ".DOCX" against a "root.docx" file.
         var files = new List<IWopiFile>();
-        await foreach (var f in _sut.GetWopiFiles(_sut.RootContainer.Identifier, new[] { ".DOCX" }))
+        await foreach (var f in _sut.GetWopiFiles(_sut.RootContainer.Identifier, s_docxUpperFilter))
         {
             files.Add(f);
         }
@@ -237,7 +243,7 @@ public class WopiFileSystemProviderTests : IDisposable
             withNull.Add(f);
         }
         var withEmpty = new List<IWopiFile>();
-        await foreach (var f in _sut.GetWopiFiles(_sut.RootContainer.Identifier, Array.Empty<string>()))
+        await foreach (var f in _sut.GetWopiFiles(_sut.RootContainer.Identifier, []))
         {
             withEmpty.Add(f);
         }

--- a/test/WopiHost.SmokeTests/Fixtures/ValidatorSampleFactory.cs
+++ b/test/WopiHost.SmokeTests/Fixtures/ValidatorSampleFactory.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
@@ -21,6 +22,9 @@ public sealed class ValidatorSampleFactory : IDisposable, IAsyncDisposable
 {
     private readonly WebApplication _app;
 
+    /// <summary>Loopback URL the listener bound to (Kestrel-allocated port).</summary>
+    [SuppressMessage("Design", "CA1056:URI-like properties should not be strings",
+        Justification = "The only consumer is Playwright's GotoAsync(string), which takes a string. Wrapping as Uri here just to ToString() at every call site adds noise without a security or correctness benefit — the loopback address is a trusted, internally-generated test seam.")]
     public string ServerUrl { get; }
 
     public ValidatorSampleFactory()

--- a/test/WopiHost.SmokeTests/Fixtures/ValidatorSampleFactory.cs
+++ b/test/WopiHost.SmokeTests/Fixtures/ValidatorSampleFactory.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
@@ -23,9 +22,7 @@ public sealed class ValidatorSampleFactory : IDisposable, IAsyncDisposable
     private readonly WebApplication _app;
 
     /// <summary>Loopback URL the listener bound to (Kestrel-allocated port).</summary>
-    [SuppressMessage("Design", "CA1056:URI-like properties should not be strings",
-        Justification = "The only consumer is Playwright's GotoAsync(string), which takes a string. Wrapping as Uri here just to ToString() at every call site adds noise without a security or correctness benefit — the loopback address is a trusted, internally-generated test seam.")]
-    public string ServerUrl { get; }
+    public Uri ServerUrl { get; }
 
     public ValidatorSampleFactory()
     {
@@ -75,8 +72,9 @@ public sealed class ValidatorSampleFactory : IDisposable, IAsyncDisposable
         _app.StartAsync().GetAwaiter().GetResult();
 
         var addresses = _app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>();
-        ServerUrl = addresses?.Addresses.FirstOrDefault()
+        var bound = addresses?.Addresses.FirstOrDefault()
             ?? throw new InvalidOperationException("No address bound — Kestrel didn't start as expected.");
+        ServerUrl = new Uri(bound);
     }
 
     public void Dispose() => DisposeAsync().AsTask().GetAwaiter().GetResult();

--- a/test/WopiHost.SmokeTests/Fixtures/WebSampleFactory.cs
+++ b/test/WopiHost.SmokeTests/Fixtures/WebSampleFactory.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
@@ -27,6 +28,8 @@ public sealed class WebSampleFactory : IDisposable, IAsyncDisposable
     private readonly WebApplication _app;
 
     /// <summary>Loopback URL the listener bound to.</summary>
+    [SuppressMessage("Design", "CA1056:URI-like properties should not be strings",
+        Justification = "The only consumer is Playwright's GotoAsync(string), which takes a string. Wrapping as Uri here just to ToString() at every call site adds noise without a security or correctness benefit — the loopback address is a trusted, internally-generated test seam.")]
     public string ServerUrl { get; }
 
     public WebSampleFactory()

--- a/test/WopiHost.SmokeTests/Fixtures/WebSampleFactory.cs
+++ b/test/WopiHost.SmokeTests/Fixtures/WebSampleFactory.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
@@ -28,9 +27,7 @@ public sealed class WebSampleFactory : IDisposable, IAsyncDisposable
     private readonly WebApplication _app;
 
     /// <summary>Loopback URL the listener bound to.</summary>
-    [SuppressMessage("Design", "CA1056:URI-like properties should not be strings",
-        Justification = "The only consumer is Playwright's GotoAsync(string), which takes a string. Wrapping as Uri here just to ToString() at every call site adds noise without a security or correctness benefit — the loopback address is a trusted, internally-generated test seam.")]
-    public string ServerUrl { get; }
+    public Uri ServerUrl { get; }
 
     public WebSampleFactory()
     {
@@ -75,8 +72,9 @@ public sealed class WebSampleFactory : IDisposable, IAsyncDisposable
         _app.StartAsync().GetAwaiter().GetResult();
 
         var addresses = _app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>();
-        ServerUrl = addresses?.Addresses.FirstOrDefault()
+        var bound = addresses?.Addresses.FirstOrDefault()
             ?? throw new InvalidOperationException("No address bound — Kestrel didn't start as expected.");
+        ServerUrl = new Uri(bound);
     }
 
     public void Dispose() => DisposeAsync().AsTask().GetAwaiter().GetResult();

--- a/test/WopiHost.SmokeTests/ValidatorSampleSmokeTests.cs
+++ b/test/WopiHost.SmokeTests/ValidatorSampleSmokeTests.cs
@@ -30,7 +30,7 @@ public sealed class ValidatorSampleSmokeTests(PlaywrightFixture playwright) : IA
     public async Task Index_renders()
     {
         var page = await _context.NewPageAsync();
-        var response = await page.GotoAsync(_factory.ServerUrl);
+        var response = await page.GotoAsync(_factory.ServerUrl.AbsoluteUri);
 
         Assert.NotNull(response);
         Assert.True(response.Ok, $"Expected 2xx, got {response.Status}");

--- a/test/WopiHost.SmokeTests/WebSampleSmokeTests.cs
+++ b/test/WopiHost.SmokeTests/WebSampleSmokeTests.cs
@@ -31,7 +31,7 @@ public sealed class WebSampleSmokeTests(PlaywrightFixture playwright) : IAsyncLi
     public async Task Index_renders_breadcrumb_and_file_table()
     {
         var page = await _context.NewPageAsync();
-        var response = await page.GotoAsync(_factory.ServerUrl);
+        var response = await page.GotoAsync(_factory.ServerUrl.AbsoluteUri);
 
         Assert.NotNull(response);
         Assert.True(response.Ok, $"Expected 2xx, got {response.Status}");
@@ -55,7 +55,7 @@ public sealed class WebSampleSmokeTests(PlaywrightFixture playwright) : IAsyncLi
     public async Task Action_links_carry_id_and_wopiaction_route_values()
     {
         var page = await _context.NewPageAsync();
-        await page.GotoAsync(_factory.ServerUrl);
+        await page.GotoAsync(_factory.ServerUrl.AbsoluteUri);
 
         // The View / Edit columns render as <a href="/Home/Detail/{id}?wopiaction=View|Edit">.
         var editAnchor = page.Locator("table.files tbody tr a[title='Edit']").First;
@@ -80,7 +80,7 @@ public sealed class WebSampleSmokeTests(PlaywrightFixture playwright) : IAsyncLi
         // controller stamps the "disabledIcon" class on action anchors whose action isn't
         // supported for that file's extension.
         var page = await _context.NewPageAsync();
-        await page.GotoAsync(_factory.ServerUrl);
+        await page.GotoAsync(_factory.ServerUrl.AbsoluteUri);
 
         // Find the row for test.html and assert both action anchors have disabledIcon.
         var htmlRow = page.Locator("table.files tbody tr").Filter(new() { HasText = "test.html" }).First;
@@ -105,7 +105,7 @@ public sealed class WebSampleSmokeTests(PlaywrightFixture playwright) : IAsyncLi
         var pageErrors = new List<string>();
         page.PageError += (_, error) => pageErrors.Add(error);
 
-        await page.GotoAsync(_factory.ServerUrl, new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
+        await page.GotoAsync(_factory.ServerUrl.AbsoluteUri, new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle });
 
         Assert.True(pageErrors.Count == 0, "Page errors:\n" + string.Join("\n", pageErrors));
     }


### PR DESCRIPTION
## Summary

Mechanical sweep of message-severity analyzer findings flagged by recent VS / .NET 10 analyzers. No behavior change.

**Production code:**
- `IDE0290` — convert four constructors to primary constructors:
  - `WopiResourceLockedException` (exception type with two public properties)
  - `WopiAzureLockProvider`, `MemoryLockProvider` (existing `<param>` docstrings hoisted onto the class declaration)
  - `WopiLockAwareWritableStorageProvider`
  - Null-check throws preserved as field initializers (`= param ?? throw new ArgumentNullException(...);`).
- `CA1859` — `FilesController.CheckMaxFileSize` return type narrowed from `IActionResult?` to `StatusCodeResult?` (the concrete type both branches produce). Both call sites use `var`, so no caller change required.

**Tests:**
- `IDE0300` / `IDE0301` + `CA1861` — extension-filter arrays passed to `GetWopiFiles` and Moq predicates extracted to private `static readonly` fields with `s_` prefix (per the repo's `.editorconfig` from #382). Empty-array spots inlined as `[]` (compiler lowers to cached `Array.Empty<T>()`).
- `CA1056` — convert `ServerUrl` on both SmokeTest fixtures from `string` to `Uri` (no suppression). Five Playwright call sites updated to pass `.AbsoluteUri` to `GotoAsync(string)`.

## Test plan

- [x] `dotnet build WOPI.slnx` — clean, 0 warnings, 0 errors
- [x] `dotnet test WOPI.slnx --filter "FullyQualifiedName!~SmokeTests"` — all 1000+ unit / integration tests pass across net8/net9/net10
- [ ] CI runs the full suite including smoke tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)