### PR TITLE
fix(filesystemprovider): make InMemoryFileIds thread-safe + O(1) reverse lookup (#409 item 2.2)

### DIFF
--- a/src/WopiHost.FileSystemProvider/InMemoryFileIds.cs
+++ b/src/WopiHost.FileSystemProvider/InMemoryFileIds.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using WopiHost.Abstractions;
 
@@ -7,109 +8,137 @@ namespace WopiHost.FileSystemProvider;
 /// <summary>
 /// Provides unique file identifiers for files.
 /// </summary>
-/// <remarks>very basic in-memory for sample purposes only</remarks>
+/// <remarks>
+/// <para>
+/// Very basic in-memory store for sample purposes only.
+/// </para>
+/// <para>
+/// Backed by two <see cref="ConcurrentDictionary{TKey, TValue}"/> instances — the primary
+/// id→path map plus a path→id reverse-lookup map — so <see cref="TryGetFileId"/> is O(1) instead
+/// of the O(n) <c>FirstOrDefault</c> scan of the pre-#409-item-2.2 implementation. Reads
+/// (<see cref="TryGetFileId"/> / <see cref="TryGetPath"/> / <see cref="GetPath"/> /
+/// <see cref="WasScanned"/>) are lock-free. Mutations (<see cref="AddFile"/> /
+/// <see cref="UpdateFile"/> / <see cref="RemoveId"/> / <see cref="ScanAll"/>) serialize on a
+/// private lock to keep the two maps consistent across the multi-step rebinding sequence
+/// (clear stale reverse entry → install new forward entry → install new reverse entry).
+/// </para>
+/// </remarks>
 public partial class InMemoryFileIds(ILogger<InMemoryFileIds> logger)
 {
-    private readonly Dictionary<string, string> _fileIds = [];
+    private readonly ConcurrentDictionary<string, string> _idToPath = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, string> _pathToId = new(StringComparer.Ordinal);
+    private readonly object _writeLock = new();
 
     /// <summary>
     /// Gets a value indicating whether any files have been scanned.
     /// </summary>
-    public bool WasScanned => _fileIds.Count > 0;
+    public bool WasScanned => !_idToPath.IsEmpty;
 
     /// <summary>
     /// Gets the file identifier for the specified path.
     /// </summary>
-    /// <param name="path"></param>
-    /// <param name="fileId"></param>
-    /// <returns></returns>
     public bool TryGetFileId(string path, [NotNullWhen(true)] out string? fileId)
-    {
-        fileId = _fileIds.FirstOrDefault(x => x.Value == path).Key;
-        return fileId != null;
-    }
+        => _pathToId.TryGetValue(path, out fileId);
 
     /// <summary>
-    /// Gets the file identifier for the specified path.
+    /// Gets the file path for the specified file identifier.
     /// </summary>
-    /// <param name="fileId"></param>
-    /// <param name="path"></param>
-    /// <returns></returns>
     public bool TryGetPath(string fileId, [NotNullWhen(true)] out string? path)
-    {
-        return _fileIds.TryGetValue(fileId, out path);
-    }
+        => _idToPath.TryGetValue(fileId, out path);
 
     /// <summary>
     /// Gets the path for the specified file identifier.
     /// </summary>
-    /// <param name="fileId"></param>
-    /// <returns></returns>
     public string? GetPath(string fileId)
     {
         ArgumentException.ThrowIfNullOrEmpty(fileId);
-        if (TryGetPath(fileId, out var path))
-        {
-            return path;
-        }
-        return null;
+        return _idToPath.TryGetValue(fileId, out var path) ? path : null;
     }
 
     /// <summary>
     /// Adds a file to the collection and returns its identifier.
     /// </summary>
-    /// <param name="path"></param>
-    /// <returns></returns>
     public string AddFile(string path)
     {
         var id = IdFromPath(path);
-        _fileIds[id] = path;
+        lock (_writeLock)
+        {
+            SetMapping(id, path);
+        }
         return id;
     }
 
     /// <summary>
     /// Removes the specified file identifier.
     /// </summary>
-    /// <param name="fileId"></param>
     public void RemoveId(string fileId)
     {
-        _fileIds.Remove(fileId);
+        lock (_writeLock)
+        {
+            if (_idToPath.TryRemove(fileId, out var path))
+            {
+                // Drop the reverse entry only if it still points at this id — otherwise we'd
+                // clobber a newer binding that re-attached the same path to a different id.
+                ((ICollection<KeyValuePair<string, string>>)_pathToId)
+                    .Remove(new KeyValuePair<string, string>(path, fileId));
+            }
+        }
     }
 
     /// <summary>
     /// Updates the file path for the specified file identifier.
     /// </summary>
-    /// <param name="id"></param>
-    /// <param name="path"></param>
     public void UpdateFile(string id, string path)
     {
-        _fileIds[id] = path;
+        lock (_writeLock)
+        {
+            SetMapping(id, path);
+        }
     }
 
     /// <summary>
     /// Scans all files and directories in the specified root path.
     /// </summary>
-    /// <param name="rootPath"></param>
     public void ScanAll(string rootPath)
     {
-        _fileIds.Clear();
-
-        _fileIds[IdFromPath(rootPath)] = rootPath;
-
-        foreach (var directory in Directory.EnumerateDirectories(rootPath, "*", SearchOption.AllDirectories))
+        lock (_writeLock)
         {
-            _fileIds[IdFromPath(directory)] = directory;
-        }
+            _idToPath.Clear();
+            _pathToId.Clear();
 
-        foreach (var file in Directory.EnumerateFiles(rootPath, "*", SearchOption.AllDirectories))
+            SetMapping(IdFromPath(rootPath), rootPath);
+
+            foreach (var directory in Directory.EnumerateDirectories(rootPath, "*", SearchOption.AllDirectories))
+            {
+                SetMapping(IdFromPath(directory), directory);
+            }
+
+            foreach (var file in Directory.EnumerateFiles(rootPath, "*", SearchOption.AllDirectories))
+            {
+                var newId = file.EndsWith("test.wopitest", StringComparison.OrdinalIgnoreCase)
+                    ? "WOPITEST"
+                    : IdFromPath(file);
+                SetMapping(newId, file);
+            }
+
+            LogScannedItems(logger, _idToPath.Count);
+        }
+    }
+
+    /// <summary>
+    /// Installs or rebinds the id↔path pair, keeping both maps consistent. The caller must
+    /// hold <see cref="_writeLock"/> — the three steps (drop stale reverse entry, install
+    /// forward entry, install reverse entry) are not individually atomic.
+    /// </summary>
+    private void SetMapping(string id, string path)
+    {
+        if (_idToPath.TryGetValue(id, out var oldPath) && !string.Equals(oldPath, path, StringComparison.Ordinal))
         {
-            var newId = file.EndsWith("test.wopitest", StringComparison.OrdinalIgnoreCase)
-                ? "WOPITEST"
-                : IdFromPath(file);
-            _fileIds[newId] = file;
+            ((ICollection<KeyValuePair<string, string>>)_pathToId)
+                .Remove(new KeyValuePair<string, string>(oldPath, id));
         }
-
-        LogScannedItems(logger, _fileIds.Count);
+        _idToPath[id] = path;
+        _pathToId[path] = id;
     }
 
     /// <summary>

--- a/test/WopiHost.FileSystemProvider.Tests/InMemoryFileIdsTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/InMemoryFileIdsTests.cs
@@ -131,4 +131,108 @@ public class InMemoryFileIdsTests : IDisposable
         Assert.True(_sut.TryGetPath("WOPITEST", out var resolved));
         Assert.Equal(path, resolved);
     }
+
+    [Fact]
+    public void UpdateFile_OldPath_NoLongerResolvesViaReverseLookup()
+    {
+        // #409 item 2.2: the path→id reverse map must drop the old binding when an id is
+        // rebound to a new path, otherwise stale entries pile up unboundedly.
+        var oldPath = Path.Combine(_tempDir.FullName, "old.docx");
+        var newPath = Path.Combine(_tempDir.FullName, "new.docx");
+        var id = _sut.AddFile(oldPath);
+
+        _sut.UpdateFile(id, newPath);
+
+        Assert.False(_sut.TryGetFileId(oldPath, out _));
+        Assert.True(_sut.TryGetFileId(newPath, out var resolvedId));
+        Assert.Equal(id, resolvedId);
+    }
+
+    [Fact]
+    public void RemoveId_Path_NoLongerResolvesViaReverseLookup()
+    {
+        var path = Path.Combine(_tempDir.FullName, "doc.docx");
+        var id = _sut.AddFile(path);
+
+        _sut.RemoveId(id);
+
+        Assert.False(_sut.TryGetFileId(path, out _));
+    }
+
+    [Fact]
+    public void ScanAll_Rescan_DropsBindingsForRemovedFiles()
+    {
+        // Confirm both maps are reset on rescan — pre-#409-item-2.2 the forward map was cleared
+        // but a parallel reverse map could have lingered if one was added in isolation.
+        var stalePath = Path.Combine(_tempDir.FullName, "stale.docx");
+        File.WriteAllText(stalePath, string.Empty);
+        _sut.ScanAll(_tempDir.FullName);
+        Assert.True(_sut.TryGetFileId(stalePath, out _));
+
+        File.Delete(stalePath);
+        _sut.ScanAll(_tempDir.FullName);
+
+        Assert.False(_sut.TryGetFileId(stalePath, out _));
+    }
+
+    [Fact]
+    public async Task AddFile_ConcurrentDistinctPaths_AllEntriesObservable()
+    {
+        // #409 item 2.2: pre-fix used a non-concurrent Dictionary, so parallel writers could
+        // corrupt the bucket array or lose entries silently. Verify each parallel add survives
+        // and is reachable in both directions.
+        const int writers = 64;
+        var paths = Enumerable.Range(0, writers)
+            .Select(i => Path.Combine(_tempDir.FullName, $"f{i}.docx"))
+            .ToArray();
+
+        var ids = await Task.WhenAll(
+            paths.Select(p => Task.Run(() => _sut.AddFile(p))));
+
+        Assert.Equal(writers, ids.Distinct().Count());
+        for (var i = 0; i < writers; i++)
+        {
+            Assert.True(_sut.TryGetFileId(paths[i], out var idViaPath));
+            Assert.Equal(ids[i], idViaPath);
+            Assert.True(_sut.TryGetPath(ids[i], out var pathViaId));
+            Assert.Equal(paths[i], pathViaId);
+        }
+    }
+
+    [Fact]
+    public async Task Mixed_ConcurrentAddAndRemove_LeavesConsistentState()
+    {
+        // Stress: half the workers add, the other half remove the same file id. Whatever the
+        // interleaving, the forward and reverse maps must agree (no dangling reverse entry).
+        const int rounds = 200;
+        var path = Path.Combine(_tempDir.FullName, "shared.docx");
+
+        var add = Task.Run(() =>
+        {
+            for (var i = 0; i < rounds; i++)
+            {
+                _sut.AddFile(path);
+            }
+        });
+        var remove = Task.Run(() =>
+        {
+            for (var i = 0; i < rounds; i++)
+            {
+                _sut.TryGetFileId(path, out var id);
+                if (id is not null)
+                {
+                    _sut.RemoveId(id);
+                }
+            }
+        });
+        await Task.WhenAll(add, remove);
+
+        // Final consistency check: every id present must round-trip through the reverse map and
+        // back. A leaked reverse entry would resolve to an id that's no longer in the forward map.
+        if (_sut.TryGetFileId(path, out var finalId))
+        {
+            Assert.True(_sut.TryGetPath(finalId, out var roundTripPath));
+            Assert.Equal(path, roundTripPath);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- `InMemoryFileIds` is registered as a Singleton in the Web sample but used a plain `Dictionary<string, string>` with unsynchronized `AddFile` / `RemoveId` / `UpdateFile` / `ScanAll` mutations — and an **O(n) `FirstOrDefault` scan** in `TryGetFileId`. The sample is what the smoke + benchmark suites hit, so the "for sample purposes only" disclaimer was not enough cover.
- Two `ConcurrentDictionary<string, string>` instances now back the map (id→path forward + path→id reverse). `TryGetFileId` is **O(1)** like `TryGetPath`, matching the claim already on the project README.
- Mutations serialize on a private `object _writeLock` so the three-step rebinding sequence (drop stale reverse entry → install new forward entry → install new reverse entry) stays consistent. Reads remain lock-free against the `ConcurrentDictionary` instances.

## Test plan

- [x] `dotnet build WOPI.slnx` — 0 errors / 0 warnings across `net8.0` / `net9.0` / `net10.0` (`TreatWarningsAsErrors` global).
- [x] `dotnet test test/WopiHost.FileSystemProvider.Tests` — 101/101 × 3 TFMs. Five new tests pin the contract: reverse-lookup drops the old binding on `UpdateFile`, `RemoveId` clears both maps, `ScanAll`-rescan evicts removed paths, 64 concurrent distinct-path `AddFile`s all survive both directions, and concurrent `Add` + `Remove` on the same path leaves no dangling reverse entry.
- [x] Used `object` (not `System.Threading.Lock`) since the library multi-targets `net8.0` and `Lock` is `net9.0+`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)