### PR TITLE
refactor(azurestorageprovider): share hash-finalize between HashingBlobWriteStream.Dispose paths (#420 item 2.12)

### DIFF
--- a/src/WopiHost.AzureStorageProvider/HashingBlobWriteStream.cs
+++ b/src/WopiHost.AzureStorageProvider/HashingBlobWriteStream.cs
@@ -67,12 +67,12 @@ internal sealed class HashingBlobWriteStream(Stream inner, BlobClient blobClient
 
         // Closing/disposing the inner Azure write stream is what actually commits the blob.
         await inner.DisposeAsync().ConfigureAwait(false);
-
-        var hash = _hasher.GetCurrentHash();
-        _hasher.Dispose();
-        _metadataToWrite[WopiBlobFile.Sha256MetadataKey] = Convert.ToHexString(hash).ToLowerInvariant();
-
+        FinalizeMetadataPayload();
         await blobClient.SetMetadataAsync(_metadataToWrite).ConfigureAwait(false);
+
+        // Stream has a finalizer; skip it now that DisposeAsync has done the work. The sync
+        // Stream.Dispose() base already calls SuppressFinalize, but the async path is on us.
+        GC.SuppressFinalize(this);
     }
 
     protected override void Dispose(bool disposing)
@@ -88,9 +88,19 @@ internal sealed class HashingBlobWriteStream(Stream inner, BlobClient blobClient
         _disposed = true;
 
         inner.Dispose();
+        FinalizeMetadataPayload();
+        blobClient.SetMetadata(_metadataToWrite);
+    }
+
+    /// <summary>
+    /// Finalizes the SHA-256 hasher and stores the lowercase-hex digest under the blob metadata
+    /// key. Shared between <see cref="Dispose(bool)"/> and <see cref="DisposeAsync"/> so the
+    /// two paths can never drift on the hex/casing/metadata-key contract (#409 item 2.12).
+    /// </summary>
+    private void FinalizeMetadataPayload()
+    {
         var hash = _hasher.GetCurrentHash();
         _hasher.Dispose();
         _metadataToWrite[WopiBlobFile.Sha256MetadataKey] = Convert.ToHexString(hash).ToLowerInvariant();
-        blobClient.SetMetadata(_metadataToWrite);
     }
 }

--- a/test/WopiHost.AzureStorageProvider.Tests/HashingBlobWriteStreamTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/HashingBlobWriteStreamTests.cs
@@ -170,6 +170,45 @@ public class HashingBlobWriteStreamTests(AzuriteFixture azurite)
     }
 
     [Fact]
+    public async Task Dispose_AfterDisposeAsync_IsNoOp()
+    {
+        // #409 item 2.12: a caller that does `await using` followed by an explicit sync Dispose
+        // (or any other cross-method redispose) must not retrigger the inner-stream close, the
+        // hasher finalization, or the metadata write. The `_disposed` flag at the top of both
+        // paths is what guarantees that — pin it cross-method.
+        var (blob, _) = await CreateBlobAsync();
+        const string payload = "cross-method-async-first";
+        var bytes = Encoding.UTF8.GetBytes(payload);
+
+        var s = await OpenWrapperAsync(blob);
+        await s.WriteAsync(bytes);
+        await s.DisposeAsync();
+
+        s.Dispose(); // must be a clean no-op; would have thrown if it tried to re-dispose inner
+        var props = await blob.GetPropertiesAsync();
+        Assert.Equal(payload.Length, props.Value.ContentLength);
+        Assert.Equal(ExpectedSha256(payload), props.Value.Metadata[WopiBlobFile.Sha256MetadataKey]);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_AfterDispose_IsNoOp()
+    {
+        // Mirror of the above for the sync-first ordering.
+        var (blob, _) = await CreateBlobAsync();
+        const string payload = "cross-method-sync-first";
+        var bytes = Encoding.UTF8.GetBytes(payload);
+
+        var s = await OpenWrapperAsync(blob);
+        s.Write(bytes, 0, bytes.Length);
+        s.Dispose();
+
+        await s.DisposeAsync(); // must be a clean no-op
+        var props = await blob.GetPropertiesAsync();
+        Assert.Equal(payload.Length, props.Value.ContentLength);
+        Assert.Equal(ExpectedSha256(payload), props.Value.Metadata[WopiBlobFile.Sha256MetadataKey]);
+    }
+
+    [Fact]
     public async Task PreservedMetadata_RoundTrips_AlongsideHash()
     {
         // Caller-provided metadata (e.g. the previous wopi_owner) should survive the write.


### PR DESCRIPTION
## Summary

- Audit item [#420 #2.12](https://github.com/petrsvihlik/WopiHost/issues/420): sync `Dispose(bool)` and `DisposeAsync` in `HashingBlobWriteStream` duplicated the `hash → hex → metadata-key` write, so the two paths could silently drift on the digest's casing or the metadata-key constant. The `_disposed` guard already prevented the audit's literal "hash and metadata are written twice" claim, so this PR is purely the drift-hazard cleanup the audit recommended.
- Extracted `FinalizeMetadataPayload()` and call it from both paths. Both branches still differ at the I/O boundary (`inner.Dispose()` + `blobClient.SetMetadata` vs. their async versions) because `Stream.Dispose` can't be async, but the hex/casing/metadata-key logic is no longer repeated.
- `DisposeAsync` now calls `GC.SuppressFinalize(this)` — the sync `Stream.Dispose()` base already did, but the async path was missing it, so async-disposed streams were still getting needlessly queued for finalization.

## Test plan

- [x] `dotnet build src/WopiHost.AzureStorageProvider` — 0 errors / 0 warnings across `net8.0` / `net9.0` / `net10.0` (`TreatWarningsAsErrors` global).
- [x] `dotnet test test/WopiHost.AzureStorageProvider.Tests` — **99/99 × 3 TFMs**. Two new cross-method idempotency tests added:
  - `Dispose_AfterDisposeAsync_IsNoOp` — `await DisposeAsync` then sync `Dispose()` leaves blob content + sha256 metadata at the single round-trip value with no exceptions.
  - `DisposeAsync_AfterDispose_IsNoOp` — mirror for sync-first ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)