### PR TITLE
fix(security): wrap JwtAccessTokenService ephemeral dev key in Lazy<T> (#420 item 2.4)

### DIFF
--- a/src/WopiHost.Core/Security/Authentication/JwtAccessTokenService.cs
+++ b/src/WopiHost.Core/Security/Authentication/JwtAccessTokenService.cs
@@ -24,7 +24,20 @@ public partial class JwtAccessTokenService(
     // MapInboundClaims maps short JWT names back to long ClaimTypes.* on validation, so
     // downstream code (e.g. ClaimsPrincipal.FindFirst(ClaimTypes.NameIdentifier)) keeps working.
     private readonly JwtSecurityTokenHandler _handler = new() { MapInboundClaims = true };
-    private SymmetricSecurityKey? _ephemeralDevKey;
+
+    // Lazy<T> default is LazyThreadSafetyMode.ExecutionAndPublication: exactly one factory
+    // invocation across all threads, the rest block on the result. Pre-#409-item-2.4 the
+    // null-check + assignment in GetSigningKey raced on first request, so concurrent first
+    // callers each minted a *different* random key and tokens signed during the race window
+    // would fail validation under whichever key lost the publish (the log line also fired
+    // multiple times). Field-initializer form keeps the factory cold until first read so the
+    // production path (SecurityKey / SigningKey configured) never pays the entropy cost.
+    private readonly Lazy<SymmetricSecurityKey> _ephemeralDevKey = new(() =>
+    {
+        var keyBytes = RandomNumberGenerator.GetBytes(64);
+        LogEphemeralSigningKey(logger);
+        return new SymmetricSecurityKey(keyBytes);
+    });
 
     /// <inheritdoc/>
     public Task<WopiAccessToken> IssueAsync(WopiAccessTokenRequest request, CancellationToken cancellationToken = default)
@@ -151,15 +164,9 @@ public partial class JwtAccessTokenService(
         {
             return new SymmetricSecurityKey(opts.SigningKey);
         }
-        // No key configured: generate a per-process random key. Loud warning so this is
-        // never silently used in production.
-        if (_ephemeralDevKey is null)
-        {
-            var keyBytes = RandomNumberGenerator.GetBytes(64);
-            _ephemeralDevKey = new SymmetricSecurityKey(keyBytes);
-            LogEphemeralSigningKey(logger);
-        }
-        return _ephemeralDevKey;
+        // No key configured: hand out the lazily-materialized per-process random key. The Lazy
+        // value-factory logs the loud-development-only warning the first time it runs.
+        return _ephemeralDevKey.Value;
     }
 
     /// <summary>

--- a/test/WopiHost.Core.Tests/Security/Authentication/JwtAccessTokenServiceTests.cs
+++ b/test/WopiHost.Core.Tests/Security/Authentication/JwtAccessTokenServiceTests.cs
@@ -312,6 +312,39 @@ public class JwtAccessTokenServiceTests
         await Assert.ThrowsAsync<ArgumentNullException>(() => svc.IssueAsync(null!));
     }
 
+    [Fact]
+    public async Task EphemeralKey_ConcurrentFirstRequests_AllTokensValidate()
+    {
+        // #420 item 2.4: the singleton-scoped service used to lazily materialize _ephemeralDevKey
+        // via a non-atomic null-check + assignment in GetSigningKey. Concurrent first callers each
+        // minted a *different* random key; whichever assignment lost the publish race signed
+        // tokens with a key the service then discarded — those tokens would fail ValidateAsync
+        // because the service holds the winning key. Lazy<T> in ExecutionAndPublication mode
+        // (the default) makes the factory run exactly once. Pin the invariant.
+        var svc = BuildService(new WopiSecurityOptions()); // no SigningKey/SecurityKey → ephemeral path
+
+        const int concurrency = 32;
+        var tokens = await Task.WhenAll(
+            Enumerable.Range(0, concurrency).Select(i => Task.Run(async () =>
+            {
+                var issued = await svc.IssueAsync(new WopiAccessTokenRequest
+                {
+                    UserId = $"u{i}",
+                    ResourceId = $"r{i}",
+                    ResourceType = WopiResourceType.File,
+                });
+                return issued.Token;
+            })));
+
+        // Every token must round-trip — proves the signing key was the same instance the service
+        // now uses for validation. A racey ephemeral key would surface as one or more failures here.
+        foreach (var token in tokens)
+        {
+            var v = await svc.ValidateAsync(token);
+            Assert.True(v.IsValid, $"Token failed validation — ephemeral key may have raced on concurrent first request.");
+        }
+    }
+
     private sealed class TestOptionsMonitor<T>(T value) : IOptionsMonitor<T>
     {
         public T CurrentValue { get; } = value;


### PR DESCRIPTION
## Summary

- Audit item [#420 #2.4](https://github.com/petrsvihlik/WopiHost/issues/420): `JwtAccessTokenService` is registered as a Singleton but lazily materialized `_ephemeralDevKey` via a non-atomic null-check + assignment inside `GetSigningKey`. Concurrent first callers each minted a *different* 64-byte random key — whichever assignment lost the publish race signed tokens with a key the service then discarded, so those tokens would fail `ValidateAsync` against the surviving key. The Warning log line also fired more than once.
- Swap to `Lazy<SymmetricSecurityKey>` in the default `ExecutionAndPublication` mode: factory runs **exactly once** across all threads, contenders block on the result, the warning fires once. Field-initializer form keeps the factory cold until first read so the production path (`SecurityKey` / `SigningKey` configured) never pays the entropy cost.

## Test plan

- [x] `dotnet build WOPI.slnx` — 0 errors / 0 warnings across `net8.0` / `net9.0` / `net10.0` (`TreatWarningsAsErrors` global). Confirms primary-ctor capture of `logger` inside the Lazy factory compiles cleanly.
- [x] `dotnet test test/WopiHost.Core.Tests` — **370/370 × 3 TFMs**. New test added: `EphemeralKey_ConcurrentFirstRequests_AllTokensValidate` fires 32 parallel `IssueAsync` calls against a service with no configured `SigningKey`/`SecurityKey` and verifies every issued token round-trips through `ValidateAsync` (which would fail probabilistically pre-fix when the race window hit).
- [x] Existing `Ephemeral_DevKey_Is_Reused_Across_Calls_When_No_Key_Configured` (sequential path) still passes — pre-existing pin on the same-instance invariant under non-concurrent use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)