### PR TITLE
chore(deps): trim redundant Project/PackageReferences across the solution

### DIFF
--- a/infra/WopiHost.AppHost/WopiHost.AppHost.csproj
+++ b/infra/WopiHost.AppHost/WopiHost.AppHost.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Aspire.Hosting.AppHost" />
     <PackageReference Include="Aspire.Hosting.Azure.Storage" />
     <PackageReference Include="Aspire.Hosting.Redis" />
-    <PackageReference Include="Azure.Storage.Blobs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/WopiHost.Validator/WopiHost.Validator.csproj
+++ b/sample/WopiHost.Validator/WopiHost.Validator.csproj
@@ -8,9 +8,7 @@
 
   <ItemGroup>
 	<PackageReference Include="Serilog.AspNetCore" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
     <ProjectReference Include="..\..\src\WopiHost.Core\WopiHost.Core.csproj" />
-    <ProjectReference Include="..\..\src\WopiHost.Discovery\WopiHost.Discovery.csproj" />
     <ProjectReference Include="..\..\src\WopiHost.FileSystemProvider\WopiHost.FileSystemProvider.csproj" />
     <ProjectReference Include="..\..\src\WopiHost.MemoryLockProvider\WopiHost.MemoryLockProvider.csproj" />
     <ProjectReference Include="..\..\src\WopiHost.Url\WopiHost.Url.csproj" />

--- a/sample/WopiHost.Web.Oidc/WopiHost.Web.Oidc.csproj
+++ b/sample/WopiHost.Web.Oidc/WopiHost.Web.Oidc.csproj
@@ -15,7 +15,6 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" />
-		<PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
 		<PackageReference Include="System.IdentityModel.Tokens.Jwt" />
 	</ItemGroup>
 
@@ -28,7 +27,6 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\WopiHost.FileSystemProvider\WopiHost.FileSystemProvider.csproj" />
 		<ProjectReference Include="..\..\src\WopiHost.Url\WopiHost.Url.csproj" />
-		<ProjectReference Include="..\..\src\WopiHost.Discovery\WopiHost.Discovery.csproj" />
 		<ProjectReference Include="..\..\infra\WopiHost.ServiceDefaults\WopiHost.ServiceDefaults.csproj" />
 	</ItemGroup>
 

--- a/sample/WopiHost.Web/WopiHost.Web.csproj
+++ b/sample/WopiHost.Web/WopiHost.Web.csproj
@@ -14,7 +14,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" />
-		<PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -30,15 +29,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\WopiHost.FileSystemProvider\WopiHost.FileSystemProvider.csproj" />
 		<ProjectReference Include="..\..\src\WopiHost.Url\WopiHost.Url.csproj" />
-		<ProjectReference Include="..\..\src\WopiHost.Discovery\WopiHost.Discovery.csproj" />
 		<ProjectReference Include="..\..\infra\WopiHost.ServiceDefaults\WopiHost.ServiceDefaults.csproj" />
 	</ItemGroup>
-
-	<Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">
-		<Exec Command="npm install" />
-		<Exec Command="bower install" />
-		<Exec Command="gulp clean" />
-		<Exec Command="gulp min" />
-	</Target>
 
 </Project>

--- a/sample/WopiHost/WopiHost.csproj
+++ b/sample/WopiHost/WopiHost.csproj
@@ -24,7 +24,6 @@
 		<ProjectReference Include="..\..\src\WopiHost.AzureStorageProvider\WopiHost.AzureStorageProvider.csproj" />
 		<ProjectReference Include="..\..\src\WopiHost.AzureLockProvider\WopiHost.AzureLockProvider.csproj" />
 		<ProjectReference Include="..\..\src\WopiHost.Core\WopiHost.Core.csproj" />
-		<ProjectReference Include="..\..\src\WopiHost.Discovery\WopiHost.Discovery.csproj" />
 		<ProjectReference Include="..\..\infra\WopiHost.ServiceDefaults\WopiHost.ServiceDefaults.csproj" />
 	</ItemGroup>
 
@@ -33,6 +32,5 @@
 		<PackageReference Include="Serilog.AspNetCore" />
 		<PackageReference Include="Scrutor" />
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" />
-		<PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
 	</ItemGroup>
 </Project>

--- a/src/WopiHost.AzureLockProvider/WopiHost.AzureLockProvider.csproj
+++ b/src/WopiHost.AzureLockProvider/WopiHost.AzureLockProvider.csproj
@@ -37,7 +37,6 @@
 		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
 		<PackageReference Include="Azure.Storage.Blobs" />
 		<PackageReference Include="Azure.Identity" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
 	</ItemGroup>

--- a/src/WopiHost.AzureStorageProvider/WopiHost.AzureStorageProvider.csproj
+++ b/src/WopiHost.AzureStorageProvider/WopiHost.AzureStorageProvider.csproj
@@ -37,7 +37,6 @@
 		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
 		<PackageReference Include="Azure.Storage.Blobs" />
 		<PackageReference Include="Azure.Identity" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
 	</ItemGroup>

--- a/src/WopiHost.Discovery/WopiHost.Discovery.csproj
+++ b/src/WopiHost.Discovery/WopiHost.Discovery.csproj
@@ -39,7 +39,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-		<PackageReference Include="Microsoft.Extensions.Options" />
 		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
 		<PackageReference Include="Microsoft.Extensions.Http" />
 	</ItemGroup>

--- a/src/WopiHost.FileSystemProvider/WopiHost.FileSystemProvider.csproj
+++ b/src/WopiHost.FileSystemProvider/WopiHost.FileSystemProvider.csproj
@@ -39,7 +39,6 @@
 		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
 		<PackageReference Include="System.IO.FileSystem.AccessControl" />
 		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
 	</ItemGroup>
 

--- a/src/WopiHost.RedisLockProvider/WopiHost.RedisLockProvider.csproj
+++ b/src/WopiHost.RedisLockProvider/WopiHost.RedisLockProvider.csproj
@@ -36,11 +36,9 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
 		<PackageReference Include="StackExchange.Redis" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
-		<PackageReference Include="Microsoft.Extensions.Options" />
 		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
 	</ItemGroup>
 

--- a/test/WopiHost.AzureLockProvider.Tests/WopiHost.AzureLockProvider.Tests.csproj
+++ b/test/WopiHost.AzureLockProvider.Tests/WopiHost.AzureLockProvider.Tests.csproj
@@ -8,7 +8,6 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Testcontainers.Azurite" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
 	</ItemGroup>
 	<ItemGroup>
 	  <PackageReference Update="coverlet.collector">

--- a/test/WopiHost.AzureStorageProvider.Tests/WopiHost.AzureStorageProvider.Tests.csproj
+++ b/test/WopiHost.AzureStorageProvider.Tests/WopiHost.AzureStorageProvider.Tests.csproj
@@ -7,7 +7,6 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Testcontainers.Azurite" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
 	</ItemGroup>
 	<ItemGroup>
 	  <PackageReference Update="coverlet.collector">

--- a/test/WopiHost.RedisLockProvider.Tests/WopiHost.RedisLockProvider.Tests.csproj
+++ b/test/WopiHost.RedisLockProvider.Tests/WopiHost.RedisLockProvider.Tests.csproj
@@ -8,8 +8,6 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Testcontainers.Redis" />
-		<PackageReference Include="StackExchange.Redis" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
 	</ItemGroup>
 	<ItemGroup>
 	  <PackageReference Update="coverlet.collector">


### PR DESCRIPTION
## Summary
- Audit across every `.csproj` for `ProjectReference` / `PackageReference` entries already supplied transitively, then trim them. 13 files, 26 deletions, no behavior change.
- Verified with `dotnet list package --include-transitive` per project plus a clean `dotnet build WOPI.slnx` (0 warnings, 0 errors).
- Also removes one dead `PrepublishScript` target in `sample/WopiHost.Web` (no `package.json`/`bower.json`/`gulpfile.js` exists — leftover ASP.NET 5 MVC scaffolding) and one unused `Azure.Storage.Blobs` reference in `WopiHost.AppHost` (`AddBlobs` is an `Aspire.Hosting.Azure.Storage` extension, not the SDK).

Two commits so the library-side trim can be reverted independently if needed:

**`51b574b` — sample / test / infra (8 files):**
- `sample/WopiHost{,.Web,.Web.Oidc,.Validator}`: drop `Microsoft.Extensions.ServiceDiscovery` (via `WopiHost.ServiceDefaults`)
- `sample/WopiHost`: drop `WopiHost.Discovery` (via `WopiHost.Core`)
- `sample/WopiHost.Web{,.Oidc}`: drop `WopiHost.Discovery` (via `WopiHost.Url`)
- `sample/WopiHost.Validator`: drop `WopiHost.Discovery` (via `WopiHost.Core`)
- `sample/WopiHost.Web`: remove dead `PrepublishScript` (npm/bower/gulp)
- `test/WopiHost.RedisLockProvider.Tests`: drop `StackExchange.Redis`, `Microsoft.Extensions.Logging.Abstractions` (via `WopiHost.RedisLockProvider`)
- `test/WopiHost.{Azure,AzureStorage}LockProvider.Tests`: drop `Microsoft.Extensions.Logging.Abstractions`
- `infra/WopiHost.AppHost`: drop unused `Azure.Storage.Blobs`

**`daf0639` — src/ libraries (5 files):**
- `Discovery`, `RedisLockProvider`: drop `Microsoft.Extensions.Options` (via `Options.ConfigurationExtensions`)
- `RedisLockProvider`, `AzureStorageProvider`, `AzureLockProvider`, `FileSystemProvider`: drop `Microsoft.Extensions.Configuration.Abstractions` (via `Configuration.Binder`; `FileSystemProvider` also via `Hosting.Abstractions`)

## Test plan
- [x] `dotnet build WOPI.slnx` — 28/28 projects, 0 warnings, 0 errors
- [ ] `dotnet test WOPI.slnx` (CI)
- [ ] Smoke check: `dotnet run --project infra/WopiHost.AppHost` boots and the WOPI host is reachable on `:5000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)