### PR TITLE
refactor(core): switch ChildFile mutable setters to init (#425 item 2.9)

### DIFF
--- a/src/WopiHost.Core/Models/ChildFile.cs
+++ b/src/WopiHost.Core/Models/ChildFile.cs
@@ -10,25 +10,25 @@ public record ChildFile(string Name, Uri Url) : AbstractChildBase(Name, Url)
 	/// <summary>
 	/// Version of the file.
 	/// </summary>
-	public string? Version { get; set; }
+	public string? Version { get; init; }
 
 	/// <summary>
 	/// Size of the file.
 	/// </summary>
-	public long Size { get; set; }
+	public long Size { get; init; }
 
 	/// <summary>
 	/// Timestamp of the file's last modification.
 	/// </summary>
-	public string? LastModifiedTime { get; set; }
+	public string? LastModifiedTime { get; init; }
 
     /// <summary>
     /// URL to view the file in the host's web interface.
     /// </summary>
-    public Uri? HostViewUrl { get; set; }
+    public Uri? HostViewUrl { get; init; }
 
     /// <summary>
     /// URL to edit the file in the host's web interface.
     /// </summary>
-    public Uri? HostEditUrl { get; set; }
+    public Uri? HostEditUrl { get; init; }
 }


### PR DESCRIPTION
## Summary

- Audit item [#425 #2.9](https://github.com/petrsvihlik/WopiHost/issues/425): `ChildFile` is declared as a `record` (the C# 12 signal for "value-like, immutable") but its five non-positional properties (`Version`, `Size`, `LastModifiedTime`, `HostViewUrl`, `HostEditUrl`) had public `set;` — letting a caller mutate the response model after construction and defeating the value-type signal.
- Flipped `set;` → `init;` on all five. Every call site in the codebase already uses object-initializer syntax — `new ChildFile(name, url) { Size = …, Version = … }` — which `init` setters fully support. `System.Text.Json` also populates `init`-only properties on deserialization via the constructor + properties pattern, so the wire contract is unchanged for any consumer that parses the response back into the type.
- Other public records in `WopiHost.Core` (`ChildContainer`, `UrlResponse`, `EnumerateAncestorsResponse`, `CreateChildContainerResponse`) were already correctly immutable via positional ctor params; `ChildFile` was the lone offender the audit flagged.

## Test plan

- [x] `dotnet build WOPI.slnx` — **0 errors / 0 warnings** across `net8.0` / `net9.0` / `net10.0`
- [x] `dotnet test test/WopiHost.Core.Tests` — **370/370 × 3 TFMs** green. No test changes — every `new ChildFile(...) { ... }` instantiation in production code and tests already uses the object-initializer form `init` supports.

Refs #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)