### PR TITLE
refactor(audit): typed provider registration replacing reflection-by-assembly-name (#425 item 4.6) [BREAKING]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Abstractions ← Abstractions.Testing (test-helper library; depends on xunit)
 
 ### Provider Model
 
-Storage and lock providers are loaded **dynamically by assembly name** from configuration (`StorageProviderAssemblyName`, `LockProviderAssemblyName` in `WopiHostOptions`). Custom providers implement `IWopiStorageProvider`/`IWopiLockProvider` and are registered via `services.AddStorageProvider(assemblyName)` / `services.AddLockProvider(assemblyName)`.
+Each storage / lock provider package exposes a typed `services.Add{Provider}{StorageOrLock}Provider(...)` extension. The composition root references the provider package(s) it wants and calls the extension directly — no reflection, no assembly-name strings. Available extensions: `AddFileSystemStorageProvider(cfg)`, `AddAzureStorageProvider(cfg)`, `AddMemoryLockProvider()`, `AddAzureLockProvider(cfg)`, `AddRedisLockProvider(cfg)`. The sample retains a small sample-local discriminator (`Sample:StorageProvider`, `Sample:LockProvider`) so the AppHost flag flow can flip providers at runtime — see [sample/WopiHost/ServiceCollectionExtensions.cs](sample/WopiHost/ServiceCollectionExtensions.cs).
 
 ### Infrastructure (infra/)
 
@@ -94,7 +94,7 @@ The Aspire AppHost reads a few `AppHost:*` flags from configuration so the defau
 | Flag | Adds |
 |---|---|
 | `AppHost:UseAzureStorage` | Azurite emulator + `BlobStorage` connection string forwarded to the WOPI host. |
-| `AppHost:UseRedisLocks` | **Default: `true` when launched via the AppHost.** Adds a Redis container; the WOPI host swaps `LockProviderAssemblyName` to `WopiHost.RedisLockProvider` and receives the Aspire-allocated connection string via `Wopi:LockProvider:ConnectionString`. Set to `false` to fall back to `WopiHost.MemoryLockProvider` (single-process) — useful on contributor machines without Docker. Aspire already manages Docker resources, so the realistic distributed-lock backend is the right default for the orchestrated dev loop. |
+| `AppHost:UseRedisLocks` | **Default: `true` when launched via the AppHost.** Adds a Redis container; the WOPI host swaps `Sample:LockProvider` to `Redis` (so `AddSampleLockProvider` dispatches to `AddRedisLockProvider`) and receives the Aspire-allocated connection string via `Wopi:LockProvider:ConnectionString`. Set to `false` to fall back to `Memory` (single-process) — useful on contributor machines without Docker. Aspire already manages Docker resources, so the realistic distributed-lock backend is the right default for the orchestrated dev loop. |
 | `AppHost:UseCollabora` | `collabora/code` container as a real WOPI client for end-to-end editing. Auto-overrides `Wopi:ClientUrl`, `Wopi:HostUrl`, `Wopi:Discovery:NetZone`, and `Wopi:Security:DisableProofValidation` on the affected projects. See the **End-to-end editing with Collabora Online** section in the root README for the full wiring (`host.docker.internal:5000`, NetZone gotcha, proof-key gotcha). |
 | `AppHost:IncludeOidcSample` | `WopiHost.Web.Oidc` frontend (requires IdP setup — see its README). |
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,7 +31,7 @@
 		<EnablePackageValidation>true</EnablePackageValidation>
 		<!-- Baseline used to detect public-API breaks against the last released version.
 		     Bump this in lockstep with releases. -->
-		<PackageValidationBaselineVersion>7.0.0</PackageValidationBaselineVersion>
+		<PackageValidationBaselineVersion>8.0.0</PackageValidationBaselineVersion>
 	</PropertyGroup>
 	
 	<ItemGroup Condition="!$(MSBuildProjectName.EndsWith('Tests'))">

--- a/infra/WopiHost.AppHost/Program.cs
+++ b/infra/WopiHost.AppHost/Program.cs
@@ -96,8 +96,10 @@ if (builder.Configuration.GetValue("AppHost:UseRedisLocks", defaultValue: true))
     var redis = builder.AddRedis("wopi-locks")
                        .WithLifetime(ContainerLifetime.Persistent);
     wopiHost
-        // Switch the backend's lock-provider assembly name so AddLockProvider() dispatches to Redis.
-        .WithEnvironment("Wopi__LockProviderAssemblyName", "WopiHost.RedisLockProvider")
+        // Flip the sample's lock-provider discriminator so AddSampleLockProvider() dispatches to
+        // Redis. Sample:LockProvider lives in the sample's appsettings (not WopiHost.Core's
+        // public options surface) — see sample/WopiHost/ServiceCollectionExtensions.cs.
+        .WithEnvironment("Sample__LockProvider", "Redis")
         // sample/WopiHost binds Wopi:LockProvider:ConnectionString to WopiRedisLockProviderOptions;
         // route Aspire's connection-string reference through this key so the provider sees it
         // without needing a separate ConnectionStrings:wopi-locks fallback path.

--- a/sample/README.md
+++ b/sample/README.md
@@ -18,9 +18,9 @@ Three runnable samples + a folder of test documents. The recommended way to laun
 
 | Key | Sample value | Purpose |
 |---|---|---|
-| `Wopi:StorageProviderAssemblyName` | `"WopiHost.FileSystemProvider"` | Assembly providing `IWopiStorageProvider`. Loaded reflectively at startup. See [src/WopiHost.FileSystemProvider](../src/WopiHost.FileSystemProvider/README.md). |
+| `Sample:StorageProvider` | `"FileSystem"` | Sample-local discriminator picking which storage provider's typed extension to call. Values: `FileSystem` ([src/WopiHost.FileSystemProvider](../src/WopiHost.FileSystemProvider/README.md)) or `Azure` ([src/WopiHost.AzureStorageProvider](../src/WopiHost.AzureStorageProvider/README.md)). Lives in the sample only — real hosts reference one provider package and call its typed extension directly. |
 | `Wopi:StorageProvider:RootPath` | `"../wopi-docs"` | Root of the directory tree the file-system provider exposes. |
-| `Wopi:LockProviderAssemblyName` | `"WopiHost.MemoryLockProvider"` | Assembly providing `IWopiLockProvider`. See [src/WopiHost.MemoryLockProvider](../src/WopiHost.MemoryLockProvider/README.md). |
+| `Sample:LockProvider` | `"Memory"` | Sample-local lock-provider discriminator. Values: `Memory`, `Azure`, `Redis` — see the per-provider READMEs. |
 | `Wopi:UseCobalt` | `false` | Reflectively register [WopiHost.Cobalt](../src/WopiHost.Cobalt/README.md) when `true`. Requires a private `Microsoft.CobaltCore` package. |
 | `Wopi:ClientUrl` | `"https://ffc-onenote.officeapps.live.com"` | Base URI of the WOPI client (Office Online Server / M365 for the Web / Collabora). Used by discovery. The AppHost overrides this to `http://localhost:9980` when run with `AppHost:UseCollabora=true` — see [End-to-end editing with Collabora Online](https://github.com/petrsvihlik/WopiHost/wiki/Collabora-Online) on the wiki. |
 

--- a/sample/WopiHost/Program.cs
+++ b/sample/WopiHost/Program.cs
@@ -57,10 +57,15 @@ public partial class Program
 
             var wopiHostOptions = wopiHostOptionsSection.Get<WopiHostOptions>();
 
-            // Add file provider (registers required dependencies based on which assembly is configured)
-            builder.Services.AddStorageProvider(builder.Configuration, wopiHostOptions.StorageProviderAssemblyName);
-            // Add lock provider
-            builder.Services.AddLockProvider(builder.Configuration, wopiHostOptions.LockProviderAssemblyName);
+            // Provider selection lives in the sample's own config section (Sample:*), not in
+            // WopiHost.Core's WopiHostOptions — choosing between bundled providers is composition-
+            // root concern. Real hosts reference one provider package and call its typed extension
+            // directly (services.AddFileSystemStorageProvider(cfg), etc.); the sample retains a
+            // small switch so the AppHost flag flow can flip providers at runtime.
+            var sampleStorage = builder.Configuration.GetValue("Sample:StorageProvider", ServiceCollectionExtensions.SampleStorageProvider.FileSystem);
+            var sampleLock = builder.Configuration.GetValue("Sample:LockProvider", ServiceCollectionExtensions.SampleLockProvider.Memory);
+            builder.Services.AddSampleStorageProvider(builder.Configuration, sampleStorage);
+            builder.Services.AddSampleLockProvider(builder.Configuration, sampleLock);
 
             // Add Discovery services
             builder.Services.AddWopiDiscovery<WopiHostOptions>(

--- a/sample/WopiHost/ServiceCollectionExtensions.cs
+++ b/sample/WopiHost/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using WopiHost.Abstractions;
 using WopiHost.AzureLockProvider;
 using WopiHost.AzureStorageProvider;
 using WopiHost.FileSystemProvider;
+using WopiHost.MemoryLockProvider;
 using WopiHost.RedisLockProvider;
 
 namespace WopiHost;
@@ -10,62 +11,72 @@ namespace WopiHost;
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers the storage provider identified by <paramref name="storageProviderAssemblyName"/>.
+    /// Sample-local discriminators for which storage / lock provider to wire up. Lives in the
+    /// sample (not in WopiHost.Core's public options surface) because choosing between bundled
+    /// providers is composition-root concern, not a contract the library should expose.
     /// </summary>
     /// <remarks>
-    /// Recognises specific assembly names so each provider's required DI dependencies are wired up
-    /// correctly (Azure clients, options binding, ID maps). Falls back to a Scrutor scan for
-    /// arbitrary third-party assemblies whose providers can be constructed from already-registered
-    /// services.
+    /// Real hosts won't ship a discriminator at all — they reference one provider package and
+    /// call its typed extension directly (e.g. <c>services.AddFileSystemStorageProvider(cfg)</c>).
+    /// The enum-based switch exists here so the AppHost flag flow and Aspire orchestration can
+    /// flip providers at runtime without recompiling the sample.
     /// </remarks>
-    public static void AddStorageProvider(
-        this IServiceCollection services,
-        IConfiguration configuration,
-        string storageProviderAssemblyName)
+    public enum SampleStorageProvider
     {
-        switch (storageProviderAssemblyName)
-        {
-            case "WopiHost.FileSystemProvider":
-                services.AddSingleton<InMemoryFileIds>();
-                services.AddScoped<IWopiStorageProvider, WopiFileSystemProvider>();
-                services.AddScoped<IWopiWritableStorageProvider, WopiFileSystemProvider>();
-                return;
+        FileSystem,
+        Azure,
+    }
 
-            case "WopiHost.AzureStorageProvider":
-                services.AddAzureStorageProvider(configuration);
-                return;
-
-            default:
-                ScanAssemblyAndRegister<IWopiStorageProvider>(services, storageProviderAssemblyName);
-                return;
-        }
+    /// <inheritdoc cref="SampleStorageProvider"/>
+    public enum SampleLockProvider
+    {
+        Memory,
+        Azure,
+        Redis,
     }
 
     /// <summary>
-    /// Registers the lock provider identified by <paramref name="lockProviderAssemblyName"/>.
+    /// Sample-only helper that dispatches to the chosen provider's typed registration extension.
+    /// Each branch is a one-liner so adding a new provider means adding an enum value and a
+    /// case — no reflection, no string-name probing, no fallback path.
     /// </summary>
-    public static void AddLockProvider(
+    public static void AddSampleStorageProvider(
         this IServiceCollection services,
         IConfiguration configuration,
-        string lockProviderAssemblyName)
+        SampleStorageProvider provider)
     {
-        switch (lockProviderAssemblyName)
+        switch (provider)
         {
-            case "WopiHost.MemoryLockProvider":
-                services.AddSingleton<IWopiLockProvider, MemoryLockProvider.MemoryLockProvider>();
+            case SampleStorageProvider.FileSystem:
+                services.AddFileSystemStorageProvider(configuration);
                 return;
+            case SampleStorageProvider.Azure:
+                services.AddAzureStorageProvider(configuration);
+                return;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(provider), provider, "Unknown sample storage provider.");
+        }
+    }
 
-            case "WopiHost.AzureLockProvider":
+    /// <inheritdoc cref="AddSampleStorageProvider"/>
+    public static void AddSampleLockProvider(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        SampleLockProvider provider)
+    {
+        switch (provider)
+        {
+            case SampleLockProvider.Memory:
+                services.AddMemoryLockProvider();
+                return;
+            case SampleLockProvider.Azure:
                 services.AddAzureLockProvider(configuration);
                 return;
-
-            case "WopiHost.RedisLockProvider":
+            case SampleLockProvider.Redis:
                 services.AddRedisLockProvider(configuration);
                 return;
-
             default:
-                ScanAssemblyAndRegister<IWopiLockProvider>(services, lockProviderAssemblyName);
-                return;
+                throw new ArgumentOutOfRangeException(nameof(provider), provider, "Unknown sample lock provider.");
         }
     }
 
@@ -81,21 +92,6 @@ public static class ServiceCollectionExtensions
             .Scan(scan => scan.FromAssemblies(cobaltAssembly)
             .AddClasses(classes => classes
                 .AssignableTo<ICobaltProcessor>())
-            .AsImplementedInterfaces());
-    }
-
-    private static void ScanAssemblyAndRegister<TInterface>(IServiceCollection services, string assemblyName)
-    {
-        var assemblyPath = Path.Combine(AppContext.BaseDirectory, $"{assemblyName}.dll");
-        if (!File.Exists(assemblyPath))
-        {
-            throw new InvalidProgramException($"Provider assembly {assemblyPath} not found.");
-        }
-        var assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
-        services
-            .Scan(scan => scan.FromAssemblies(assembly)
-            .AddClasses(classes => classes
-                .AssignableTo<TInterface>())
             .AsImplementedInterfaces());
     }
 }

--- a/sample/WopiHost/appsettings.json
+++ b/sample/WopiHost/appsettings.json
@@ -1,12 +1,14 @@
-﻿{
+{
   "Wopi": {
     "UseCobalt": false,
-    "StorageProviderAssemblyName": "WopiHost.FileSystemProvider",
-    "LockProviderAssemblyName": "WopiHost.MemoryLockProvider",
     "StorageProvider": {
       "RootPath": "../wopi-docs"
     },
     "ClientUrl": "https://ffc-onenote.officeapps.live.com"
+  },
+  "Sample": {
+    "StorageProvider": "FileSystem",
+    "LockProvider": "Memory"
   },
   "Logging": {
     "LogLevel": {

--- a/src/WopiHost.Abstractions/README.md
+++ b/src/WopiHost.Abstractions/README.md
@@ -25,7 +25,7 @@ dotnet add package WopiHost.Abstractions
 | [`IWopiHostExtensions`](IWopiHostExtensions.cs) | Single host-customization seam for `CheckFileInfo` / `CheckContainerInfo` / `CheckFolderInfo` / `CheckEcosystem` / `PutFile` / `PutRelativeFile`. | `WopiHostExtensions` (pass-through) | Subclass when you want to layer custom properties, rewrite URLs, or hook write-completion telemetry. |
 | [`ICheckFileInfoBuilder`](ICheckFileInfoBuilder.cs) / [`ICheckContainerInfoBuilder`](ICheckContainerInfoBuilder.cs) / [`ICheckFolderInfoBuilder`](ICheckFolderInfoBuilder.cs) | Build the corresponding response shapes. The default implementations fire the matching `IWopiHostExtensions` hook. | `DefaultCheck*InfoBuilder` (in `WopiHost.Core`) | Replace when you need scoped services that don't fit in the host-extensions seam, or to short-circuit the default population entirely. |
 
-The defaults ship in `WopiHost.Core`, `WopiHost.FileSystemProvider`, `WopiHost.MemoryLockProvider`, `WopiHost.AzureStorageProvider`, and `WopiHost.AzureLockProvider` — selected via `WopiHostOptions.StorageProviderAssemblyName` / `LockProviderAssemblyName`.
+The defaults ship in `WopiHost.Core`, `WopiHost.FileSystemProvider`, `WopiHost.MemoryLockProvider`, `WopiHost.AzureStorageProvider`, `WopiHost.AzureLockProvider`, and `WopiHost.RedisLockProvider`. Each provider package exposes a typed `services.Add{Provider}{StorageOrLock}Provider(...)` extension — reference the package you want and call its extension.
 
 ## Resource model
 
@@ -161,7 +161,7 @@ public class AzureBlobStorageProvider(BlobContainerClient container)
 }
 ```
 
-Once registered, `services.AddWopi()` discovers it via `WopiHostOptions.StorageProviderAssemblyName`. See [WopiHost.FileSystemProvider](../WopiHost.FileSystemProvider/README.md) for a working reference implementation.
+Expose a typed `services.AddMy…Provider(IConfiguration?)` extension on your provider assembly that registers your implementation against `IWopiStorageProvider` / `IWopiWritableStorageProvider`. Consumers reference your package and call the extension directly — no reflection, no string-name probing. See [WopiHost.FileSystemProvider](../WopiHost.FileSystemProvider/README.md) for a working reference implementation.
 
 ## License
 

--- a/src/WopiHost.AzureLockProvider/README.md
+++ b/src/WopiHost.AzureLockProvider/README.md
@@ -15,7 +15,6 @@ dotnet add package WopiHost.AzureLockProvider
 
 ```jsonc
 "Wopi": {
-  "LockProviderAssemblyName": "WopiHost.AzureLockProvider",
   "LockProvider": {
     "ConnectionString": "UseDevelopmentStorage=true",
     "ContainerName": "wopi-locks"
@@ -25,7 +24,6 @@ dotnet add package WopiHost.AzureLockProvider
 
 ```jsonc
 "Wopi": {
-  "LockProviderAssemblyName": "WopiHost.AzureLockProvider",
   "LockProvider": {
     "ServiceUri": "https://my-account.blob.core.windows.net",
     "ContainerName": "wopi-locks"
@@ -41,11 +39,11 @@ The lock container is dedicated and separate from your content blobs — that ke
 builder.Services.AddAzureLockProvider(builder.Configuration);
 builder.Services.AddWopi(o =>
 {
-    o.LockProviderAssemblyName = "WopiHost.AzureLockProvider";
+    o.ClientUrl = new Uri("https://your-office-online-server.com");
 });
 ```
 
-The sample's [`AddLockProvider`](../../sample/WopiHost/ServiceCollectionExtensions.cs) helper recognises `"WopiHost.AzureLockProvider"` and dispatches to the call above.
+The runnable sample exposes a small `Sample:LockProvider` discriminator (`Memory` / `Azure` / `Redis`) and dispatches to the chosen provider's typed extension — see [`sample/WopiHost/ServiceCollectionExtensions.cs`](../../sample/WopiHost/ServiceCollectionExtensions.cs).
 
 ## How it works
 

--- a/src/WopiHost.AzureStorageProvider/README.md
+++ b/src/WopiHost.AzureStorageProvider/README.md
@@ -20,7 +20,6 @@ Two authentication modes — connection string (Azurite, dev) and `TokenCredenti
 ```jsonc
 // appsettings.json — connection string
 "Wopi": {
-  "StorageProviderAssemblyName": "WopiHost.AzureStorageProvider",
   "StorageProvider": {
     "ConnectionString": "UseDevelopmentStorage=true",
     "ContainerName": "wopi-files"
@@ -31,7 +30,6 @@ Two authentication modes — connection string (Azurite, dev) and `TokenCredenti
 ```jsonc
 // appsettings.json — DefaultAzureCredential
 "Wopi": {
-  "StorageProviderAssemblyName": "WopiHost.AzureStorageProvider",
   "StorageProvider": {
     "ServiceUri": "https://my-account.blob.core.windows.net",
     "ContainerName": "wopi-files"
@@ -53,12 +51,11 @@ The container is created on first use if it doesn't exist.
 builder.Services.AddAzureStorageProvider(builder.Configuration);
 builder.Services.AddWopi(o =>
 {
-    o.ClientUrl                   = new Uri("https://your-office-online-server.com");
-    o.StorageProviderAssemblyName = "WopiHost.AzureStorageProvider";
+    o.ClientUrl = new Uri("https://your-office-online-server.com");
 });
 ```
 
-The sample's [`AddStorageProvider`](../../sample/WopiHost/ServiceCollectionExtensions.cs) helper recognises `"WopiHost.AzureStorageProvider"` and dispatches to the call above, so a single config-driven registration works there too.
+The runnable sample exposes a small `Sample:StorageProvider` discriminator (`FileSystem` / `Azure`) and dispatches to the chosen provider's typed extension — see [`sample/WopiHost/ServiceCollectionExtensions.cs`](../../sample/WopiHost/ServiceCollectionExtensions.cs).
 
 ## How it maps to Blob Storage
 

--- a/src/WopiHost.Core/Models/WopiHostOptions.cs
+++ b/src/WopiHost.Core/Models/WopiHostOptions.cs
@@ -25,17 +25,6 @@ public class WopiHostOptions : IDiscoveryOptions
     public bool UseCobalt { get; set; }
 
     /// <summary>
-    /// Name of the assembly containing the implementation of the <see cref="Abstractions.IWopiStorageProvider"/>.
-    /// </summary>
-    [Required]
-    public required string StorageProviderAssemblyName { get; set; }
-
-    /// <summary>
-    /// Name of the assembly containing the implementation of the <see cref="Abstractions.IWopiLockProvider"/>
-    /// </summary>
-    public string? LockProviderAssemblyName { get; set; }
-
-    /// <summary>
     /// Value written to the <c>X-WOPI-Lock</c> response header when the file is unlocked but the
     /// spec requires the header to be present (notably <c>GetLock</c> on an unlocked file and
     /// <c>PutFile</c> on a non-empty unlocked file).

--- a/src/WopiHost.Core/README.md
+++ b/src/WopiHost.Core/README.md
@@ -19,9 +19,13 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddWopi(o =>
 {
     o.ClientUrl = new Uri("https://your-office-online-server.com");
-    o.StorageProviderAssemblyName = "WopiHost.FileSystemProvider";
-    o.LockProviderAssemblyName    = "WopiHost.MemoryLockProvider";
 });
+
+// Reference one storage provider package + one lock provider package and call their
+// typed registration extensions. Each provider's options bind from the configuration
+// section it documents (Wopi:StorageProvider / Wopi:LockProvider).
+builder.Services.AddFileSystemStorageProvider(builder.Configuration);
+builder.Services.AddMemoryLockProvider();
 
 // Required in production: pin the access-token signing key.
 builder.Services.ConfigureWopiSecurity(o =>
@@ -39,19 +43,31 @@ app.Run();
 
 `AddWopi()` registers controllers, the access-token authentication scheme, the proof-key validator, default `IWopiAccessTokenService` (signed JWT), and default `IWopiPermissionProvider` (reads from token claims). Override either by registering your own implementation — the defaults are added with `TryAdd*` so a custom registration wins regardless of order. See [the runnable sample](../../sample/WopiHost/Program.cs).
 
+The bundled provider packages each ship a typed `Add{Provider}{StorageOrLock}Provider(...)` extension — pick the one you want and reference its package. Available extensions:
+
+| Provider package | Extension |
+|---|---|
+| `WopiHost.FileSystemProvider` | `services.AddFileSystemStorageProvider(IConfiguration)` |
+| `WopiHost.AzureStorageProvider` | `services.AddAzureStorageProvider(IConfiguration)` |
+| `WopiHost.MemoryLockProvider` | `services.AddMemoryLockProvider()` |
+| `WopiHost.AzureLockProvider` | `services.AddAzureLockProvider(IConfiguration)` |
+| `WopiHost.RedisLockProvider` | `services.AddRedisLockProvider(IConfiguration)` |
+
+Third-party providers register themselves the same way — implement `IWopiStorageProvider` / `IWopiWritableStorageProvider` (or `IWopiLockProvider`) and expose a typed extension on `IServiceCollection`.
+
 ## Configuration
 
 ```jsonc
 {
   "Wopi": {
     "ClientUrl": "https://your-office-online-server.com",
-    "StorageProviderAssemblyName": "WopiHost.FileSystemProvider",
-    "LockProviderAssemblyName":    "WopiHost.MemoryLockProvider",
     "UseCobalt": false,
     "Discovery": {
       "NetZone":         "ExternalHttps",
       "RefreshInterval": "12:00:00"
     }
+    // Provider-specific options bind under "Wopi:StorageProvider" and "Wopi:LockProvider" —
+    // see each provider's README.
   }
 }
 ```
@@ -137,7 +153,8 @@ public class MyAclPermissionProvider : IWopiPermissionProvider
         ClaimsPrincipal user, IWopiContainer container, CancellationToken ct = default) { /* ... */ }
 }
 
-services.AddWopi(o => { o.ClientUrl = ...; o.StorageProviderAssemblyName = ...; });
+services.AddWopi(o => { o.ClientUrl = ...; });
+services.AddFileSystemStorageProvider(Configuration);   // or any other storage provider
 services.AddSingleton<IWopiPermissionProvider, MyAclPermissionProvider>();
 services.ConfigureWopiSecurity(o =>
 {
@@ -259,9 +276,9 @@ public class MyHostExtensions(IAuditLog audit, ITelemetry telemetry) : WopiHostE
 services.AddSingleton<IWopiHostExtensions, MyHostExtensions>();
 services.AddWopi(o =>
 {
-    o.ClientUrl                   = ...;
-    o.StorageProviderAssemblyName = "...";
+    o.ClientUrl = ...;
 });
+services.AddFileSystemStorageProvider(Configuration);   // or any other storage provider
 ```
 
 Throwing inside any hook turns the response into a 500 — for best-effort bookkeeping (audit log, last-edit telemetry), catch exceptions inside the override.
@@ -314,8 +331,8 @@ Or register your own `IWopiLockComparer` implementation tailored to the specific
 
 ```csharp
 services.AddWopi(...);
-services.AddStorageProvider("WopiHost.AzureStorageProvider");
-services.AddLockProvider("WopiHost.AzureLockProvider");
+services.AddAzureStorageProvider(Configuration);
+services.AddAzureLockProvider(Configuration);
 services.AddWopiLockAwareWritableStorage();   // must run after the storage + lock providers are registered
 ```
 

--- a/src/WopiHost.FileSystemProvider/README.md
+++ b/src/WopiHost.FileSystemProvider/README.md
@@ -18,7 +18,6 @@ dotnet add package WopiHost.FileSystemProvider
 ```jsonc
 // appsettings.json
 "Wopi": {
-  "StorageProviderAssemblyName": "WopiHost.FileSystemProvider",
   "StorageProvider": {
     "RootPath": "./wopi-docs"   // absolute or relative to ContentRootPath
   }
@@ -30,17 +29,14 @@ dotnet add package WopiHost.FileSystemProvider
 ## Register
 
 ```csharp
-builder.Services.AddSingleton<InMemoryFileIds>();
-builder.Services.AddScoped<IWopiStorageProvider,         WopiFileSystemProvider>();
-builder.Services.AddScoped<IWopiWritableStorageProvider, WopiFileSystemProvider>();
+builder.Services.AddFileSystemStorageProvider(builder.Configuration);
 builder.Services.AddWopi(o =>
 {
-    o.ClientUrl                   = new Uri("https://your-office-online-server.com");
-    o.StorageProviderAssemblyName = "WopiHost.FileSystemProvider";
+    o.ClientUrl = new Uri("https://your-office-online-server.com");
 });
 ```
 
-If you use the sample's assembly-name loader (`AddStorageProvider`), the two `AddScoped` lines are not needed — the sample reflectively scans the assembly and registers anything that implements `IWopiStorageProvider` / `IWopiWritableStorageProvider`. See [`sample/WopiHost/Program.cs`](../../sample/WopiHost/Program.cs).
+`AddFileSystemStorageProvider` registers `WopiFileSystemProvider` as both `IWopiStorageProvider` and `IWopiWritableStorageProvider` (one shared instance per scope) plus the singleton `InMemoryFileIds` map the provider uses for path↔id round-tripping. The runnable sample drives all of this through a sample-local `Sample:StorageProvider` discriminator — see [`sample/WopiHost/Program.cs`](../../sample/WopiHost/Program.cs).
 
 ## How identifiers work
 

--- a/src/WopiHost.FileSystemProvider/ServiceCollectionExtensions.cs
+++ b/src/WopiHost.FileSystemProvider/ServiceCollectionExtensions.cs
@@ -1,0 +1,42 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using WopiHost.Abstractions;
+
+namespace WopiHost.FileSystemProvider;
+
+/// <summary>
+/// DI extensions to register <see cref="WopiFileSystemProvider"/>.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="WopiFileSystemProvider"/> as both <see cref="IWopiStorageProvider"/>
+    /// and <see cref="IWopiWritableStorageProvider"/>, together with the singleton
+    /// <see cref="InMemoryFileIds"/> map the provider uses for path↔id round-tripping.
+    /// </summary>
+    /// <remarks>
+    /// Reads <see cref="WopiFileSystemProviderOptions"/> from the <c>Wopi:StorageProvider</c>
+    /// configuration section. <c>RootPath</c> is required.
+    /// </remarks>
+    public static IServiceCollection AddFileSystemStorageProvider(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services
+            .AddOptions<WopiFileSystemProviderOptions>()
+            .Bind(configuration.GetSection(WopiFileSystemProviderOptions.SectionName))
+            .Validate(o => !string.IsNullOrWhiteSpace(o.RootPath), "Wopi:StorageProvider:RootPath is required.")
+            .ValidateOnStart();
+
+        services.TryAddSingleton<InMemoryFileIds>();
+        services.AddScoped<WopiFileSystemProvider>();
+        services.AddScoped<IWopiStorageProvider>(sp => sp.GetRequiredService<WopiFileSystemProvider>());
+        services.AddScoped<IWopiWritableStorageProvider>(sp => sp.GetRequiredService<WopiFileSystemProvider>());
+
+        return services;
+    }
+}

--- a/src/WopiHost.MemoryLockProvider/README.md
+++ b/src/WopiHost.MemoryLockProvider/README.md
@@ -18,22 +18,11 @@ dotnet add package WopiHost.MemoryLockProvider
 
 ## Register
 
-The provider is loaded by assembly name from `WopiHostOptions`, so the only thing the host has to do is reference the package and point at it:
-
-```jsonc
-// appsettings.json
-"Wopi": {
-  "LockProviderAssemblyName": "WopiHost.MemoryLockProvider"
-}
-```
-
-If you prefer manual registration:
-
 ```csharp
-services.AddSingleton<IWopiLockProvider, MemoryLockProvider>();
+services.AddMemoryLockProvider();
 ```
 
-`MemoryLockProvider` keeps state in a `static` field — register it once, lifetime doesn't matter.
+`AddMemoryLockProvider` registers `MemoryLockProvider` as the singleton `IWopiLockProvider`. Singleton lifetime ensures every request in the process shares the same in-memory lock dictionary — anything narrower would let concurrent requests see independent stores and silently break exclusion.
 
 ## API
 

--- a/src/WopiHost.MemoryLockProvider/ServiceCollectionExtensions.cs
+++ b/src/WopiHost.MemoryLockProvider/ServiceCollectionExtensions.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.DependencyInjection;
+using WopiHost.Abstractions;
+
+namespace WopiHost.MemoryLockProvider;
+
+/// <summary>
+/// DI extensions to register <see cref="MemoryLockProvider"/>.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="MemoryLockProvider"/> as the singleton <see cref="IWopiLockProvider"/>.
+    /// </summary>
+    /// <remarks>
+    /// Singleton lifetime ensures every request in the process shares the same in-memory lock
+    /// dictionary — anything narrower would let concurrent requests see independent stores and
+    /// silently break exclusion. State does not survive process restart or extend across
+    /// instances; use <c>WopiHost.RedisLockProvider</c> or <c>WopiHost.AzureLockProvider</c>
+    /// for multi-instance deployments.
+    /// </remarks>
+    public static IServiceCollection AddMemoryLockProvider(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        services.AddSingleton<IWopiLockProvider, MemoryLockProvider>();
+        return services;
+    }
+}

--- a/src/WopiHost.RedisLockProvider/README.md
+++ b/src/WopiHost.RedisLockProvider/README.md
@@ -26,11 +26,11 @@ Each non-trivial operation is a Lua script evaluated on the Redis server with `E
 
 ## Registration
 
-The sample's `AddLockProvider` helper recognises `"WopiHost.RedisLockProvider"` and dispatches to `services.AddRedisLockProvider(configuration)`. Direct registration:
-
 ```csharp
 services.AddRedisLockProvider(builder.Configuration);
 ```
+
+The runnable sample's `Sample:LockProvider` discriminator (`Memory` / `Azure` / `Redis`) dispatches to the typed extension above — see [`sample/WopiHost/ServiceCollectionExtensions.cs`](../../sample/WopiHost/ServiceCollectionExtensions.cs).
 
 Reads `Wopi:LockProvider:ConnectionString` for the StackExchange.Redis connection string. If an `IConnectionMultiplexer` is already registered in DI (e.g. via Aspire's `builder.AddRedisClient("wopi-locks")`), that wins so a single multiplexer is reused across the process.
 

--- a/test/WopiHost.Core.Tests/Controllers/EcosystemControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/EcosystemControllerTests.cs
@@ -103,7 +103,6 @@ public class EcosystemControllerTests
 
     private static WopiHostOptions DefaultOptions() => new()
     {
-        StorageProviderAssemblyName = "Test",
         ClientUrl = new Uri("http://localhost"),
     };
 

--- a/test/WopiHost.Core.Tests/Controllers/FilesControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/FilesControllerTests.cs
@@ -71,8 +71,6 @@ public class FilesControllerTests
             .SetupGet(o => o.Value)
             .Returns(new WopiHostOptions()
             {
-                StorageProviderAssemblyName = "test",
-                LockProviderAssemblyName = "test",
                 ClientUrl = new Uri("http://localhost:5000"),
             });
         _memoryCache = new MemoryCache(new MemoryCacheOptions());
@@ -951,7 +949,6 @@ public class FilesControllerTests
 
         var optionsWithLimit = Options.Create(new WopiHostOptions
         {
-            StorageProviderAssemblyName = "test",
             ClientUrl = new Uri("http://localhost:5000"),
             MaxFileSize = 1024,
         });
@@ -1182,7 +1179,6 @@ public class FilesControllerTests
 
         var optionsWithLimit = Options.Create(new WopiHostOptions
         {
-            StorageProviderAssemblyName = "test",
             ClientUrl = new Uri("http://localhost:5000"),
             MaxFileSize = 1024,
         });
@@ -1485,7 +1481,6 @@ public class FilesControllerTests
 
         var customOptions = Options.Create(new WopiHostOptions
         {
-            StorageProviderAssemblyName = "test",
             ClientUrl = new Uri("http://localhost:5000"),
             EmptyLockHeaderValue = " ",
         });
@@ -1511,7 +1506,6 @@ public class FilesControllerTests
 
         var customOptions = Options.Create(new WopiHostOptions
         {
-            StorageProviderAssemblyName = "test",
             ClientUrl = new Uri("http://localhost:5000"),
             EmptyLockHeaderValue = " ",
         });

--- a/test/WopiHost.Core.Tests/Security/Authorization/DefaultWopiPermissionProviderTests.cs
+++ b/test/WopiHost.Core.Tests/Security/Authorization/DefaultWopiPermissionProviderTests.cs
@@ -14,7 +14,6 @@ public class DefaultWopiPermissionProviderTests
         options ??= new WopiHostOptions
         {
             ClientUrl = new Uri("http://localhost"),
-            StorageProviderAssemblyName = "x",
         };
         var monitor = new Mock<IOptionsMonitor<WopiHostOptions>>();
         monitor.SetupGet(m => m.CurrentValue).Returns(options);
@@ -40,7 +39,6 @@ public class DefaultWopiPermissionProviderTests
         var options = new WopiHostOptions
         {
             ClientUrl = new Uri("http://localhost"),
-            StorageProviderAssemblyName = "x",
             DefaultFilePermissions = WopiFilePermissions.UserCanWrite,
         };
         var provider = Build(options);
@@ -71,7 +69,6 @@ public class DefaultWopiPermissionProviderTests
         var options = new WopiHostOptions
         {
             ClientUrl = new Uri("http://localhost"),
-            StorageProviderAssemblyName = "x",
             DefaultContainerPermissions = WopiContainerPermissions.UserCanDelete,
         };
         var provider = Build(options);
@@ -88,7 +85,6 @@ public class DefaultWopiPermissionProviderTests
         var options = new WopiHostOptions
         {
             ClientUrl = new Uri("http://localhost"),
-            StorageProviderAssemblyName = "x",
             DefaultFilePermissions = WopiFilePermissions.UserCanWrite,
         };
         var provider = Build(options);

--- a/test/WopiHost.IntegrationTests/Fixtures/WopiBackendFactory.cs
+++ b/test/WopiHost.IntegrationTests/Fixtures/WopiBackendFactory.cs
@@ -19,8 +19,8 @@ public sealed class WopiBackendFactory(string wopiSigningSecret) : WebApplicatio
             config.AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["Wopi:UseCobalt"] = "false",
-                ["Wopi:StorageProviderAssemblyName"] = "WopiHost.FileSystemProvider",
-                ["Wopi:LockProviderAssemblyName"] = "WopiHost.MemoryLockProvider",
+                ["Sample:StorageProvider"] = "FileSystem",
+                ["Sample:LockProvider"] = "Memory",
                 ["Wopi:StorageProvider:RootPath"] = TestPaths.WopiDocsRoot,
                 ["Wopi:ClientUrl"] = "https://office.example.test",
                 ["Wopi:Discovery:NetZone"] = "ExternalHttps",

--- a/test/WopiHost.SmokeTests/Fixtures/ValidatorSampleFactory.cs
+++ b/test/WopiHost.SmokeTests/Fixtures/ValidatorSampleFactory.cs
@@ -32,9 +32,9 @@ public sealed class ValidatorSampleFactory : IDisposable, IAsyncDisposable
         builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Wopi:UseCobalt"] = "false",
-            ["Wopi:StorageProviderAssemblyName"] = "WopiHost.FileSystemProvider",
+            ["Sample:StorageProvider"] = "FileSystem",
+            ["Sample:LockProvider"] = "Memory",
             ["Wopi:StorageProvider:RootPath"] = TestPaths.WopiDocsRoot,
-            ["Wopi:LockProviderAssemblyName"] = "WopiHost.MemoryLockProvider",
             ["Wopi:HostUrl"] = "http://localhost",
             ["Wopi:ClientUrl"] = "https://office.example.test",
             ["Wopi:Discovery:NetZone"] = "ExternalHttps",


### PR DESCRIPTION
## Summary

Audit item [#425 #4.6](https://github.com/petrsvihlik/WopiHost/issues/425). `WopiHostOptions` carried two string properties — `StorageProviderAssemblyName` and `LockProviderAssemblyName` — that the sample read at startup, dispatched on via a switch over known assembly names, and fell back to an `AssemblyLoadContext` + Scrutor reflection scan for arbitrary third-party assemblies. The audit's structural concern was that the failure modes are cryptic (misconfigured name → `InvalidProgramException` at startup), the loaded assembly's version is never validated, and the public API leaks composition-root concerns that shouldn't be on `WopiHost.Core`'s options surface in the first place.

This PR replaces it with idiomatic .NET typed registration. Each provider package exposes a typed extension; the composition root references the package(s) it wants and calls the extension directly — no reflection, no string-name probing.

## ⚠️ Breaking change

`WopiHost.Core`'s public API changes:

- `WopiHostOptions.StorageProviderAssemblyName` — **deleted**
- `WopiHostOptions.LockProviderAssemblyName` — **deleted**
- `PackageValidationBaselineVersion` bumped `7.0.0` → `8.0.0`

Consumers replace:

```csharp
services.AddWopi(o =>
{
    o.ClientUrl                   = new Uri("https://oos.example.com");
    o.StorageProviderAssemblyName = ""WopiHost.FileSystemProvider"";
    o.LockProviderAssemblyName    = ""WopiHost.MemoryLockProvider"";
});
```

with:

```csharp
services.AddWopi(o => { o.ClientUrl = new Uri("https://oos.example.com"); });
services.AddFileSystemStorageProvider(builder.Configuration);
services.AddMemoryLockProvider();
```

## What's in the PR

### `WopiHost.Core`

- Delete `StorageProviderAssemblyName` / `LockProviderAssemblyName` from `WopiHostOptions`. The composition root is no longer expected to negotiate provider identity through a string round-trip.
- Bump `PackageValidationBaselineVersion` 7.0.0 → 8.0.0.

### Per-provider typed extensions

- **`WopiHost.FileSystemProvider`** (NEW) — `AddFileSystemStorageProvider(IConfiguration)`. Binds `WopiFileSystemProviderOptions` from `Wopi:StorageProvider` with required `RootPath`, registers the singleton `InMemoryFileIds` map, and shares one `WopiFileSystemProvider` instance per scope across both `IWopiStorageProvider` and `IWopiWritableStorageProvider` (the prior dual-`AddScoped` registration built two instances per scope — fine but wasteful).
- **`WopiHost.MemoryLockProvider`** (NEW) — `AddMemoryLockProvider()`. Singleton lifetime is intentional — anything narrower lets concurrent requests see independent lock dictionaries.
- **`WopiHost.AzureStorageProvider` / `.AzureLockProvider` / `.RedisLockProvider`** already shipped typed extensions; documentation updated.

### Sample composition root

- `sample/WopiHost/ServiceCollectionExtensions.cs`: replace the assembly-name switch + Scrutor reflection fallback with two small **sample-local** enums (`SampleStorageProvider: FileSystem|Azure`; `SampleLockProvider: Memory|Azure|Redis`) and `AddSampleStorageProvider` / `AddSampleLockProvider` helpers that dispatch to the chosen typed extension. The discriminator lives in the sample (where switching is legitimate composition-root logic), not in `WopiHost.Core`'s public options. Real hosts won't need a discriminator at all. `AddCobalt()` is unchanged (out of scope).
- `appsettings.json`: drop `Wopi:StorageProviderAssemblyName` / `Wopi:LockProviderAssemblyName`; add `Sample:StorageProvider = "FileSystem"` and `Sample:LockProvider = "Memory"`.

### AppHost wiring

- `infra/WopiHost.AppHost`: when `UseRedisLocks=true`, flip the sample's `Sample__LockProvider=Redis` env var instead of the deleted `Wopi__LockProviderAssemblyName`.

### Test fixtures & unit tests

- `WopiBackendFactory` + `ValidatorSampleFactory`: switch their in-memory config to the new `Sample:StorageProvider` / `Sample:LockProvider` keys.
- Three unit-test files drop the now-defunct `StorageProviderAssemblyName = "test"` initializers on `WopiHostOptions`.

### Docs

READMEs (`WopiHost.Core`, `WopiHost.Abstractions`, each provider, sample), plus `CLAUDE.md`, updated to describe the typed-extension model and remove every assembly-name string.

## Test plan

- [x] `dotnet build WOPI.slnx` — **0 errors / 0 warnings** across `net8.0` / `net9.0` / `net10.0`
- [x] `dotnet test WOPI.slnx` — full solution green:
  - `WopiHost.Core.Tests`: 370 × 3 TFMs
  - `WopiHost.FileSystemProvider.Tests`: 100 × 3 TFMs
  - `WopiHost.MemoryLockProvider.Tests`: 23 × 3 TFMs
  - `WopiHost.AzureStorageProvider.Tests`: 101 × 3 TFMs
  - `WopiHost.AzureLockProvider.Tests`: 41 × 3 TFMs
  - `WopiHost.RedisLockProvider.Tests`: 30 × 3 TFMs
  - `WopiHost.Discovery.Tests`: 80 × 3 TFMs
  - `WopiHost.Cobalt.Tests`: 64 × 3 TFMs
  - `WopiHost.Url.Tests`: × 3 TFMs
  - `WopiHost.IntegrationTests`: 25 — exercises the full `sample/WopiHost` composition root end-to-end through the new typed registration path
  - `WopiHost.SmokeTests`: 5 — exercises the Validator-sample composition root the same way

Closes #425 #4.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)