### PR TITLE
chore: revert PackageValidationBaselineVersion to 7.0.0 for 8.0.0 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,7 +31,7 @@
 		<EnablePackageValidation>true</EnablePackageValidation>
 		<!-- Baseline used to detect public-API breaks against the last released version.
 		     Bump this in lockstep with releases. -->
-		<PackageValidationBaselineVersion>8.0.0</PackageValidationBaselineVersion>
+		<PackageValidationBaselineVersion>7.0.0</PackageValidationBaselineVersion>
 	</PropertyGroup>
 	
 	<ItemGroup Condition="!$(MSBuildProjectName.EndsWith('Tests'))">


### PR DESCRIPTION
## Summary

- Reverts the premature bump to `8.0.0` introduced in #428.
- Restores the baseline to `7.0.0` so the [release workflow](.github/workflows/release.yml)'s `dotnet pack` step can resolve a real published baseline on NuGet.org.

## Why

`Microsoft.NET.Sdk`'s pack-time package validator downloads the baseline package from NuGet.org to diff API surfaces. If we leave the baseline at `8.0.0`, the v8.0.0 release pipeline will fail at pack time when it tries to download a version that doesn't exist on NuGet yet.

Convention from prior releases (5.x → 6.x → 7.x): the baseline stays at *N* during the release of *N+1*, and the auto-bump job in [release.yml](.github/workflows/release.yml) opens a follow-up PR setting the baseline to *N+1* after the release publishes (e.g. #358 did this for 7.0.0).

## Test plan

- [ ] CI green on the PR
- [ ] After this merges, tag/publish 8.0.0 → release workflow's `dotnet pack` step succeeds
- [ ] Auto-bump PR fires post-release and bumps the baseline back to 8.0.0