### PR TITLE
chore: drop net8.0/net9.0 multitargeting; libraries are net10.0 only

### DIFF
--- a/.github/workflows/infersharp.yml
+++ b/.github/workflows/infersharp.yml
@@ -44,14 +44,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 2
 
-      - name: Setup .NET 8.0
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: '8.0.x'
-      - name: Setup .NET 9.0
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: '9.0.x'
       - name: Setup .NET 10.0
         uses: actions/setup-dotnet@v5
         with:

--- a/.github/workflows/infersharp.yml
+++ b/.github/workflows/infersharp.yml
@@ -58,14 +58,16 @@ jobs:
       - name: Build (Release, no warnings-as-errors for analysis-only build)
         run: dotnet build --no-restore -c Release /p:ContinuousIntegrationBuild=true
 
-      - name: Stage src/ libraries (net10.0)
+      - name: Stage src/ libraries
         run: |
           # UseArtifactsOutput (#313) centralizes outputs under
-          # artifacts/bin/<Project>/<config>_<tfm>/ — replaces the legacy
-          # src/<Project>/bin/Release/net10.0/ paths.
+          # artifacts/bin/<Project>/<config>/ — replaces the legacy
+          # src/<Project>/bin/Release/net10.0/ paths. The previous
+          # release_net10.0 suffix only appeared while we multi-targeted; now
+          # that net10 is the sole TFM, the SDK drops the suffix.
           mkdir -p infer-staging
           for proj in WopiHost.Abstractions WopiHost.Core WopiHost.Discovery WopiHost.Url WopiHost.Cobalt WopiHost.FileSystemProvider WopiHost.MemoryLockProvider; do
-            cp "artifacts/bin/$proj/release_net10.0/$proj.dll" "artifacts/bin/$proj/release_net10.0/$proj.pdb" infer-staging/
+            cp "artifacts/bin/$proj/release/$proj.dll" "artifacts/bin/$proj/release/$proj.pdb" infer-staging/
           done
           ls -la infer-staging/
 

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -21,18 +21,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - name: Setup .NET 8.0
-      uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: '8.0.x'
-    - name: Setup .NET 9.0
-      uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: '9.0.x'
     - name: Setup .NET 10.0
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '10.0.x'        
+        dotnet-version: '10.0.x'
     - name: Set Cobalt packages token
       run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> $GITHUB_ENV
     - name: Restore dependencies

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,14 +34,6 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 2
-    - name: Setup .NET 8.0
-      uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: '8.0.x'
-    - name: Setup .NET 9.0
-      uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: '9.0.x'
     - name: Setup .NET 10.0
       uses: actions/setup-dotnet@v5
       with:
@@ -87,14 +79,6 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 1
-    - name: Setup .NET 8.0
-      uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: '8.0.x'
-    - name: Setup .NET 9.0
-      uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: '9.0.x'
     - name: Setup .NET 10.0
       uses: actions/setup-dotnet@v5
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,14 +16,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - name: Setup .NET 8.0
-      uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: '8.0.x'
-    - name: Setup .NET 9.0
-      uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: '9.0.x'
     - name: Setup .NET 10.0
       uses: actions/setup-dotnet@v5
       with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,9 @@ dotnet run --project sample/WopiHost
 - .NET analyzers and code style enforcement are on (`EnforceCodeStyleInBuild`).
 - Follow [.NET Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/).
 - Centralized package management via `Directory.Packages.props` — specify versions there, not in individual `.csproj` files.
-- Multi-targeting: libraries target `net8.0;net9.0;net10.0`; sample apps target `net10.0` only.
+- Single-targeted on `net10.0` (libraries, samples, infra, tests). The v8 line was the last to support `net8.0` / `net9.0`; v9 onward is net10 only. The `tools/wopi-validator/` helper project stays on `net8.0` because the upstream `Microsoft.Office.WopiValidator` NuGet does.
 - Build output is centralized under `artifacts/` at the repo root (`UseArtifactsOutput=true` in `Directory.Build.props`) — there are no per-project `bin/`/`obj/` folders.
-- Package validation baseline is `6.0.0` — avoid breaking public API changes in NuGet-packaged libraries. Bump in lockstep with releases. The two newest packages (`WopiHost.AzureStorageProvider`, `WopiHost.AzureLockProvider`) opt out via `EnablePackageValidation=false` in their `.csproj` until they have a prior release to validate against.
+- Package validation baseline is `8.0.0` — avoid breaking public API changes in NuGet-packaged libraries. Bump in lockstep with releases (auto-bumped by `.github/workflows/release.yml` after each stable release). Packages without a prior release on NuGet.org opt out via `EnablePackageValidation=false` in their `.csproj`.
 - `InternalsVisibleTo` is auto-configured for `*.Tests` assemblies.
 
 ## Architecture

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,11 +23,9 @@
     <PackageVersion Include="Scrutor" Version="7.0.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.6.0" />
-    <!-- WopiHost.RedisLockProvider client. Aspire.Hosting.Redis (registered in the net10.0 group
-         further down) is what wires the Redis container into the AppHost. -->
+    <!-- WopiHost.RedisLockProvider client. Aspire.Hosting.Redis (below) is what wires the
+         Redis container into the AppHost. -->
     <PackageVersion Include="StackExchange.Redis" Version="2.9.32" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
@@ -38,7 +36,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.3.2" />
     <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="13.3.2" />
-    <!-- Aspire integration for the Redis lock provider opt-in. Only the AppHost (net10) needs it. -->
+    <!-- Aspire integration for the Redis lock provider opt-in. Only the AppHost needs it. -->
     <PackageVersion Include="Aspire.Hosting.Redis" Version="13.3.2" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
   </ItemGroup>

--- a/PACKAGE_VALIDATION_IMPLEMENTATION.md
+++ b/PACKAGE_VALIDATION_IMPLEMENTATION.md
@@ -13,7 +13,7 @@ WopiHost validates the public API surface of its NuGet packages on two layers.
 </PropertyGroup>
 ```
 
-This runs after `dotnet pack` and **fails the release build** if the new package introduces breaking changes versus `PackageValidationBaselineVersion` on NuGet.org. It also enforces that all TFMs (`net8.0`, `net9.0`, `net10.0`) expose the same public surface.
+This runs after `dotnet pack` and **fails the release build** if the new package introduces breaking changes versus `PackageValidationBaselineVersion` on NuGet.org. The libraries target `net10.0`; the v8 line was the last to multi-target `net8.0`/`net9.0`.
 
 `PackageValidationBaselineVersion` is auto-bumped to the latest stable release by [`.github/workflows/release.yml`](.github/workflows/release.yml) — after a successful publish-to-NuGet, that workflow opens a PR updating the value.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A modular **WOPI host** implementation for .NET that lets you plug your own data
 
 ### Prerequisites
 
-- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) (the AppHost requires it; libraries also target net8.0 and net9.0)
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
 - [Docker Desktop](https://www.docker.com/products/docker-desktop) (used by .NET Aspire for container resources)
 - Recommended: [Visual Studio 2026](https://visualstudio.microsoft.com/vs/) with the .NET Aspire workload, or [VS Code](https://code.visualstudio.com/) with the C# Dev Kit
 

--- a/src/WopiHost.Abstractions/WopiHost.Abstractions.csproj
+++ b/src/WopiHost.Abstractions/WopiHost.Abstractions.csproj
@@ -4,7 +4,7 @@
 		<Nullable>enable</Nullable>
 		<Description>WopiHost.Abstractions Class Library</Description>
 		<Authors>Petr Svihlik</Authors>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 		<AssemblyName>WopiHost.Abstractions</AssemblyName>
 		<PackageId>WopiHost.Abstractions</PackageId>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>

--- a/src/WopiHost.AzureLockProvider/WopiHost.AzureLockProvider.csproj
+++ b/src/WopiHost.AzureLockProvider/WopiHost.AzureLockProvider.csproj
@@ -4,7 +4,7 @@
 		<Nullable>enable</Nullable>
 		<Description>WopiHost.AzureLockProvider Class Library — distributed lock provider backed by Azure Blob leases.</Description>
 		<Authors>Petr Svihlik</Authors>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 		<AssemblyName>WopiHost.AzureLockProvider</AssemblyName>
 		<PackageId>WopiHost.AzureLockProvider</PackageId>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>

--- a/src/WopiHost.AzureStorageProvider/WopiHost.AzureStorageProvider.csproj
+++ b/src/WopiHost.AzureStorageProvider/WopiHost.AzureStorageProvider.csproj
@@ -4,7 +4,7 @@
 		<Nullable>enable</Nullable>
 		<Description>WopiHost.AzureStorageProvider Class Library — Azure Blob Storage backend.</Description>
 		<Authors>Petr Svihlik</Authors>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 		<AssemblyName>WopiHost.AzureStorageProvider</AssemblyName>
 		<PackageId>WopiHost.AzureStorageProvider</PackageId>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>

--- a/src/WopiHost.Cobalt/WopiHost.Cobalt.csproj
+++ b/src/WopiHost.Cobalt/WopiHost.Cobalt.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>WopiHost.Cobalt Class Library</Description>
     <Authors>Petr Svihlik</Authors>
-	<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+	<TargetFramework>net10.0</TargetFramework>
     <AssemblyName>WopiHost.Cobalt</AssemblyName>
     <PackageId>WopiHost.Cobalt</PackageId>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>

--- a/src/WopiHost.Core/WopiHost.Core.csproj
+++ b/src/WopiHost.Core/WopiHost.Core.csproj
@@ -4,7 +4,7 @@
 		<Nullable>enable</Nullable>
 		<Description>WopiHost.Core Class Library</Description>
 		<Authors>Petr Svihlik</Authors>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 		<AssemblyName>WopiHost.Core</AssemblyName>
 		<PackageId>WopiHost.Core</PackageId>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>

--- a/src/WopiHost.Discovery/WopiHost.Discovery.csproj
+++ b/src/WopiHost.Discovery/WopiHost.Discovery.csproj
@@ -4,7 +4,7 @@
 		<Nullable>enable</Nullable>
 		<Description>WopiHost.Discovery Class Library</Description>
 		<Authors>Petr Svihlik</Authors>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 		<AssemblyName>WopiHost.Discovery</AssemblyName>
 		<PackageId>WopiHost.Discovery</PackageId>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>

--- a/src/WopiHost.FileSystemProvider/InMemoryFileIds.cs
+++ b/src/WopiHost.FileSystemProvider/InMemoryFileIds.cs
@@ -27,7 +27,7 @@ public partial class InMemoryFileIds(ILogger<InMemoryFileIds> logger)
 {
     private readonly ConcurrentDictionary<string, string> _idToPath = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, string> _pathToId = new(StringComparer.Ordinal);
-    private readonly object _writeLock = new();
+    private readonly Lock _writeLock = new();
 
     /// <summary>
     /// Gets a value indicating whether any files have been scanned.

--- a/src/WopiHost.FileSystemProvider/WopiHost.FileSystemProvider.csproj
+++ b/src/WopiHost.FileSystemProvider/WopiHost.FileSystemProvider.csproj
@@ -4,7 +4,7 @@
 		<Nullable>enable</Nullable>
 		<Description>WopiHost.FileSystemProvider Class Library</Description>
 		<Authors>Petr Svihlik</Authors>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 		<!-- Required by [LibraryImport] generated marshalling code (uses pointers internally). -->
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<AssemblyName>WopiHost.FileSystemProvider</AssemblyName>

--- a/src/WopiHost.MemoryLockProvider/WopiHost.MemoryLockProvider.csproj
+++ b/src/WopiHost.MemoryLockProvider/WopiHost.MemoryLockProvider.csproj
@@ -4,7 +4,7 @@
 		<Nullable>enable</Nullable>
 		<Description>WopiHost.MemoryLockProvider Class Library</Description>
 		<Authors>Leon Segal</Authors>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 		<AssemblyName>WopiHost.MemoryLockProvider</AssemblyName>
 		<PackageId>WopiHost.MemoryLockProvider</PackageId>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>

--- a/src/WopiHost.RedisLockProvider/WopiHost.RedisLockProvider.csproj
+++ b/src/WopiHost.RedisLockProvider/WopiHost.RedisLockProvider.csproj
@@ -4,7 +4,7 @@
 		<Nullable>enable</Nullable>
 		<Description>WopiHost.RedisLockProvider Class Library — distributed lock provider backed by Redis, with atomic compare-and-swap via Lua scripts and TTL-driven WOPI expiry. Best-effort against a single Redis instance; deliberately does not implement Redlock — see the README for the rationale.</Description>
 		<Authors>Petr Svihlik</Authors>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 		<AssemblyName>WopiHost.RedisLockProvider</AssemblyName>
 		<PackageId>WopiHost.RedisLockProvider</PackageId>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>

--- a/src/WopiHost.Url/WopiHost.Url.csproj
+++ b/src/WopiHost.Url/WopiHost.Url.csproj
@@ -4,7 +4,7 @@
 		<Nullable>enable</Nullable>
 		<Description>WopiHost.Url Class Library</Description>
 		<Authors>Petr Svihlik</Authors>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 		<AssemblyName>WopiHost.Url</AssemblyName>
 		<PackageId>WopiHost.Url</PackageId>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -18,7 +18,6 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.59.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
     <PackageVersion Include="Testcontainers" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.Azurite" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.Redis" Version="4.11.0" />

--- a/test/WopiHost.Abstractions.Testing/WopiHost.Abstractions.Testing.csproj
+++ b/test/WopiHost.Abstractions.Testing/WopiHost.Abstractions.Testing.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<Nullable>enable</Nullable>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 		<AssemblyName>WopiHost.Abstractions.Testing</AssemblyName>
 		<!-- This is a class library that exposes abstract xUnit test classes for downstream
 		     IWopiLockProvider implementers; it is NOT itself a test project. Override the

--- a/test/WopiHost.AzureLockProvider.Tests/WopiHost.AzureLockProvider.Tests.csproj
+++ b/test/WopiHost.AzureLockProvider.Tests/WopiHost.AzureLockProvider.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\WopiHost.AzureLockProvider\WopiHost.AzureLockProvider.csproj" />

--- a/test/WopiHost.AzureStorageProvider.Tests/WopiHost.AzureStorageProvider.Tests.csproj
+++ b/test/WopiHost.AzureStorageProvider.Tests/WopiHost.AzureStorageProvider.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\WopiHost.AzureStorageProvider\WopiHost.AzureStorageProvider.csproj" />

--- a/test/WopiHost.Cobalt.Tests/WopiHost.Cobalt.Tests.csproj
+++ b/test/WopiHost.Cobalt.Tests/WopiHost.Cobalt.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\..\src\WopiHost.Cobalt\WopiHost.Cobalt.csproj" />

--- a/test/WopiHost.Core.Tests/WopiHost.Core.Tests.csproj
+++ b/test/WopiHost.Core.Tests/WopiHost.Core.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\WopiHost.Core\WopiHost.Core.csproj" />
@@ -13,10 +13,6 @@
 	</ItemGroup>
 	<ItemGroup>
 	  <PackageReference Include="Moq" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
-	  <PackageReference Include="System.Linq.Async" />
 	</ItemGroup>
 	<ItemGroup>
 	  <PackageReference Update="coverlet.collector">

--- a/test/WopiHost.Discovery.Tests/WopiHost.Discovery.Tests.csproj
+++ b/test/WopiHost.Discovery.Tests/WopiHost.Discovery.Tests.csproj
@@ -6,7 +6,7 @@
 	</ItemGroup>
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 	
 	<ItemGroup>

--- a/test/WopiHost.FileSystemProvider.Tests/WopiHost.FileSystemProvider.Tests.csproj
+++ b/test/WopiHost.FileSystemProvider.Tests/WopiHost.FileSystemProvider.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\WopiHost.FileSystemProvider\WopiHost.FileSystemProvider.csproj" />

--- a/test/WopiHost.MemoryLockProvider.Tests/WopiHost.MemoryLockProvider.Tests.csproj
+++ b/test/WopiHost.MemoryLockProvider.Tests/WopiHost.MemoryLockProvider.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\..\src\WopiHost.MemoryLockProvider\WopiHost.MemoryLockProvider.csproj" />

--- a/test/WopiHost.RedisLockProvider.Tests/WopiHost.RedisLockProvider.Tests.csproj
+++ b/test/WopiHost.RedisLockProvider.Tests/WopiHost.RedisLockProvider.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\WopiHost.RedisLockProvider\WopiHost.RedisLockProvider.csproj" />

--- a/test/WopiHost.Url.Tests/WopiHost.Url.Tests.csproj
+++ b/test/WopiHost.Url.Tests/WopiHost.Url.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\WopiHost.Url\WopiHost.Url.csproj" />


### PR DESCRIPTION
## Summary

- Drops `net8.0` and `net9.0` from all 20 multi-targeted projects (10 in `src/`, 10 in `test/`) — they now target a single `net10.0`.
- .NET 8 reaches end of support on **2026-11-10** and .NET 9 already has. The v8 line was the last release on the older TFMs; v9 onward ships net10 only.
- **Fix [#419](https://github.com/petrsvihlik/WopiHost/issues/419)** by switching `InMemoryFileIds._writeLock` from `object` to `System.Threading.Lock` — now that net9 is gone from the build graph, the type is universally available.

## Why

- Faster CI: one TFM instead of three.
- Faster local test loop (the user's primary motivation here).
- Eliminates `#if NET*` / TFM-conditional `ItemGroup` polyfills — none existed in source, two existed in build files.
- Unlocks `System.Threading.Lock` (and similar net9-only BCL surfaces) project-wide without conditional compilation.

## Changes

### Project files
- All 20 multi-targeted `.csproj`s: `<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>` → `<TargetFramework>net10.0</TargetFramework>`.
- [Directory.Packages.props](Directory.Packages.props): flatten the `Condition=\"'$(TargetFramework)' == 'net10.0'\"` `ItemGroup` into the main one.
- [test/Directory.Packages.props](test/Directory.Packages.props): drop `System.Linq.Async` — only needed as an `IAsyncEnumerable.ToListAsync()` polyfill for net8/net9; net10's BCL has it.
- [test/WopiHost.Core.Tests/WopiHost.Core.Tests.csproj](test/WopiHost.Core.Tests/WopiHost.Core.Tests.csproj): drop the matching `Condition=\"'$(TargetFramework)' != 'net10.0'\"` `PackageReference`.

### CI workflows
- [integrate.yml](.github/workflows/integrate.yml), [pull_request.yml](.github/workflows/pull_request.yml), [release.yml](.github/workflows/release.yml), [infersharp.yml](.github/workflows/infersharp.yml): drop the `setup-dotnet` steps for `8.0.x` / `9.0.x`; only install `10.0.x`.
- [wopi-validator.yml](.github/workflows/wopi-validator.yml) **stays on net8** — the upstream `Microsoft.Office.WopiValidator` NuGet targets net8, and [tools/wopi-validator/wopi-validator.csproj](tools/wopi-validator/wopi-validator.csproj) is purely a fetch-helper for that external tool. That workflow already pulls both SDKs; left as-is.

### Lock fix ([#419](https://github.com/petrsvihlik/WopiHost/issues/419))
- [src/WopiHost.FileSystemProvider/InMemoryFileIds.cs](src/WopiHost.FileSystemProvider/InMemoryFileIds.cs):
  ```diff
  -    private readonly object _writeLock = new();
  +    private readonly Lock _writeLock = new();
  ```
  No call-site changes needed — `lock (_writeLock) { ... }` is lowered by the compiler to `Lock.EnterScope()` / `Scope.Dispose()` automatically when the field is typed `Lock` (fewer allocations, no boxing). The compiler also warns on accidental `Monitor.Enter(_writeLock)` from now on. **Repo-wide sweep**: only one matching `private (static )?readonly object \w*[Ll]ock` field exists in `src/`; no others needed conversion.

### Docs
- [CLAUDE.md](CLAUDE.md): updated the Code Style & Build Rules section — multi-targeting bullet replaced with a single-target note, and the stale \"baseline is 6.0.0\" line refreshed to 8.0.0.
- [README.md](README.md): drop the \"libraries also target net8.0 and net9.0\" aside from Prerequisites.
- [PACKAGE_VALIDATION_IMPLEMENTATION.md](PACKAGE_VALIDATION_IMPLEMENTATION.md): drop the \"enforces same surface across all TFMs\" line.

## Test plan

- [x] `dotnet build WOPI.slnx` — 0 warnings, 0 errors.
- [x] `dotnet test WOPI.slnx` — 857 tests across 11 projects, all green.
- [ ] CI integrate.yml green on the PR (single dotnet 10.0 setup).
- [ ] api-compat sticky comment on the PR — there should be no public-surface delta from this change.

Closes #419