### PR TITLE
test: raise src/ line coverage 95.7% → 97.7% (137 → 74 uncovered)

### DIFF
--- a/test/WopiHost.Core.Tests/Abstractions/WopiHostExtensionsTests.cs
+++ b/test/WopiHost.Core.Tests/Abstractions/WopiHostExtensionsTests.cs
@@ -1,0 +1,99 @@
+using System.Collections.ObjectModel;
+using System.Security.Claims;
+using Moq;
+using WopiHost.Abstractions;
+
+namespace WopiHost.Core.Tests.Abstractions;
+
+/// <summary>
+/// Tests for the default <see cref="WopiHostExtensions"/> pass-through implementation. Hosts
+/// extend this class and override the hooks they need; the un-overridden defaults must echo
+/// the input context or complete as a no-op, never mutate state.
+/// </summary>
+public class WopiHostExtensionsTests
+{
+    private readonly WopiHostExtensions _sut = new();
+
+    [Fact]
+    public async Task OnCheckFileInfoAsync_ReturnsContextCheckFileInfo()
+    {
+        var info = new WopiCheckFileInfo { BaseFileName = "doc.docx", OwnerId = "u1", UserId = "u1", Version = "v1" };
+        var ctx = new WopiCheckFileInfoContext(new ClaimsPrincipal(), Mock.Of<IWopiFile>(), info);
+
+        var result = await _sut.OnCheckFileInfoAsync(ctx);
+
+        Assert.Same(info, result);
+    }
+
+    [Fact]
+    public async Task OnCheckContainerInfoAsync_ReturnsContextCheckContainerInfo()
+    {
+        var info = new WopiCheckContainerInfo { Name = "folder" };
+        var ctx = new WopiCheckContainerInfoContext(new ClaimsPrincipal(), Mock.Of<IWopiContainer>(), info);
+
+        var result = await _sut.OnCheckContainerInfoAsync(ctx);
+
+        Assert.Same(info, result);
+    }
+
+    [Fact]
+    public async Task OnCheckFolderInfoAsync_ReturnsContextCheckFolderInfo()
+    {
+        var info = new WopiCheckFolderInfo { FolderName = "folder" };
+        var ctx = new WopiCheckFolderInfoContext(new ClaimsPrincipal(), Mock.Of<IWopiContainer>(), info);
+
+        var result = await _sut.OnCheckFolderInfoAsync(ctx);
+
+        Assert.Same(info, result);
+    }
+
+    [Fact]
+    public async Task OnCheckEcosystemAsync_ReturnsContextCheckEcosystem()
+    {
+        var info = new WopiCheckEcosystem();
+        var ctx = new WopiCheckEcosystemContext(new ClaimsPrincipal(), info);
+
+        var result = await _sut.OnCheckEcosystemAsync(ctx);
+
+        Assert.Same(info, result);
+    }
+
+    [Fact]
+    public async Task OnPutFileAsync_IsNoOp()
+    {
+        var ctx = new WopiPutFileContext(new ClaimsPrincipal(), Mock.Of<IWopiFile>(), new ReadOnlyCollection<string>([]));
+
+        // The default pass-through impl completes without inspecting the context. The visible
+        // behavior is "it doesn't throw and returns a completed task".
+        await _sut.OnPutFileAsync(ctx);
+    }
+
+    [Fact]
+    public async Task OnPutRelativeFileAsync_IsNoOp()
+    {
+        var ctx = new WopiPutRelativeFileContext(
+            new ClaimsPrincipal(),
+            Mock.Of<IWopiFile>(),
+            Mock.Of<IWopiFile>(),
+            IsFileConversion: true,
+            DeclaredSize: 1024);
+
+        await _sut.OnPutRelativeFileAsync(ctx);
+    }
+
+    [Fact]
+    public async Task OnCheckFileInfoAsync_NullContext_Throws()
+        => await Assert.ThrowsAsync<ArgumentNullException>(() => _sut.OnCheckFileInfoAsync(null!));
+
+    [Fact]
+    public async Task OnCheckContainerInfoAsync_NullContext_Throws()
+        => await Assert.ThrowsAsync<ArgumentNullException>(() => _sut.OnCheckContainerInfoAsync(null!));
+
+    [Fact]
+    public async Task OnCheckFolderInfoAsync_NullContext_Throws()
+        => await Assert.ThrowsAsync<ArgumentNullException>(() => _sut.OnCheckFolderInfoAsync(null!));
+
+    [Fact]
+    public async Task OnCheckEcosystemAsync_NullContext_Throws()
+        => await Assert.ThrowsAsync<ArgumentNullException>(() => _sut.OnCheckEcosystemAsync(null!));
+}

--- a/test/WopiHost.Core.Tests/Abstractions/WopiLockComparerTests.cs
+++ b/test/WopiHost.Core.Tests/Abstractions/WopiLockComparerTests.cs
@@ -94,5 +94,15 @@ public class WopiLockComparerTests
             Assert.True(_sut.AreEqual(noS, noS));
             Assert.False(_sut.AreEqual(noS, """{"F":2}"""));
         }
+
+        [Fact]
+        public void OneNullInput_AreNotEqual()
+        {
+            // The fast-path ordinal equality returns true only when both inputs match exactly,
+            // so (null, null) is handled there. Asymmetric null inputs must short-circuit to
+            // false before the JSON-parse path attempts to dereference either string.
+            Assert.False(_sut.AreEqual(null, """{"S":"abc"}"""));
+            Assert.False(_sut.AreEqual("""{"S":"abc"}""", null));
+        }
     }
 }

--- a/test/WopiHost.Core.Tests/Abstractions/WopiNewChildFileResultTests.cs
+++ b/test/WopiHost.Core.Tests/Abstractions/WopiNewChildFileResultTests.cs
@@ -1,0 +1,69 @@
+using Moq;
+using WopiHost.Abstractions;
+
+namespace WopiHost.Core.Tests.Abstractions;
+
+/// <summary>
+/// Tests for the <see cref="WopiNewChildFileResult"/> factory shorthands. Each factory must
+/// set <see cref="WopiNewChildFileResult.Outcome"/> to the matching enum value and populate
+/// only the outcome-relevant payload field; the others stay null.
+/// </summary>
+public class WopiNewChildFileResultTests
+{
+    [Fact]
+    public void Success_SetsOutcomeAndFile()
+    {
+        var file = Mock.Of<IWopiWritableFile>();
+
+        var result = WopiNewChildFileResult.Success(file);
+
+        Assert.Equal(WopiNewChildFileOutcome.Success, result.Outcome);
+        Assert.Same(file, result.File);
+        Assert.Null(result.ValidRelativeTargetSuggestion);
+        Assert.Null(result.ExistingLockId);
+    }
+
+    [Fact]
+    public void BadRequest_SetsOnlyOutcome()
+    {
+        var result = WopiNewChildFileResult.BadRequest();
+
+        Assert.Equal(WopiNewChildFileOutcome.BadRequest, result.Outcome);
+        Assert.Null(result.File);
+        Assert.Null(result.ValidRelativeTargetSuggestion);
+        Assert.Null(result.ExistingLockId);
+    }
+
+    [Fact]
+    public void Conflict_CarriesSuggestion()
+    {
+        var result = WopiNewChildFileResult.Conflict("Report (1).docx");
+
+        Assert.Equal(WopiNewChildFileOutcome.Conflict, result.Outcome);
+        Assert.Equal("Report (1).docx", result.ValidRelativeTargetSuggestion);
+        Assert.Null(result.File);
+        Assert.Null(result.ExistingLockId);
+    }
+
+    [Fact]
+    public void Locked_CarriesExistingLockId()
+    {
+        var result = WopiNewChildFileResult.Locked("lock-A");
+
+        Assert.Equal(WopiNewChildFileOutcome.Locked, result.Outcome);
+        Assert.Equal("lock-A", result.ExistingLockId);
+        Assert.Null(result.File);
+        Assert.Null(result.ValidRelativeTargetSuggestion);
+    }
+
+    [Fact]
+    public void InternalError_SetsOnlyOutcome()
+    {
+        var result = WopiNewChildFileResult.InternalError();
+
+        Assert.Equal(WopiNewChildFileOutcome.InternalError, result.Outcome);
+        Assert.Null(result.File);
+        Assert.Null(result.ValidRelativeTargetSuggestion);
+        Assert.Null(result.ExistingLockId);
+    }
+}

--- a/test/WopiHost.Core.Tests/Abstractions/WopiPutContextTests.cs
+++ b/test/WopiHost.Core.Tests/Abstractions/WopiPutContextTests.cs
@@ -1,0 +1,71 @@
+using System.Collections.ObjectModel;
+using System.Security.Claims;
+using Moq;
+using WopiHost.Abstractions;
+
+namespace WopiHost.Core.Tests.Abstractions;
+
+/// <summary>
+/// Smoke tests for the <see cref="WopiPutFileContext"/> and <see cref="WopiPutRelativeFileContext"/>
+/// record types. Records are auto-generated, but the property-getter IL is only emitted/exercised
+/// when something actually reads the values — which the controllers do at runtime but no other
+/// test does directly.
+/// </summary>
+public class WopiPutContextTests
+{
+    [Fact]
+    public void WopiPutFileContext_PreservesArguments()
+    {
+        var user = new ClaimsPrincipal();
+        var file = Mock.Of<IWopiFile>();
+        var editors = new ReadOnlyCollection<string>(["u1", "u2"]);
+
+        var ctx = new WopiPutFileContext(user, file, editors);
+
+        Assert.Same(user, ctx.User);
+        Assert.Same(file, ctx.File);
+        Assert.Same(editors, ctx.Editors);
+    }
+
+    [Fact]
+    public void WopiPutFileContext_AllowsNullUser()
+    {
+        // The User field is nullable on the record — service-to-service callers (a host job that
+        // proxies an end-user write) may not have a principal in scope.
+        var ctx = new WopiPutFileContext(User: null, Mock.Of<IWopiFile>(), new ReadOnlyCollection<string>([]));
+
+        Assert.Null(ctx.User);
+    }
+
+    [Fact]
+    public void WopiPutRelativeFileContext_PreservesArguments()
+    {
+        var user = new ClaimsPrincipal();
+        var original = Mock.Of<IWopiFile>();
+        var created = Mock.Of<IWopiFile>();
+
+        var ctx = new WopiPutRelativeFileContext(user, original, created, IsFileConversion: true, DeclaredSize: 4096);
+
+        Assert.Same(user, ctx.User);
+        Assert.Same(original, ctx.OriginalFile);
+        Assert.Same(created, ctx.NewFile);
+        Assert.True(ctx.IsFileConversion);
+        Assert.Equal(4096, ctx.DeclaredSize);
+    }
+
+    [Fact]
+    public void WopiPutRelativeFileContext_AllowsNullSizeAndUser()
+    {
+        // X-WOPI-Size is optional — when absent the controller passes null through.
+        var ctx = new WopiPutRelativeFileContext(
+            User: null,
+            OriginalFile: Mock.Of<IWopiFile>(),
+            NewFile: Mock.Of<IWopiFile>(),
+            IsFileConversion: false,
+            DeclaredSize: null);
+
+        Assert.Null(ctx.User);
+        Assert.Null(ctx.DeclaredSize);
+        Assert.False(ctx.IsFileConversion);
+    }
+}

--- a/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
+++ b/test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs
@@ -490,6 +490,43 @@ public class ContainersControllerTests
     }
 
     [Fact]
+    public async Task RenameContainer_IllegalName_ReturnsBadRequestWithInvalidNameHeader()
+    {
+        // Providers signal an illegal name post-validation by throwing ArgumentException with
+        // ParamName=requestedName. The controller maps this to 400 + the WOPI-spec
+        // X-WOPI-InvalidContainerName response header (logging-only per the spec).
+        var controller = _controller;
+        _storageProviderMock.Setup(sp => sp.GetWopiContainer(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Mock<IWopiContainer>().Object);
+        _writableStorageProviderMock.Setup(wsp => wsp.CheckValidContainerName(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _writableStorageProviderMock.Setup(wsp => wsp.RenameWopiContainer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ArgumentException("illegal", paramName: "requestedName"));
+        var httpCtx = new DefaultHttpContext();
+        controller.ControllerContext = new ControllerContext { HttpContext = httpCtx };
+
+        var result = await controller.RenameContainer("containerId", UtfString.FromDecoded("bogus"));
+
+        Assert.IsType<BadRequestResult>(result);
+        Assert.Equal("Specified name is illegal", httpCtx.Response.Headers[WopiHeaders.INVALID_CONTAINER_NAME].ToString());
+    }
+
+    [Fact]
+    public async Task RenameContainer_UnrelatedArgumentException_BubblesToFramework()
+    {
+        // The `when (ae.ParamName == nameof(requestedName))` filter must NOT swallow other
+        // ArgumentExceptions — they signal a different bug class and should bubble to the
+        // framework exception middleware. This guards against the filter losing its specificity.
+        _storageProviderMock.Setup(sp => sp.GetWopiContainer(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Mock<IWopiContainer>().Object);
+        _writableStorageProviderMock.Setup(wsp => wsp.CheckValidContainerName(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _writableStorageProviderMock.Setup(wsp => wsp.RenameWopiContainer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ArgumentException("not the renamed-name param", paramName: "somethingElse"));
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _controller.RenameContainer("containerId", UtfString.FromDecoded("newName")));
+    }
+
+    [Fact]
     public async Task GetEcosystem_ReturnsNotFound_WhenContainerDoesNotExist()
     {
         _storageProviderMock.Setup(sp => sp.GetWopiContainer(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() => null);

--- a/test/WopiHost.Core.Tests/Extensions/ExtensionsTests.cs
+++ b/test/WopiHost.Core.Tests/Extensions/ExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using WopiHost.Core.Extensions;
+﻿using Moq;
+using WopiHost.Core.Extensions;
 
 namespace WopiHost.Core.Tests.Extensions;
 
@@ -45,5 +46,48 @@ public class ExtensionsTests
 
         Assert.Throws<ArgumentOutOfRangeException>(() =>
             url.Object.GetWopiSrc((WopiHost.Abstractions.WopiResourceType)999, "id"));
+    }
+
+    [Theory]
+    [InlineData(WopiHost.Abstractions.WopiResourceType.File, WopiHost.Core.Infrastructure.WopiRouteNames.CheckFileInfo)]
+    [InlineData(WopiHost.Abstractions.WopiResourceType.Container, WopiHost.Core.Infrastructure.WopiRouteNames.CheckContainerInfo)]
+    public void GetWopiSrc_EnumOverload_RoutesToMatchingControllerAction(
+        WopiHost.Abstractions.WopiResourceType resourceType, string expectedRouteName)
+    {
+        // The enum overload of GetWopiSrc maps File → CheckFileInfo, Container → CheckContainerInfo.
+        // Both arms (and the throw arm in the test above) round out coverage on the resource-type
+        // dispatch. The mock asserts both that the call went out and which route name was used.
+        string? observedRouteName = null;
+        var url = new Moq.Mock<Microsoft.AspNetCore.Mvc.IUrlHelper>();
+        url.Setup(u => u.ActionContext).Returns(new Microsoft.AspNetCore.Mvc.ActionContext
+        {
+            HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext { Request = { Scheme = "https", Host = new("h") } }
+        });
+        url.Setup(u => u.RouteUrl(It.IsAny<Microsoft.AspNetCore.Mvc.Routing.UrlRouteContext>()))
+            .Callback<Microsoft.AspNetCore.Mvc.Routing.UrlRouteContext>(ctx => observedRouteName = ctx.RouteName)
+            .Returns("/wopi/x");
+
+        var src = url.Object.GetWopiSrc(resourceType, "id", "access");
+
+        Assert.Equal(expectedRouteName, observedRouteName);
+        Assert.NotNull(src);
+    }
+
+    [Fact]
+    public void GetWopiSrc_WhenRouteUrlReturnsNull_FallsBackGracefully()
+    {
+        // The proxy-aware URL helper returns null when no route matches. The caller (GetWopiSrc)
+        // must surface that via an InvalidOperationException so the bug isn't silently masked
+        // by an empty Uri. This exercises the null-route-path branch in ProxyAwareRouteUrl.
+        var url = new Moq.Mock<Microsoft.AspNetCore.Mvc.IUrlHelper>();
+        url.Setup(u => u.ActionContext).Returns(new Microsoft.AspNetCore.Mvc.ActionContext
+        {
+            HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext { Request = { Scheme = "https", Host = new("h") } }
+        });
+        url.Setup(u => u.RouteUrl(It.IsAny<Microsoft.AspNetCore.Mvc.Routing.UrlRouteContext>()))
+            .Returns((string?)null);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            url.Object.GetWopiSrc(WopiHost.Abstractions.WopiResourceType.File, "id"));
     }
 }

--- a/test/WopiHost.Core.Tests/Infrastructure/DefaultWopiNewChildFileNegotiatorTests.cs
+++ b/test/WopiHost.Core.Tests/Infrastructure/DefaultWopiNewChildFileNegotiatorTests.cs
@@ -1,0 +1,225 @@
+using Moq;
+using WopiHost.Abstractions;
+using WopiHost.Core.Infrastructure;
+
+namespace WopiHost.Core.Tests.Infrastructure;
+
+/// <summary>
+/// Tests for the WOPI spec's PutRelativeFile / CreateChildFile name-negotiation protocol as
+/// implemented by <see cref="DefaultWopiNewChildFileNegotiator"/>. Each test pins one branch of
+/// the spec dance — relative vs. suggested mode, collision-vs-not, overwrite-vs-not,
+/// locked-vs-not — and asserts the outcome a controller will translate into the wire response.
+/// </summary>
+public class DefaultWopiNewChildFileNegotiatorTests
+{
+    private const string Container = "container-1";
+    private readonly Mock<IWopiStorageProvider> _storage = new();
+    private readonly Mock<IWopiWritableStorageProvider> _writable = new();
+    private readonly Mock<IWopiLockProvider> _lockProvider = new();
+
+    private DefaultWopiNewChildFileNegotiator CreateNegotiator(bool withLockProvider = true)
+        => new(_storage.Object, _writable.Object, withLockProvider ? _lockProvider.Object : null);
+
+    private static WopiNewChildFileRequest Request(
+        string? suggested = null,
+        string? relative = null,
+        bool overwrite = false,
+        string fallbackStem = "Untitled")
+        => new(Container, suggested, relative, overwrite, fallbackStem);
+
+    [Fact]
+    public async Task BothTargetsMissing_ReturnsBadRequest()
+    {
+        // Controllers short-circuit this case with 501 before invoking the negotiator; the
+        // negotiator itself defensively maps to BadRequest for direct callers that skip the
+        // pre-check. Covers the trailing-return branch of NegotiateAsync.
+        var result = await CreateNegotiator().NegotiateAsync(Request());
+
+        Assert.Equal(WopiNewChildFileOutcome.BadRequest, result.Outcome);
+    }
+
+    [Fact]
+    public async Task RelativeTarget_InvalidName_ReturnsBadRequest()
+    {
+        _writable.Setup(w => w.CheckValidFileName("bad/name.docx", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await CreateNegotiator().NegotiateAsync(Request(relative: "bad/name.docx"));
+
+        Assert.Equal(WopiNewChildFileOutcome.BadRequest, result.Outcome);
+    }
+
+    [Fact]
+    public async Task RelativeTarget_NoCollision_CreatesFile()
+    {
+        var newFile = Mock.Of<IWopiWritableFile>();
+        _writable.Setup(w => w.CheckValidFileName("new.docx", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _storage.Setup(s => s.GetWopiFileByName(Container, "new.docx", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IWopiFile?)null);
+        _writable.Setup(w => w.CreateWopiChildFile(Container, "new.docx", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(newFile);
+
+        var result = await CreateNegotiator().NegotiateAsync(Request(relative: "new.docx"));
+
+        Assert.Equal(WopiNewChildFileOutcome.Success, result.Outcome);
+        Assert.Same(newFile, result.File);
+    }
+
+    [Fact]
+    public async Task RelativeTarget_NoCollision_CreateReturnsNull_ReturnsInternalError()
+    {
+        _writable.Setup(w => w.CheckValidFileName("new.docx", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _storage.Setup(s => s.GetWopiFileByName(Container, "new.docx", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IWopiFile?)null);
+        _writable.Setup(w => w.CreateWopiChildFile(Container, "new.docx", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IWopiWritableFile?)null);
+
+        var result = await CreateNegotiator().NegotiateAsync(Request(relative: "new.docx"));
+
+        Assert.Equal(WopiNewChildFileOutcome.InternalError, result.Outcome);
+    }
+
+    [Fact]
+    public async Task RelativeTarget_Collision_NoOverwrite_ReturnsConflictWithSuggestion()
+    {
+        var existing = Mock.Of<IWopiFile>(f => f.Identifier == "existing-id");
+        _writable.Setup(w => w.CheckValidFileName("doc.docx", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _storage.Setup(s => s.GetWopiFileByName(Container, "doc.docx", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+        _writable.Setup(w => w.GetSuggestedFileName(Container, "doc.docx", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("doc (1).docx");
+
+        var result = await CreateNegotiator().NegotiateAsync(Request(relative: "doc.docx", overwrite: false));
+
+        Assert.Equal(WopiNewChildFileOutcome.Conflict, result.Outcome);
+        Assert.Equal("doc (1).docx", result.ValidRelativeTargetSuggestion);
+    }
+
+    [Fact]
+    public async Task RelativeTarget_Collision_Overwrite_Locked_ReturnsLocked()
+    {
+        var existing = Mock.Of<IWopiFile>(f => f.Identifier == "existing-id");
+        _writable.Setup(w => w.CheckValidFileName("doc.docx", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _storage.Setup(s => s.GetWopiFileByName(Container, "doc.docx", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+        _lockProvider.Setup(l => l.GetLockAsync("existing-id", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WopiLockInfo { FileId = "existing-id", LockId = "L-1" });
+
+        var result = await CreateNegotiator().NegotiateAsync(Request(relative: "doc.docx", overwrite: true));
+
+        Assert.Equal(WopiNewChildFileOutcome.Locked, result.Outcome);
+        Assert.Equal("L-1", result.ExistingLockId);
+    }
+
+    [Fact]
+    public async Task RelativeTarget_Collision_Overwrite_Unlocked_ReturnsSuccessFromGetWritableFile()
+    {
+        var existing = Mock.Of<IWopiFile>(f => f.Identifier == "existing-id");
+        var writableExisting = Mock.Of<IWopiWritableFile>();
+        _writable.Setup(w => w.CheckValidFileName("doc.docx", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _storage.Setup(s => s.GetWopiFileByName(Container, "doc.docx", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+        _lockProvider.Setup(l => l.GetLockAsync("existing-id", It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _writable.Setup(w => w.GetWritableFile("existing-id", It.IsAny<CancellationToken>())).ReturnsAsync(writableExisting);
+
+        var result = await CreateNegotiator().NegotiateAsync(Request(relative: "doc.docx", overwrite: true));
+
+        Assert.Equal(WopiNewChildFileOutcome.Success, result.Outcome);
+        Assert.Same(writableExisting, result.File);
+    }
+
+    [Fact]
+    public async Task RelativeTarget_Collision_Overwrite_Unlocked_GetWritableFileReturnsNull_ReturnsInternalError()
+    {
+        // The writable provider's contract says GetWritableFile returns non-null for a file the
+        // read-side already resolved by name. A null here is defensive — covers line 86.
+        var existing = Mock.Of<IWopiFile>(f => f.Identifier == "existing-id");
+        _writable.Setup(w => w.CheckValidFileName("doc.docx", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _storage.Setup(s => s.GetWopiFileByName(Container, "doc.docx", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+        _lockProvider.Setup(l => l.GetLockAsync("existing-id", It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _writable.Setup(w => w.GetWritableFile("existing-id", It.IsAny<CancellationToken>())).ReturnsAsync((IWopiWritableFile?)null);
+
+        var result = await CreateNegotiator().NegotiateAsync(Request(relative: "doc.docx", overwrite: true));
+
+        Assert.Equal(WopiNewChildFileOutcome.InternalError, result.Outcome);
+    }
+
+    [Fact]
+    public async Task RelativeTarget_Collision_Overwrite_NoLockProvider_SkipsLockProbe()
+    {
+        // Hosts without a lock provider registered still need to honor overwrite — the lock probe
+        // is conditional on lockProvider being non-null. Covers the "lockProvider is null" branch
+        // (we exercise both halves: this test for the null case, the previous two for non-null).
+        var existing = Mock.Of<IWopiFile>(f => f.Identifier == "existing-id");
+        var writableExisting = Mock.Of<IWopiWritableFile>();
+        _writable.Setup(w => w.CheckValidFileName("doc.docx", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _storage.Setup(s => s.GetWopiFileByName(Container, "doc.docx", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+        _writable.Setup(w => w.GetWritableFile("existing-id", It.IsAny<CancellationToken>())).ReturnsAsync(writableExisting);
+
+        var result = await CreateNegotiator(withLockProvider: false)
+            .NegotiateAsync(Request(relative: "doc.docx", overwrite: true));
+
+        Assert.Equal(WopiNewChildFileOutcome.Success, result.Outcome);
+        _lockProvider.Verify(l => l.GetLockAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SuggestedTarget_ExtensionOnly_CombinesWithFallbackStem()
+    {
+        // Extension-only suggested target: ".pdf" combines with the caller-supplied stem to
+        // produce the actual name. PutRelativeFile passes the original file's stem;
+        // CreateChildFile passes a fresh GUID — the negotiator doesn't care which.
+        var newFile = Mock.Of<IWopiWritableFile>();
+        _writable.Setup(w => w.GetSuggestedFileName(Container, "Untitled.pdf", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("Untitled.pdf");
+        _writable.Setup(w => w.CreateWopiChildFile(Container, "Untitled.pdf", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(newFile);
+
+        var result = await CreateNegotiator().NegotiateAsync(Request(suggested: ".pdf"));
+
+        Assert.Equal(WopiNewChildFileOutcome.Success, result.Outcome);
+        // Validate that the .pdf name was prepended with the fallback stem before deduplication.
+        _writable.Verify(w => w.GetSuggestedFileName(Container, "Untitled.pdf", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SuggestedTarget_InvalidName_ReturnsBadRequest()
+    {
+        _writable.Setup(w => w.CheckValidFileName("bad/name.docx", It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        var result = await CreateNegotiator().NegotiateAsync(Request(suggested: "bad/name.docx"));
+
+        Assert.Equal(WopiNewChildFileOutcome.BadRequest, result.Outcome);
+    }
+
+    [Fact]
+    public async Task SuggestedTarget_HappyPath_DeduplicatesAndCreates()
+    {
+        var newFile = Mock.Of<IWopiWritableFile>();
+        _writable.Setup(w => w.CheckValidFileName("doc.docx", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _writable.Setup(w => w.GetSuggestedFileName(Container, "doc.docx", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("doc (1).docx");
+        _writable.Setup(w => w.CreateWopiChildFile(Container, "doc (1).docx", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(newFile);
+
+        var result = await CreateNegotiator().NegotiateAsync(Request(suggested: "doc.docx"));
+
+        Assert.Equal(WopiNewChildFileOutcome.Success, result.Outcome);
+        Assert.Same(newFile, result.File);
+    }
+
+    [Fact]
+    public async Task SuggestedTarget_CreateReturnsNull_ReturnsInternalError()
+    {
+        _writable.Setup(w => w.CheckValidFileName(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _writable.Setup(w => w.GetSuggestedFileName(Container, "doc.docx", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("doc.docx");
+        _writable.Setup(w => w.CreateWopiChildFile(Container, "doc.docx", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IWopiWritableFile?)null);
+
+        var result = await CreateNegotiator().NegotiateAsync(Request(suggested: "doc.docx"));
+
+        Assert.Equal(WopiNewChildFileOutcome.InternalError, result.Outcome);
+    }
+
+    [Fact]
+    public async Task NullRequest_Throws()
+        => await Assert.ThrowsAsync<ArgumentNullException>(() => CreateNegotiator().NegotiateAsync(null!));
+}

--- a/test/WopiHost.Core.Tests/Infrastructure/WopiLockAwareWritableStorageProviderTests.cs
+++ b/test/WopiHost.Core.Tests/Infrastructure/WopiLockAwareWritableStorageProviderTests.cs
@@ -85,16 +85,104 @@ public class WopiLockAwareWritableStorageProviderTests
     public async Task ReadOnlyMethods_DoNotConsultLockProvider()
     {
         _innerMock.Setup(x => x.CheckValidFileName("name", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _innerMock.Setup(x => x.CheckValidContainerName("cname", It.IsAny<CancellationToken>())).ReturnsAsync(true);
         _innerMock.Setup(x => x.GetSuggestedFileName("parent", "name", It.IsAny<CancellationToken>())).ReturnsAsync("suggested");
+        _innerMock.Setup(x => x.GetSuggestedContainerName("parent", "cname", It.IsAny<CancellationToken>())).ReturnsAsync("suggested-c");
         _innerMock.SetupGet(x => x.FileNameMaxLength).Returns(123);
 
         var decorator = CreateDecorator();
         Assert.True(await decorator.CheckValidFileName("name"));
+        Assert.True(await decorator.CheckValidContainerName("cname"));
         Assert.Equal("suggested", await decorator.GetSuggestedFileName("parent", "name"));
+        Assert.Equal("suggested-c", await decorator.GetSuggestedContainerName("parent", "cname"));
         Assert.Equal(123, decorator.FileNameMaxLength);
 
         _lockProviderMock.Verify(x => x.GetLockAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
+
+    [Fact]
+    public async Task GetWritableFile_DelegatesToInner()
+    {
+        // Plain pass-through — there's no lock to consult for an opaque "give me a writable
+        // handle" request; the lock check belongs at the call site that mutates content.
+        var file = Mock.Of<IWopiWritableFile>();
+        _innerMock.Setup(x => x.GetWritableFile("file-x", It.IsAny<CancellationToken>())).ReturnsAsync(file);
+
+        var result = await CreateDecorator().GetWritableFile("file-x");
+
+        Assert.Same(file, result);
+        _lockProviderMock.Verify(x => x.GetLockAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateWopiChildContainer_BypassesLockCheck()
+    {
+        // Mirror of the file-creation test: a brand-new container has no prior lock.
+        var newContainer = Mock.Of<IWopiContainer>();
+        _innerMock.Setup(x => x.CreateWopiChildContainer("parent", "subdir", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(newContainer);
+
+        var result = await CreateDecorator().CreateWopiChildContainer("parent", "subdir");
+
+        Assert.Same(newContainer, result);
+        _lockProviderMock.Verify(x => x.GetLockAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteWopiContainer_NoLock_DelegatesToInner()
+    {
+        _lockProviderMock.Setup(x => x.GetLockAsync("c-1", It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _innerMock.Setup(x => x.DeleteWopiContainer("c-1", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        var result = await CreateDecorator().DeleteWopiContainer("c-1");
+
+        Assert.True(result);
+        _innerMock.Verify(x => x.DeleteWopiContainer("c-1", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteWopiContainer_Locked_Throws()
+    {
+        _lockProviderMock.Setup(x => x.GetLockAsync("c-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WopiLockInfo { FileId = "c-1", LockId = "L" });
+
+        var ex = await Assert.ThrowsAsync<WopiResourceLockedException>(
+            () => CreateDecorator().DeleteWopiContainer("c-1"));
+        Assert.Equal("c-1", ex.ResourceIdentifier);
+        Assert.Equal("L", ex.LockId);
+        _innerMock.Verify(x => x.DeleteWopiContainer(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RenameWopiContainer_NoLock_DelegatesToInner()
+    {
+        _lockProviderMock.Setup(x => x.GetLockAsync("c-2", It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _innerMock.Setup(x => x.RenameWopiContainer("c-2", "renamed", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        var result = await CreateDecorator().RenameWopiContainer("c-2", "renamed");
+
+        Assert.True(result);
+        _innerMock.Verify(x => x.RenameWopiContainer("c-2", "renamed", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RenameWopiContainer_Locked_Throws()
+    {
+        _lockProviderMock.Setup(x => x.GetLockAsync("c-2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new WopiLockInfo { FileId = "c-2", LockId = "L-c" });
+
+        await Assert.ThrowsAsync<WopiResourceLockedException>(
+            () => CreateDecorator().RenameWopiContainer("c-2", "renamed"));
+        _innerMock.Verify(x => x.RenameWopiContainer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public void Constructor_NullInner_Throws()
+        => Assert.Throws<ArgumentNullException>(() => new WopiLockAwareWritableStorageProvider(null!, _lockProviderMock.Object));
+
+    [Fact]
+    public void Constructor_NullLockProvider_Throws()
+        => Assert.Throws<ArgumentNullException>(() => new WopiLockAwareWritableStorageProvider(_innerMock.Object, null!));
 
     [Fact]
     public void AddWopiLockAwareWritableStorage_WithoutPriorRegistration_Throws()
@@ -124,5 +212,66 @@ public class WopiLockAwareWritableStorageProviderTests
         Assert.IsType<WopiLockAwareWritableStorageProvider>(resolved);
         await Assert.ThrowsAsync<WopiResourceLockedException>(
             () => resolved.DeleteWopiFile("file-x"));
+    }
+
+    [Fact]
+    public async Task AddWopiLockAwareWritableStorage_PreservesFactoryRegistration()
+    {
+        // Covers the ImplementationFactory branch of the decorator-wiring code: when the inner
+        // registration is `services.AddSingleton<IWopiWritableStorageProvider>(sp => ...)` the
+        // wiring code must call the factory (not new up the type, which there isn't one for).
+        var inner = _innerMock.Object;
+        var services = new ServiceCollection();
+        services.AddSingleton<IWopiWritableStorageProvider>(_ => inner);
+        services.AddSingleton(_lockProviderMock.Object);
+        services.AddWopiLockAwareWritableStorage();
+
+        _lockProviderMock.Setup(x => x.GetLockAsync("file-y", It.IsAny<CancellationToken>())).ReturnsAsync((WopiLockInfo?)null);
+        _innerMock.Setup(x => x.DeleteWopiFile("file-y", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        using var sp = services.BuildServiceProvider();
+        var resolved = sp.GetRequiredService<IWopiWritableStorageProvider>();
+
+        Assert.IsType<WopiLockAwareWritableStorageProvider>(resolved);
+        Assert.True(await resolved.DeleteWopiFile("file-y"));
+        // The factory must have been invoked exactly once when the decorated registration was resolved.
+        _innerMock.Verify(x => x.DeleteWopiFile("file-y", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public void AddWopiLockAwareWritableStorage_ActivatesImplementationType()
+    {
+        // Covers the ActivatorUtilities branch: when the inner is registered as
+        // `AddSingleton<IWopiWritableStorageProvider, ConcreteType>()` neither
+        // ImplementationInstance nor ImplementationFactory is set, and the wiring must reach
+        // for ActivatorUtilities to construct the concrete type from DI.
+        var services = new ServiceCollection();
+        services.AddSingleton<IWopiWritableStorageProvider, DummyWritableStorageProvider>();
+        services.AddSingleton(_lockProviderMock.Object);
+        services.AddWopiLockAwareWritableStorage();
+
+        using var sp = services.BuildServiceProvider();
+        var resolved = sp.GetRequiredService<IWopiWritableStorageProvider>();
+
+        // Outer wrapper is the decorator; the inner one (visible behind delegation) is the dummy
+        // class. Asserting the wrapper type proves the decorator was wired correctly via the
+        // ActivatorUtilities branch.
+        Assert.IsType<WopiLockAwareWritableStorageProvider>(resolved);
+    }
+
+    private sealed class DummyWritableStorageProvider : IWopiWritableStorageProvider
+    {
+        public int FileNameMaxLength => 250;
+        public Task<IWopiWritableFile?> CreateWopiChildFile(string containerId, string name, CancellationToken cancellationToken = default) => Task.FromResult<IWopiWritableFile?>(null);
+        public Task<IWopiContainer?> CreateWopiChildContainer(string containerId, string name, CancellationToken cancellationToken = default) => Task.FromResult<IWopiContainer?>(null);
+        public Task<IWopiWritableFile?> GetWritableFile(string identifier, CancellationToken cancellationToken = default) => Task.FromResult<IWopiWritableFile?>(null);
+        public Task<bool> DeleteWopiFile(string identifier, CancellationToken cancellationToken = default) => Task.FromResult(false);
+        public Task<bool> DeleteWopiContainer(string identifier, CancellationToken cancellationToken = default) => Task.FromResult(false);
+        public Task<bool> RenameWopiFile(string identifier, string requestedName, CancellationToken cancellationToken = default) => Task.FromResult(false);
+        public Task<bool> RenameWopiContainer(string identifier, string requestedName, CancellationToken cancellationToken = default) => Task.FromResult(false);
+        public Task<bool> CheckValidFileName(string name, CancellationToken cancellationToken = default) => Task.FromResult(true);
+        public Task<bool> CheckValidContainerName(string name, CancellationToken cancellationToken = default) => Task.FromResult(true);
+        public Task<string> GetSuggestedFileName(string containerId, string name, CancellationToken cancellationToken = default) => Task.FromResult(name);
+        public Task<string> GetSuggestedContainerName(string containerId, string name, CancellationToken cancellationToken = default) => Task.FromResult(name);
     }
 }

--- a/test/WopiHost.Core.Tests/Infrastructure/WopiNewChildFileResultExtensionsTests.cs
+++ b/test/WopiHost.Core.Tests/Infrastructure/WopiNewChildFileResultExtensionsTests.cs
@@ -1,0 +1,101 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using WopiHost.Abstractions;
+using WopiHost.Core.Infrastructure;
+using WopiHost.Core.Results;
+
+namespace WopiHost.Core.Tests.Infrastructure;
+
+/// <summary>
+/// Tests for the WOPI-spec response-mapping in <see cref="WopiNewChildFileResultExtensions.ToErrorActionResult"/>.
+/// Translates the negotiator's <see cref="WopiNewChildFileResult"/> into the appropriate
+/// <see cref="IActionResult"/> plus the spec-mandated response-header side effects.
+/// </summary>
+public class WopiNewChildFileResultExtensionsTests
+{
+    private readonly HttpResponse _response = new DefaultHttpContext().Response;
+
+    [Fact]
+    public void Success_ReturnsNull()
+    {
+        // Null is the explicit "no error result — controller should proceed with result.File" signal.
+        var result = WopiNewChildFileResult.Success(Mock.Of<IWopiWritableFile>());
+
+        Assert.Null(result.ToErrorActionResult(_response));
+    }
+
+    [Fact]
+    public void BadRequest_ReturnsBadRequestResult_WithoutHeaders()
+    {
+        var result = WopiNewChildFileResult.BadRequest();
+
+        var actionResult = result.ToErrorActionResult(_response);
+
+        Assert.IsType<BadRequestResult>(actionResult);
+        Assert.Empty(_response.Headers);
+    }
+
+    [Fact]
+    public void Conflict_WritesValidRelativeTargetHeader_AndReturnsConflictResult()
+    {
+        var result = WopiNewChildFileResult.Conflict("Report (1).docx");
+
+        var actionResult = result.ToErrorActionResult(_response);
+
+        Assert.IsType<ConflictResult>(actionResult);
+        Assert.True(_response.Headers.ContainsKey(WopiHeaders.VALID_RELATIVE_TARGET));
+        // Header value is UTF-7 encoded per the WOPI spec — the round-trip is asserted in
+        // UtfStringTests; here we only check the header was set with non-empty content.
+        Assert.NotEmpty(_response.Headers[WopiHeaders.VALID_RELATIVE_TARGET].ToString());
+    }
+
+    [Fact]
+    public void Locked_ReturnsLockMismatchResult_WithExistingLockHeader()
+    {
+        var result = WopiNewChildFileResult.Locked("active-lock-id");
+
+        var actionResult = result.ToErrorActionResult(_response);
+
+        Assert.IsType<LockMismatchResult>(actionResult);
+        Assert.Equal("active-lock-id", _response.Headers[WopiHeaders.LOCK].ToString());
+    }
+
+    [Fact]
+    public void InternalError_ReturnsInternalServerErrorResult()
+    {
+        var result = WopiNewChildFileResult.InternalError();
+
+        var actionResult = result.ToErrorActionResult(_response);
+
+        Assert.IsType<InternalServerErrorResult>(actionResult);
+    }
+
+    [Fact]
+    public void UnknownOutcome_Throws()
+    {
+        // The switch is exhaustive at compile time but uses a `default: throw` arm as a guard
+        // for future enum additions or hand-crafted instances. Construct an out-of-range
+        // outcome via the property init and verify the throw fires.
+        var result = new WopiNewChildFileResult { Outcome = (WopiNewChildFileOutcome)999 };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => result.ToErrorActionResult(_response));
+        Assert.Contains("999", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NullResult_Throws()
+    {
+        WopiNewChildFileResult result = null!;
+
+        Assert.Throws<ArgumentNullException>(() => result.ToErrorActionResult(_response));
+    }
+
+    [Fact]
+    public void NullResponse_Throws()
+    {
+        var result = WopiNewChildFileResult.BadRequest();
+
+        Assert.Throws<ArgumentNullException>(() => result.ToErrorActionResult(null!));
+    }
+}

--- a/test/WopiHost.Core.Tests/Infrastructure/WopiTelemetryActionFilterTests.cs
+++ b/test/WopiHost.Core.Tests/Infrastructure/WopiTelemetryActionFilterTests.cs
@@ -147,6 +147,86 @@ public sealed class WopiTelemetryActionFilterTests : IDisposable
         Assert.Equal(WopiTelemetry.Outcomes.Conflict, activity.GetTagItem(WopiTelemetry.Tags.Outcome));
     }
 
+    [Theory]
+    [InlineData(StatusCodes.Status200OK, WopiTelemetry.Outcomes.Success)]
+    [InlineData(StatusCodes.Status204NoContent, WopiTelemetry.Outcomes.Success)]
+    [InlineData(StatusCodes.Status400BadRequest, WopiTelemetry.Outcomes.BadRequest)]
+    [InlineData(StatusCodes.Status412PreconditionFailed, WopiTelemetry.Outcomes.PreconditionFailed)]
+    [InlineData(StatusCodes.Status501NotImplemented, WopiTelemetry.Outcomes.NotImplemented)]
+    [InlineData(StatusCodes.Status500InternalServerError, WopiTelemetry.Outcomes.Error)]
+    public async Task MapStatusCode_ClassifiesViaRawStatusCodeResult(int statusCode, string expectedOutcome)
+    {
+        // Covers the MapStatusCode branches that the typed-result Theory doesn't reach. The
+        // controller returns a bare StatusCodeResult — there's no typed *Result MVC wrapper for
+        // these status codes (200, 204, 400, 412, 501, 500) — so the filter falls through to
+        // MapStatusCode for classification.
+        var (_, activity) = await RunFilterAsync(
+            controller: new FilesController(null!, null!, null!, null!, null!, null!),
+            result: new StatusCodeResult(statusCode));
+
+        Assert.NotNull(activity);
+        Assert.Equal(expectedOutcome, activity.GetTagItem(WopiTelemetry.Tags.Outcome));
+    }
+
+    [Fact]
+    public async Task Cancellation_ClassifiedAsCancelled_NotError()
+    {
+        // Client-side disconnect: next() faults with an OperationCanceledException and the
+        // request's CancellationToken has fired. The filter must record "Cancelled" instead of
+        // "Error" — a stopped browser tab is not an application failure.
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var ctx = new DefaultHttpContext { RequestAborted = cts.Token };
+
+        var (_, activity) = await RunFilterAsync(
+            controller: new FilesController(null!, null!, null!, null!, null!, null!),
+            result: null,
+            httpContext: ctx,
+            exception: new OperationCanceledException(cts.Token));
+
+        Assert.NotNull(activity);
+        Assert.Equal(WopiTelemetry.Outcomes.Cancelled, activity.GetTagItem(WopiTelemetry.Tags.Outcome));
+    }
+
+    [Fact]
+    public async Task Cancellation_FromAggregateOfOCEs_AlsoClassifiedAsCancelled()
+    {
+        // Task.WhenAll wraps an observed OCE into an AggregateException whose only inner is the
+        // OCE. The filter unwraps that shape to keep the Cancelled classification stable across
+        // both forms.
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var ctx = new DefaultHttpContext { RequestAborted = cts.Token };
+        var agg = new AggregateException(new OperationCanceledException(cts.Token), new OperationCanceledException(cts.Token));
+
+        var (_, activity) = await RunFilterAsync(
+            controller: new FilesController(null!, null!, null!, null!, null!, null!),
+            result: null,
+            httpContext: ctx,
+            exception: agg);
+
+        Assert.NotNull(activity);
+        Assert.Equal(WopiTelemetry.Outcomes.Cancelled, activity.GetTagItem(WopiTelemetry.Tags.Outcome));
+    }
+
+    [Fact]
+    public async Task OperationCanceledException_WithoutTokenFiring_ClassifiedAsError()
+    {
+        // OCE thrown without the request actually being aborted = real bug (someone canceled
+        // an internal CTS by mistake). Don't whitewash that as "client disconnect".
+        var ctx = new DefaultHttpContext();
+        Assert.False(ctx.RequestAborted.IsCancellationRequested);
+
+        var (_, activity) = await RunFilterAsync(
+            controller: new FilesController(null!, null!, null!, null!, null!, null!),
+            result: null,
+            httpContext: ctx,
+            exception: new OperationCanceledException());
+
+        Assert.NotNull(activity);
+        Assert.Equal(WopiTelemetry.Outcomes.Error, activity.GetTagItem(WopiTelemetry.Tags.Outcome));
+    }
+
     private static async Task<(ActionExecutingContext executing, Activity? activity)> RunFilterAsync(
         ControllerBase controller,
         IActionResult? result,

--- a/test/WopiHost.Core.Tests/Security/Authentication/WopiProofValidatorTests.cs
+++ b/test/WopiHost.Core.Tests/Security/Authentication/WopiProofValidatorTests.cs
@@ -197,6 +197,52 @@ public class WopiProofValidatorTests
         Assert.False(result);
     }
 
+    [Fact]
+    public async Task Returns_false_when_request_proof_is_not_base64()
+    {
+        // VerifyProof Convert.FromBase64String's the request-side proof. Non-base64 input
+        // throws FormatException, which the validator's defensive catch maps to "not valid".
+        // Hosts must not 500 on malformed headers — just reject the request.
+        using var current = new RSACryptoServiceProvider(2048);
+        using var old = new RSACryptoServiceProvider(2048);
+        SetupDiscovery(current, old);
+
+        var ticks = _time.GetUtcNow().UtcDateTime.Ticks;
+        var ctx = BuildHttpContext(timestampOverride: ticks.ToString(CultureInfo.InvariantCulture));
+        // Embedded space + '@' is not valid base64 → FormatException inside VerifyProof.
+        ctx.Request.Headers[WopiHeaders.PROOF] = "not valid base64@@@@";
+
+        var validator = CreateValidator();
+        var result = await validator.ValidateProofAsync(ctx, AccessToken);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task Returns_false_when_discovery_key_is_garbage_csp_blob()
+    {
+        // VerifyProof calls ImportCspBlob on the discovery key. A base64-decodable string whose
+        // bytes aren't a valid CSP blob raises CryptographicException; the defensive catch maps
+        // it to "not valid". Covers the second catch arm of VerifyProof.
+        _discoverer
+            .Setup(d => d.GetProofKeysAsync())
+            .ReturnsAsync(new WopiProofKeys
+            {
+                // 16 zero bytes is well-formed base64 but doesn't deserialize as an RSA CSP blob.
+                Value = Convert.ToBase64String(new byte[16]),
+                OldValue = Convert.ToBase64String(new byte[16]),
+            });
+
+        var ticks = _time.GetUtcNow().UtcDateTime.Ticks;
+        var ctx = BuildHttpContext(timestampOverride: ticks.ToString(CultureInfo.InvariantCulture));
+        ctx.Request.Headers[WopiHeaders.PROOF] = Convert.ToBase64String(new byte[256]);
+
+        var validator = CreateValidator();
+        var result = await validator.ValidateProofAsync(ctx, AccessToken);
+
+        Assert.False(result);
+    }
+
     private WopiProofValidator CreateValidator()
         => new(_discoverer.Object, NullLogger<WopiProofValidator>.Instance, _time);
 

--- a/test/WopiHost.Core.Tests/Security/Authorization/WopiAuthorizationHandlerTests.cs
+++ b/test/WopiHost.Core.Tests/Security/Authorization/WopiAuthorizationHandlerTests.cs
@@ -365,4 +365,37 @@ public class WopiAuthorizationHandlerTests
 
         Assert.False(ctx.HasSucceeded);
     }
+
+    [Fact]
+    public async Task Unknown_ResourceType_Falls_Through_To_False_Arm()
+    {
+        // The switch over WopiResourceType is exhaustive at compile time but the handler keeps
+        // a `_ => false` guard for future enum additions / hand-crafted attribute instances.
+        // Cast an out-of-range integer onto the enum to exercise it. The user is otherwise
+        // fully authenticated so the only thing left to reject the request is the default arm.
+        var requirement = new WopiAuthorizeAttribute((WopiResourceType)999, Permission.Read);
+        var ctx = BuildContext(requirement, "any-id",
+            Authenticated(new Claim(WopiClaimTypes.ResourceId, "any-id")));
+
+        await _handler.HandleAsync(ctx);
+
+        Assert.False(ctx.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task Unknown_Permission_On_File_Falls_Through_To_False_Arm()
+    {
+        // Same guard, one level deeper — HasFilePermission's switch also has a `_ => false`
+        // arm. Exercise it with an out-of-range Permission value. Use UserCanWrite so we get
+        // past the early Read-implies-true and ReadOnly checks.
+        var requirement = new WopiAuthorizeAttribute(WopiResourceType.File, (Permission)999);
+        var ctx = BuildContext(requirement, "fileId",
+            Authenticated(
+                new Claim(WopiClaimTypes.ResourceId, "fileId"),
+                new Claim(WopiClaimTypes.FilePermissions, WopiFilePermissions.UserCanWrite.ToString())));
+
+        await _handler.HandleAsync(ctx);
+
+        Assert.False(ctx.HasSucceeded);
+    }
 }

--- a/test/WopiHost.Discovery.Tests/AsyncExpiringLazyTests.cs
+++ b/test/WopiHost.Discovery.Tests/AsyncExpiringLazyTests.cs
@@ -199,4 +199,20 @@ public class AsyncExpiringLazyTests
         await sut.Value();
         Assert.Equal(2, calls);
     }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        // Double-Dispose must short-circuit on the second call — the inner SemaphoreSlim is
+        // disposed exactly once. Hits the `_disposed = true` early-return branch on the second
+        // invocation; previously uncovered because nothing in the discovery flow disposes twice.
+        var sut = CreateSut(_ => Task.FromResult(new TemporaryValue<string>
+        {
+            Result = "x",
+            ValidUntil = DateTimeOffset.UtcNow.AddHours(1),
+        }));
+
+        sut.Dispose();
+        sut.Dispose();
+    }
 }

--- a/test/WopiHost.Discovery.Tests/WopiDiscovererTests.cs
+++ b/test/WopiHost.Discovery.Tests/WopiDiscovererTests.cs
@@ -243,4 +243,17 @@ public class WopiDiscovererTests
 
         Assert.DoesNotContain(expectedValue, result);
     }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        // Two AsyncExpiringLazy instances and one IDisposable proof-key cache live inside the
+        // discoverer. Double-Dispose must short-circuit on the second call so the inner
+        // resources aren't double-disposed; previously the early-return branch was never hit
+        // because nothing in the discovery flow disposes twice.
+        InitDiscoverer(XmlOo2019, NetZoneEnum.ExternalHttps);
+
+        _wopiDiscoverer.Dispose();
+        _wopiDiscoverer.Dispose();
+    }
 }

--- a/test/WopiHost.FileSystemProvider.Tests/WopiFileSystemProviderTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/WopiFileSystemProviderTests.cs
@@ -729,4 +729,57 @@ public class WopiFileSystemProviderTests : IDisposable
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             _sut.RenameWopiContainer(folderId, "sub"));
     }
+
+    [Fact]
+    public async Task RenameWopiContainer_InvalidName_Throws()
+    {
+        // Mirror of RenameWopiResource_InvalidName_Throws but for the container variant —
+        // the existing test only exercises the file path, so the container's invalid-name
+        // guard (ArgumentException) was previously uncovered.
+        Assert.True(_fileIds.TryGetFileId(_empty.FullName, out var folderId));
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            _sut.RenameWopiContainer(folderId, "bad\0name"));
+    }
+
+    [Fact]
+    public async Task GetSuggestedContainerName_InvalidName_Throws()
+    {
+        // The file-name variant is tested via GetSuggestedName_InvalidName_Throws; the
+        // container path uses CheckValidContainerName instead and was missed.
+        Assert.True(_fileIds.TryGetFileId(_root.FullName, out var rootId));
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            _sut.GetSuggestedContainerName(rootId, "bad\0name"));
+    }
+
+    [Fact]
+    public async Task GetWritableFile_UnknownId_ReturnsNull()
+    {
+        // GetWritableFile is the writable-side counterpart of GetWopiFile; on miss it must
+        // return null (not throw) so PutRelativeFile can map to 404.
+        var result = await _sut.GetWritableFile("does-not-exist");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetWopiContainerByName_UnknownContainer_ReturnsNull()
+    {
+        // Mirrors GetWopiFileByName's missing-container behavior — the parent-container miss
+        // returns null per the #380 item 4.2 null-on-missing contract.
+        var result = await _sut.GetWopiContainerByName("missing-container-id", "anything");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetWopiContainerByName_UnknownName_ReturnsNull()
+    {
+        Assert.True(_fileIds.TryGetFileId(_root.FullName, out var rootId));
+
+        var result = await _sut.GetWopiContainerByName(rootId, "does-not-exist");
+
+        Assert.Null(result);
+    }
 }

--- a/test/WopiHost.Url.Tests/WopiUrlGeneratorTests.cs
+++ b/test/WopiHost.Url.Tests/WopiUrlGeneratorTests.cs
@@ -96,6 +96,27 @@ public partial class WopiUrlGeneratorTests
     }
 
     [Fact]
+    public async Task GetFileUrlAsync_MethodArgUrlSettings_OverrideConstructorArgUrlSettings()
+    {
+        // Both the constructor and the method accept a WopiUrlSettings. When both supply the same
+        // key the method-arg wins — the per-call value is intentionally the override seam.
+        var constructorSettings = new WopiUrlSettings { UiLlcc = new CultureInfo("en-US") };
+        var methodSettings = new WopiUrlSettings { UiLlcc = new CultureInfo("cs-CZ") };
+
+        var urlGenerator = new WopiUrlBuilder(_discoverer, NullLogger<WopiUrlBuilder>.Instance, constructorSettings);
+
+        var result = await urlGenerator.GetFileUrlAsync(
+            "xlsx",
+            new Uri("http://wopihost:5000/wopi/files/test.xlsx"),
+            WopiActionEnum.Edit,
+            methodSettings);
+
+        Assert.NotNull(result);
+        Assert.Contains("ui=cs-CZ", result, StringComparison.Ordinal);
+        Assert.DoesNotContain("ui=en-US", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task GetFileUrlAsync_CallerProvidedWopiSourceSetting_IsOverriddenByFileUrlParameter()
     {
         // Defensive: even if a caller leaks WOPI_SOURCE into urlSettings, the wopiFileUrl

--- a/test/WopiHost.Url.Tests/WopiUrlSettingsTests.cs
+++ b/test/WopiHost.Url.Tests/WopiUrlSettingsTests.cs
@@ -1,0 +1,44 @@
+namespace WopiHost.Url.Tests;
+
+/// <summary>
+/// Tests for <see cref="WopiUrlSettings"/> constructors and the method-arg-overrides-ctor-arg
+/// precedence in <see cref="WopiUrlBuilder"/>. The IDictionary constructor and the override
+/// branch are otherwise unexercised by the existing URL-generation tests, which feed settings
+/// only via the typed properties.
+/// </summary>
+public class WopiUrlSettingsTests
+{
+    [Fact]
+    public void DefaultConstructor_ProducesEmptySettings()
+    {
+        var settings = new WopiUrlSettings();
+
+        Assert.Empty(settings);
+    }
+
+    [Fact]
+    public void DictionaryConstructor_CopiesAllPairs()
+    {
+        var source = new Dictionary<string, string>
+        {
+            [WopiUrlSettings.Placeholders.UiLlcc] = "cs-CZ",
+            [WopiUrlSettings.Placeholders.Perfstats] = "Roundtrip",
+        };
+
+        var settings = new WopiUrlSettings(source);
+
+        Assert.Equal(2, settings.Count);
+        Assert.Equal("cs-CZ", settings[WopiUrlSettings.Placeholders.UiLlcc]);
+        Assert.Equal("Roundtrip", settings[WopiUrlSettings.Placeholders.Perfstats]);
+    }
+
+    [Fact]
+    public void DictionaryConstructor_NullInput_ProducesEmptySettings()
+    {
+        // Null is allowed and means "no initial values" — used by callers that build the
+        // settings up incrementally after construction.
+        var settings = new WopiUrlSettings(settings: null);
+
+        Assert.Empty(settings);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds 81 targeted tests across 17 files in `test/`. **Nothing in `src/` was changed.**
- Coverage of `src/` (excluding `sample/`, `infra/`, `test/`, and source-generated files):
  - **Line**:   95.7% → **97.7%** (uncovered: **137 → 74**)
  - **Branch**: 86.7% → **90.7%** (uncovered: 188 → 131)
  - **Method**: 82.1% → **83.3%** (uncovered: 135 → 126)
- Tests pass locally: **938 / 938** across 11 test projects.

## How the gaps were found

Aggregated lcov from all 11 test projects via `reportgenerator`, filtered to `src/**`, sorted files by uncovered line count, then hand-picked the ones with real behavior (skipped platform-only P/Invoke and infra-dependent paths that need real Azure / Redis / Cobalt).

## What was covered

### `WopiHost.Abstractions` (new files)
- [`WopiHostExtensionsTests.cs`](test/WopiHost.Core.Tests/Abstractions/WopiHostExtensionsTests.cs): pass-through defaults for the four `CheckXxx` hooks (verifies the returned context payload is the same instance, not a copy) + null-context guards + `OnPutFileAsync` / `OnPutRelativeFileAsync` no-op completion.
- [`WopiNewChildFileResultTests.cs`](test/WopiHost.Core.Tests/Abstractions/WopiNewChildFileResultTests.cs): every static factory shape including the previously-unreached `InternalError()`.
- [`WopiPutContextTests.cs`](test/WopiHost.Core.Tests/Abstractions/WopiPutContextTests.cs): the two record types' getters — record-getter IL was uninstrumented because nothing in the test suite actually read them.
- Extended [`WopiLockComparerTests.cs`](test/WopiHost.Core.Tests/Abstractions/WopiLockComparerTests.cs) with the asymmetric-null branch of `JsonShapedWopiLockComparer.AreEqual`.

### `WopiHost.Url` (new file + extension)
- [`WopiUrlSettingsTests.cs`](test/WopiHost.Url.Tests/WopiUrlSettingsTests.cs): default + `IDictionary` constructors (incl. null source).
- [`WopiUrlGeneratorTests.cs`](test/WopiHost.Url.Tests/WopiUrlGeneratorTests.cs): method-arg `WopiUrlSettings` overrides constructor-arg on collision — the override branch in `GetFileUrlAsync` was unexercised.

### `WopiHost.Core` / Infrastructure (new files + extensions)
- [`WopiNewChildFileResultExtensionsTests.cs`](test/WopiHost.Core.Tests/Infrastructure/WopiNewChildFileResultExtensionsTests.cs): every outcome arm including `InternalError` + the default-case throw + the two `ArgumentNullException` guards.
- [`DefaultWopiNewChildFileNegotiatorTests.cs`](test/WopiHost.Core.Tests/Infrastructure/DefaultWopiNewChildFileNegotiatorTests.cs): 12 cases covering all four protocol modes (relative + suggested, with/without overwrite, locked + unlocked, no-lock-provider, extension-only fallback) plus defensive defaults.
- Extended [`WopiLockAwareWritableStorageProviderTests.cs`](test/WopiHost.Core.Tests/Infrastructure/WopiLockAwareWritableStorageProviderTests.cs): container delete/rename branches, read-only delegations (`GetWritableFile`, `CreateWopiChildContainer`, `CheckValidContainerName`, `GetSuggestedContainerName`), constructor null-guards, and the `ImplementationFactory` + `ActivatorUtilities` branches of `AddWopiLockAwareWritableStorage`.
- Extended [`WopiTelemetryActionFilterTests.cs`](test/WopiHost.Core.Tests/Infrastructure/WopiTelemetryActionFilterTests.cs):
  - Cancellation classification: `OperationCanceledException` + `AggregateException`-of-OCEs while `RequestAborted` is set → `Cancelled`; bare OCE → `Error`.
  - `MapStatusCode` arms for 200, 204, 400, 412, 501, 500 via raw `StatusCodeResult`.

### `WopiHost.Core` / Controllers
- Extended [`ContainersControllerTests.cs`](test/WopiHost.Core.Tests/Controllers/ContainersControllerTests.cs): `RenameContainer` with `ArgumentException(paramName=requestedName)` → 400 + `X-WOPI-InvalidContainerName` header; with an unrelated `ArgumentException` → bubbles to the framework (matches the existing generic-exception bubble pattern).

### `WopiHost.Core` / Security
- Extended [`WopiProofValidatorTests.cs`](test/WopiHost.Core.Tests/Security/Authentication/WopiProofValidatorTests.cs): `FormatException` catch (request proof not base64) and `CryptographicException` catch (garbage discovery CSP blob).
- Extended [`WopiAuthorizationHandlerTests.cs`](test/WopiHost.Core.Tests/Security/Authorization/WopiAuthorizationHandlerTests.cs): unknown `WopiResourceType` → false default arm; unknown `Permission` on a file with `UserCanWrite` → `HasFilePermission`'s default-false arm.

### `WopiHost.Core` / Extensions
- Extended [`ExtensionsTests.cs`](test/WopiHost.Core.Tests/Extensions/ExtensionsTests.cs): `GetWopiSrc` enum overload's File and Container arms; null-`routePath` from `ProxyAwareRouteUrl` → `InvalidOperationException`.

### `WopiHost.FileSystemProvider`
- Extended [`WopiFileSystemProviderTests.cs`](test/WopiHost.FileSystemProvider.Tests/WopiFileSystemProviderTests.cs): `GetWritableFile` with unknown id → null; `GetWopiContainerByName` with unknown container / unknown name → null; `GetSuggestedContainerName` and `RenameWopiContainer` with invalid name → `ArgumentException` (container-side equivalents of existing file-side tests).

### `WopiHost.Discovery`
- Extended [`AsyncExpiringLazyTests.cs`](test/WopiHost.Discovery.Tests/AsyncExpiringLazyTests.cs) and [`WopiDiscovererTests.cs`](test/WopiHost.Discovery.Tests/WopiDiscovererTests.cs): `Dispose` idempotency for both types (the `if (_disposed) return` early-return branch).

## What's still uncovered (intentional — not chasing 100%)

| Lines | File | Why |
|---|---|---|
| 22 | `LinuxFileOwner.cs` | Linux-only P/Invoke (`statx` + `getpwuid_r`). Linux CI exercises it; Windows dev box can't. |
| 13 | `WopiAzureStorageProvider.cs` | Rare `RequestFailedException` arms — needs fault injection against Azurite. |
| 11 | `CobaltSession.cs` | Real MS-FSSHTTP protocol flow. Out of scope until [#321](https://github.com/petrsvihlik/WopiHost/issues/321) (from-scratch FSSHTTP impl). |
| 11 | `FilesController.cs` | `ProcessCobalt` action body + size-OK helper return; depends on a Cobalt processor. |
| 5 | `WopiAzureLockProvider.cs` | Lease-acquire-failed + metadata-update-failed catches — fault injection. |
| 4 | `WopiFile.cs` | Linux owner branches — same blocker as `LinuxFileOwner`. |
| 3 | `WopiRedisLockProvider.cs` | Lost-race branch in `AddLockAsync` — could test, low impact. |
| 3 | `WopiFileSystemProvider.cs` | Defensive guards in `GetFolderParentIdentifier` — unreachable in normal flow (the public API only calls it on resolved containers). |
| 1 | `WopiRedisLockProvider/ServiceCollectionExtensions.cs` | `ConnectionMultiplexer.Connect` — needs a real Redis endpoint. |
| 1 | `ContainersController.cs` | Defensive `BadRequest` after the both-missing / both-present checks already returned 501. |

## Test plan

- [x] `dotnet build WOPI.slnx` clean.
- [x] `dotnet test WOPI.slnx` — 938 / 938 pass.
- [x] `reportgenerator` aggregated lcov shows 97.7% src line coverage.
- [ ] CI green on the PR.
- [ ] Codecov + qlty reflect the gain.