### PR TITLE
chore(ci): bump baseline to 8.0.0 + harden post-release auto-bump against the race

### DIFF
--- a/.github/workflows/bump-baseline.yml
+++ b/.github/workflows/bump-baseline.yml
@@ -1,0 +1,137 @@
+name: Bump PackageValidationBaselineVersion
+
+# Keeps Directory.Build.props's PackageValidationBaselineVersion aligned with the latest
+# stable WopiHost package published to NuGet.org.
+#
+# Two triggers, two recovery paths:
+#
+# 1. release: published  — fires automatically after every stable GitHub Release. Picks the
+#    just-released version straight from the tag.
+#
+# 2. workflow_dispatch  — manual re-run. Lets you recover from races where the auto-trigger
+#    saw stale master state (e.g. a revert PR merging shortly after release time, leaving
+#    the file at the wrong baseline with no auto-bump PR queued). With no input, it falls
+#    back to NuGet.org's latest stable WopiHost.Core as the target version.
+#
+# Split out of release.yml so it can be re-triggered without re-running the publish job.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Target baseline version (leave empty to query NuGet.org for the latest stable)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    name: Bump baseline
+    # Skip the auto path for pre-releases and drafts. workflow_dispatch is always allowed —
+    # the operator opts in by triggering it.
+    if: ${{ github.event_name == 'workflow_dispatch' || (!github.event.release.prerelease && !github.event.release.draft) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Determine target version
+        id: target
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            # Strip a leading "v" so both "v8.0.0" and "8.0.0" tag styles work.
+            TARGET="${{ github.event.release.tag_name }}"
+            TARGET="${TARGET#v}"
+            echo "Source: release tag → $TARGET"
+          else
+            TARGET="${{ github.event.inputs.version }}"
+            if [[ -z "$TARGET" ]]; then
+              # No explicit target — query NuGet.org for the latest stable WopiHost.Core
+              # version. WopiHost.Core is the canonical packable assembly (every other
+              # package targets the same baseline). Same flatcontainer query the api-compat
+              # job in pull_request.yml uses for its diffs.
+              echo "Source: NuGet.org (no input version supplied)"
+              versions_json="$(curl -fsSL 'https://api.nuget.org/v3-flatcontainer/wopihost.core/index.json')"
+              # Filter out prereleases (anything containing a '-'), pick the highest by tail-after-sort.
+              TARGET="$(echo "$versions_json" | grep -oE '"[0-9][^"]+"' | tr -d '"' | grep -v -- '-' | sort -V | tail -n 1)"
+              echo "NuGet's latest stable: $TARGET"
+            else
+              echo "Source: workflow_dispatch input → $TARGET"
+            fi
+          fi
+          if [[ -z "$TARGET" ]]; then
+            echo "::error::Could not determine a target version."
+            exit 1
+          fi
+          echo "version=$TARGET" >> "$GITHUB_OUTPUT"
+
+      - name: Update Directory.Build.props
+        id: update
+        shell: bash
+        run: |
+          set -euo pipefail
+          NEW="${{ steps.target.outputs.version }}"
+          FILE="Directory.Build.props"
+          CURRENT="$(sed -n 's:.*<PackageValidationBaselineVersion>\([^<]*\)</PackageValidationBaselineVersion>.*:\1:p' "$FILE" | head -n 1)"
+          echo "Current baseline: ${CURRENT:-<unset>}"
+          echo "New baseline:     $NEW"
+
+          if [[ -z "$CURRENT" ]]; then
+            echo "::error::No <PackageValidationBaselineVersion> element found in $FILE."
+            exit 1
+          fi
+
+          if [[ "$CURRENT" == "$NEW" ]]; then
+            echo "Baseline already matches the target — peter-evans will see no diff and skip the PR."
+            # Don't early-exit: let sed run as a no-op so the action proceeds and logs the
+            # "no changes" outcome explicitly. Removes a class of subtle bugs where a future
+            # edit to the early-exit condition silently stops bumps.
+          fi
+
+          # Refuse to bump *backward* (NEW < CURRENT, semver-aware). Guards against running
+          # workflow_dispatch with an older version by mistake, or a patch release on an older
+          # line dragging the baseline back. The auto-release path can still produce this
+          # situation if you ship a patch on an older major after a newer major shipped —
+          # in that case set the input explicitly and re-run; the operator owns the override.
+          if [[ "$CURRENT" != "$NEW" ]]; then
+            HIGHEST="$(printf '%s\n%s\n' "$CURRENT" "$NEW" | sort -V | tail -n 1)"
+            if [[ "$HIGHEST" != "$NEW" ]]; then
+              echo "::warning::Target $NEW is older than current baseline $CURRENT — refusing to bump backward."
+              exit 0
+            fi
+          fi
+
+          sed -i "s|<PackageValidationBaselineVersion>[^<]*</PackageValidationBaselineVersion>|<PackageValidationBaselineVersion>${NEW}</PackageValidationBaselineVersion>|g" "$FILE"
+
+      - name: Open PR with the bump
+        # peter-evans/create-pull-request is intentionally idempotent: if Directory.Build.props
+        # has no diff (because CURRENT was already at NEW, or because the backward-bump guard
+        # exited early), it logs "no changes" and creates no PR. The action also re-uses the
+        # named branch — re-running this workflow updates the existing PR in place rather than
+        # spawning duplicates.
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/bump-package-validation-baseline-${{ steps.target.outputs.version }}
+          base: master
+          commit-message: "chore: bump PackageValidationBaselineVersion to ${{ steps.target.outputs.version }}"
+          title: "chore: bump PackageValidationBaselineVersion to ${{ steps.target.outputs.version }}"
+          body: |
+            Auto-generated bump of `PackageValidationBaselineVersion` in `Directory.Build.props` to `${{ steps.target.outputs.version }}`.
+
+            ${{ github.event_name == 'release' && format('Triggered by the [{0}]({1}) release.', github.event.release.tag_name, github.event.release.html_url) || 'Triggered manually via workflow_dispatch.' }}
+
+            Keeps the SDK's pack-time package validator comparing the current public surface against the version that's actually published to NuGet.org.
+          labels: |
+            chore
+            automated
+          delete-branch: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: write
   id-token: write # Required for OIDC
-  pull-requests: write # Required for the baseline-bump PR
 
 jobs:
   build:
@@ -64,55 +63,3 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  bump-baseline:
-    name: Bump PackageValidationBaselineVersion
-    needs: [build]
-    if: ${{ !github.event.release.prerelease && !github.event.release.draft }}
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        ref: master
-        fetch-depth: 0
-    - name: Extract version from tag
-      id: get_version
-      run: |
-        REF="${GITHUB_REF#refs/tags/}"
-        echo "version-without-v=${REF#v}" >> $GITHUB_OUTPUT
-    - name: Update PackageValidationBaselineVersion
-      id: bump
-      shell: bash
-      run: |
-        set -euo pipefail
-        NEW_VERSION="${{ steps.get_version.outputs.version-without-v }}"
-        FILE="Directory.Build.props"
-
-        CURRENT="$(sed -n 's:.*<PackageValidationBaselineVersion>\([^<]*\)</PackageValidationBaselineVersion>.*:\1:p' "$FILE" | head -n 1)"
-        echo "Current baseline: ${CURRENT:-<unset>}"
-        echo "New baseline:     ${NEW_VERSION}"
-
-        if [[ "$CURRENT" == "$NEW_VERSION" ]]; then
-          echo "Baseline already matches the released version — no PR needed."
-          echo "changed=false" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-
-        sed -i "s|<PackageValidationBaselineVersion>[^<]*</PackageValidationBaselineVersion>|<PackageValidationBaselineVersion>${NEW_VERSION}</PackageValidationBaselineVersion>|g" "$FILE"
-        echo "changed=true" >> $GITHUB_OUTPUT
-    - name: Open PR with the bump
-      if: steps.bump.outputs.changed == 'true'
-      uses: peter-evans/create-pull-request@v8
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        branch: chore/bump-package-validation-baseline-${{ steps.get_version.outputs.version-without-v }}
-        base: master
-        commit-message: "chore: bump PackageValidationBaselineVersion to ${{ steps.get_version.outputs.version-without-v }}"
-        title: "chore: bump PackageValidationBaselineVersion to ${{ steps.get_version.outputs.version-without-v }}"
-        body: |
-          Auto-generated after the [${{ github.event.release.tag_name }}](${{ github.event.release.html_url }}) release.
-
-          Bumps `PackageValidationBaselineVersion` in `Directory.Build.props` so the SDK's pack-time package validator compares against the version that was just published to NuGet.org.
-        labels: |
-          chore
-          automated
-        delete-branch: true

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,13 +25,20 @@
 		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
 
-	<!-- Package Validation Configuration for NuGet packages -->
-	<!-- Baseline is auto-bumped by .github/workflows/release.yml after each stable release. -->
+	<!-- Package Validation Configuration for NuGet packages.
+
+	     PackageValidationBaselineVersion is the last NuGet-published version we validate the
+	     current public surface against. It is auto-managed by the bump-baseline job in
+	     .github/workflows/release.yml — DO NOT bump it manually in a feature PR. Manual bumps
+	     have a nasty interaction with the release flow: the bump job runs immediately after
+	     the package upload, and if master already shows the new value at that moment it skips
+	     (because the value already matches the just-released version). A revert merging shortly
+	     after the release then leaves the baseline at the wrong version with no auto-bump PR
+	     queued. If you genuinely need to override the baseline (e.g. to skip a buggy release),
+	     do it in its own dedicated PR, not bundled with API changes. -->
 	<PropertyGroup Condition="$(IsPackable) == 'true' AND $(PackageId) != ''">
 		<EnablePackageValidation>true</EnablePackageValidation>
-		<!-- Baseline used to detect public-API breaks against the last released version.
-		     Bump this in lockstep with releases. -->
-		<PackageValidationBaselineVersion>7.0.0</PackageValidationBaselineVersion>
+		<PackageValidationBaselineVersion>8.0.0</PackageValidationBaselineVersion>
 	</PropertyGroup>
 	
 	<ItemGroup Condition="!$(MSBuildProjectName.EndsWith('Tests'))">


### PR DESCRIPTION
## Summary

- Bumps `PackageValidationBaselineVersion` in [Directory.Build.props](Directory.Build.props) from `7.0.0` → `8.0.0` (it should have been bumped automatically after 8.0.0 shipped — explanation below).
- Adds a clearer comment in `Directory.Build.props` warning against manual baseline bumps in feature PRs.
- Splits the bump-baseline job out of [release.yml](.github/workflows/release.yml) into its own [bump-baseline.yml](.github/workflows/bump-baseline.yml) workflow:
  - **`workflow_dispatch` trigger** so the bump can be re-run on demand without re-running the publish job.
  - Optional `version` input. With no input, the workflow queries **NuGet.org's flatcontainer** for the latest stable `WopiHost.Core` and uses that as the target — same pattern as the api-compat job in `pull_request.yml`.
  - **Semver-aware backward-bump guard** — refuses to drag the baseline backward if someone re-runs with an older version or a patch on an older line fires the auto-trigger.
  - **Idempotency**: the "current matches target → skip" early-exit is gone. `sed` always runs; `peter-evans/create-pull-request` handles the no-diff case as a no-op.

## Why the bump

8.0.0 [shipped to NuGet on 2026-05-14](https://www.nuget.org/packages?q=WopiHost) but the auto-bump PR never opened. The root cause is a timing race:

- **18:36:32Z** [PR #431](https://github.com/petrsvihlik/WopiHost/pull/431) (revert baseline 8.0.0 → 7.0.0) was opened.
- **18:43:21Z** 8.0.0 release published → triggered [release.yml run #25878667799](https://github.com/petrsvihlik/WopiHost/actions/runs/25878667799).
- **18:46:52Z** bump-baseline job ran. Master at that moment was at `7ee307f` ([PR #428](https://github.com/petrsvihlik/WopiHost/pull/428)) which had pre-bumped the baseline to 8.0.0. The job's `if current == new, skip` check saw `Current=8.0.0, New=8.0.0` and exited cleanly with "Baseline already matches the released version — no PR needed."
- **18:47:45Z** PR #431 merged. Master dropped back to 7.0.0. No follow-up auto-bump PR queued.

Bug class: the bump job snapshots master once, immediately after publish. It can't see in-flight PRs that haven't merged yet.

## Why the workflow change

The race itself is fundamentally a timing bug — no single algorithm change in the bump job can prevent it. But the workflow can be made *recoverable*:

1. **`workflow_dispatch` trigger.** If the auto-trigger misses, an operator can re-run the bump on demand without re-running publish. With no input, it queries NuGet.org for the latest stable `WopiHost.Core` (canonical truth) and bumps to that.
2. **Backward-bump guard.** Prevents accidental backward bumps from a mistaken manual re-run or from a patch release on an older major line.
3. **Idempotency via `peter-evans/create-pull-request`.** The action's own diff-detection handles "nothing to do" — no need for our own early-exit. Removes a class of bugs where a future edit to the early-exit condition would silently stop bumps.

The convention stays the same: **don't pre-bump baseline in feature PRs**. The new comment in `Directory.Build.props` makes that explicit and explains why.

## Test plan

- [x] `dotnet pack WOPI.slnx -c Release -p:Version=9.0.0-dev` against baseline `8.0.0` — clean, no `CP*` / `PKV*` findings from the API validator (i.e. it ran against the just-published 8.0.0 NuGet package and is happy).
- [ ] CI green on the PR.
- [ ] **Manually trigger the new workflow** from the Actions tab after merge to validate the dispatch path: `gh workflow run "Bump PackageValidationBaselineVersion"` with no input should query NuGet, see baseline already at 8.0.0, and `peter-evans` should log "no changes / no PR".
- [ ] Next stable release should auto-trigger the new workflow via the `release: published` event and open the bump PR.

## Files changed

- [Directory.Build.props](Directory.Build.props): `7.0.0` → `8.0.0`, comment expanded.
- [.github/workflows/release.yml](.github/workflows/release.yml): bump-baseline job removed; `pull-requests: write` permission removed (no longer needed here).
- [.github/workflows/bump-baseline.yml](.github/workflows/bump-baseline.yml): new file (replaces and extends what was in release.yml).