### PR TITLE
chore(deps): re-apply test-package bumps Dependabot wrongly closed (#442, #443, #444)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,19 @@ updates:
     commit-message:
       prefix: "chore(deps)"
 
+  # test/Directory.Packages.props is a sibling CPM file that doesn't inherit
+  # from the root one — it must be scanned separately or Dependabot will
+  # auto-close test-only package PRs with "no longer a dependency". (See #445.)
+  - package-ecosystem: nuget
+    directory: "/test"
+    registries:
+      - cobalt-github-packages
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 20
+    commit-message:
+      prefix: "chore(deps)"
+
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -3,15 +3,15 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="coverlet.collector" Version="10.0.0">
+    <PackageVersion Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="coverlet.msbuild" Version="10.0.0">
+    <PackageVersion Include="coverlet.msbuild" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.3.2" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.3.3" />
     <PackageVersion Include="FakeItEasy" Version="9.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.8" />


### PR DESCRIPTION
## Summary

Dependabot opened three PRs against `test/Directory.Packages.props` and then auto-closed all three with the message _"Looks like \<package\> is no longer a dependency, so this is no longer needed."_ — but the packages are still actively referenced by every project under `test/`. This PR re-applies the bumps **and** fixes the Dependabot config that caused the false closures.

### Commit 1 — re-apply the three closed bumps

| Closed PR | Package | From → To |
| --- | --- | --- |
| #442 | `Aspire.Hosting.Testing` | 13.3.2 → 13.3.3 |
| #443 | `coverlet.collector` | 10.0.0 → 10.0.1 |
| #444 | `coverlet.msbuild` | 10.0.0 → 10.0.1 |

### Commit 2 — stop this happening again

`.github/dependabot.yml` only configures `directory: "/"` for nuget, so Dependabot scans the root `Directory.Packages.props`. The three packages above live exclusively in `test/Directory.Packages.props` — a sibling CPM file that doesn't inherit from the root one. When Dependabot re-evaluated each PR it didn't find these entries in the root file and incorrectly concluded the dependency had been removed.

Added a second nuget update entry rooted at `/test` so Dependabot inspects that CPM file directly. The `cobalt-github-packages` registry is included on the test scope as well, because `WopiHost.Cobalt.Tests` transitively pulls `Microsoft.CobaltCore` (which lives on the private GitHub Packages feed) via the `WopiHost.Cobalt` project reference.

### Cross-check

The companion `Aspire.Hosting.AppHost` / `Aspire.Hosting.Azure.Storage` / `Aspire.Hosting.Redis` 13.3.2 → 13.3.3 bumps already merged cleanly via #439/#440/#441, so the Aspire 13.3.3 line is known-good for this codebase.

## Test plan

- [ ] CI build passes (validates restore + compile against the new versions)
- [ ] WOPI validator job stays green
- [ ] APICompat job (informational) shows no new breaks vs. baseline 8.0.0
- [ ] After merge: confirm Dependabot's next daily run opens any future test-package PRs without auto-closing them