### PR TITLE
chore(deps): re-apply test-package bumps Dependabot wrongly closed (#449-#452)

### DIFF
--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.3.3" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.3.4" />
     <PackageVersion Include="FakeItEasy" Version="9.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
@@ -19,9 +19,9 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.59.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="Testcontainers" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.Azurite" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.Redis" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.Azurite" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.Redis" Version="4.12.0" />
     <!-- StackExchange.Redis client. The test/ Directory.Packages.props doesn't inherit from
          the root one, so the version must be redeclared here for the Redis lock provider tests. -->
     <PackageVersion Include="StackExchange.Redis" Version="2.9.32" />


### PR DESCRIPTION
## Summary

Same pattern as #445: Dependabot opened four test-scope bumps against `test/Directory.Packages.props`, then auto-closed all four with _"Looks like \<package\> is no longer a dependency, so this is no longer needed."_ The packages are still in active use, so this PR re-applies them.

| Closed PR | Package | From → To |
| --- | --- | --- |
| #449 | `Aspire.Hosting.Testing` | 13.3.3 → 13.3.4 |
| #450 | `Testcontainers` | 4.11.0 → 4.12.0 |
| #451 | `Testcontainers.Azurite` | 4.11.0 → 4.12.0 |
| #452 | `Testcontainers.Redis` | 4.11.0 → 4.12.0 |

### Notes on the bumps

- **Aspire.Hosting.Testing 13.3.4** — companion `Aspire.Hosting.AppHost` / `Aspire.Hosting.Azure.Storage` / `Aspire.Hosting.Redis` 13.3.4 bumps already merged via #446 / #447 / #448, so this line is known-good.
- **Testcontainers 4.12.0** — release notes flag an internal `Docker.DotNet 3.131.1 → 4.0.2` bump as "breaking". The breakage is for consumers that reference `Docker.DotNet` directly; this repo has no such references (`grep -r "Docker.DotNet"` returns nothing), so the bump is transparent here.

### Note on the dependabot.yml fix from #445

#445 added a `/test` directory entry to `.github/dependabot.yml` to make Dependabot scan `test/Directory.Packages.props` directly. That part appears to be working — these four PRs were opened from branches under `dependabot/nuget/test/...`, consistent with the `/test` scope. **But the auto-closure logic still fires** with the same false "no longer a dependency" message, so the config tweak alone wasn't sufficient. Worth opening a Dependabot issue (or experimenting with `groups:` / disabling the auto-close) as a follow-up — out of scope for this PR.

## Test plan

- [ ] CI build passes (validates restore + compile against the new versions)
- [ ] Testcontainers-using suites (`WopiHost.AzureStorageProvider.Tests`, `WopiHost.AzureLockProvider.Tests`, `WopiHost.RedisLockProvider.Tests`) still pass — these exercise the 4.12 Docker.DotNet rev
- [ ] E2E Collabora suite (`WopiHost.E2ETests.Collabora`) still passes — this is the Aspire.Hosting.Testing consumer
- [ ] WOPI validator job stays green

---
_Generated by [Claude Code](https://claude.ai/code/session_01Czr9UsgtRgBsu2pw1X4oCJ)_