### PR TITLE
chore(deps): re-apply Aspire.Hosting.Testing 13.3.5 bump Dependabot wrongly closed (#462)

### DIFF
--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.3.4" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.3.5" />
     <PackageVersion Include="FakeItEasy" Version="9.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.8" />


### PR DESCRIPTION
## Summary

Third occurrence of the same false-positive pattern from #445 and #453. Dependabot opened PR #462 to bump `Aspire.Hosting.Testing` 13.3.4 → 13.3.5 in `test/Directory.Packages.props`, then auto-closed it with _"Looks like Aspire.Hosting.Testing is no longer a dependency, so this is no longer needed."_ — but the package is still in active use (consumed by `test/WopiHost.E2ETests.Collabora`). This PR re-applies the bump.

| Closed PR | Package | From → To |
| --- | --- | --- |
| #462 | `Aspire.Hosting.Testing` | 13.3.4 → 13.3.5 |

### Cross-check

The companion root-scope bumps merged cleanly today:
- `Aspire.Hosting.AppHost` 13.3.5 — #459
- `Aspire.Hosting.Azure.Storage` 13.3.5 — #460
- `Aspire.Hosting.Redis` 13.3.5 — #461

So Aspire 13.3.5 is known-good for this codebase.

### Recurring problem — next step

This is the third time Dependabot has falsely closed a `test/Directory.Packages.props` bump:
- #442–#444 → re-applied via #445 (added `/test` directory entry to `dependabot.yml`)
- #449–#452 → re-applied via #453
- #462 → re-applied via this PR

#445's `dependabot.yml` change made Dependabot **scan** the test CPM file (these PRs are opened under `dependabot/nuget/test/...` branches), but the auto-closure heuristic still misfires. The root cause is almost certainly the two-`Directory.Packages.props` layout — Dependabot's "is this still a dependency?" check reads the root CPM file only. Filed/findable as [dependabot/dependabot-core#10186](https://github.com/dependabot/dependabot-core/issues/10186)-style.

Pragmatic options if this keeps happening:
1. **Merge the two CPM files** — collapse `test/Directory.Packages.props` into the root file with `<PrivateAssets>` / `<IncludeAssets>` already preserved. Simplest fix; downside is the root file gets longer and test-only versions leak into the package-validation surface.
2. **Add a `groups:` config** so Dependabot batches test-scope bumps into one PR — doesn't fix the false closure, but reduces the cost of each round.
3. **Live with manual re-apply via PR** like this one (what we're doing now).

Happy to tackle option 1 in a follow-up if you'd like — not in this PR's scope.

## Test plan

- [ ] CI build passes (validates restore + compile against 13.3.5)
- [ ] `WopiHost.E2ETests.Collabora` still passes — sole Aspire.Hosting.Testing consumer
- [ ] WOPI validator job stays green

---
_Generated by [Claude Code](https://claude.ai/code/session_01Czr9UsgtRgBsu2pw1X4oCJ)_