### PR TITLE
fix(core): return 501 on unauthorized overwrite in PutRelativeFile

### DIFF
--- a/.github/infer-allowlist.txt
+++ b/.github/infer-allowlist.txt
@@ -30,8 +30,8 @@ Endpoints/ContainerEndpoints.cs:69: error: Null Dereference
 Endpoints/ContainerEndpoints.cs:87: error: Null Dereference
 Endpoints/ContainerEndpoints.cs:111: error: Null Dereference
 Endpoints/ContainerEndpoints.cs:122: error: Null Dereference
-Endpoints/ContainerMutatingEndpoints.cs:212: error: Null Dereference
+Endpoints/ContainerMutatingEndpoints.cs:213: error: Null Dereference
 Endpoints/FileEndpoints.cs:117: error: Null Dereference
 Endpoints/FileEndpoints.cs:134: error: Null Dereference
-Endpoints/FileMutatingEndpoints.cs:320: error: Null Dereference
+Endpoints/FileMutatingEndpoints.cs:321: error: Null Dereference
 Endpoints/FolderEndpoints.cs:70: error: Null Dereference

--- a/src/WopiHost.Abstractions/IWopiPermissionProvider.cs
+++ b/src/WopiHost.Abstractions/IWopiPermissionProvider.cs
@@ -34,4 +34,42 @@ public interface IWopiPermissionProvider
     /// Returns the permissions <paramref name="user"/> has on <paramref name="container"/>.
     /// </summary>
     Task<WopiContainerPermissions> GetContainerPermissionsAsync(ClaimsPrincipal user, IWopiContainer container, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Decides whether <paramref name="user"/> is authorized to overwrite the existing target
+    /// <paramref name="existingFile"/> via <c>PutRelativeFile</c> when the client sets
+    /// <c>X-WOPI-OverwriteRelativeTarget: true</c> against a name that already exists.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/putrelativefile">PutRelativeFile spec</see>
+    /// mandates a distinct status code for this failure mode:
+    /// </para>
+    /// <para>
+    /// "If the user is not authorized to overwrite the target file, the host must respond with
+    /// a <c>501 Not Implemented</c>."
+    /// </para>
+    /// <para>
+    /// Unlike <see cref="GetFilePermissionsAsync"/>, this decision is made <em>per existing
+    /// target file</em> at the moment of the call — the file's identity isn't known when the
+    /// access token is minted, so the decision can't be encoded as a flag on
+    /// <see cref="WopiFilePermissions"/> ahead of time. This seam exists precisely so hosts
+    /// that distinguish "user may create relative files in this container" from "user may
+    /// overwrite this specific file" can express the latter at the right moment.
+    /// </para>
+    /// <para>
+    /// The default implementation returns <see langword="true"/> to preserve the historical
+    /// behaviour (any user that passed the <c>Permission.Create</c> gate may overwrite any
+    /// existing target). Hosts that need stricter rules — owner-only overwrite, label-based
+    /// gating, etc. — override and consult their ACL store using the supplied
+    /// <paramref name="existingFile"/>'s identity.
+    /// </para>
+    /// </remarks>
+    /// <param name="user">The authenticated principal making the request.</param>
+    /// <param name="existingFile">The target file the user is attempting to overwrite.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns><see langword="true"/> if the overwrite is authorized; <see langword="false"/>
+    /// to surface the spec-mandated <c>501 Not Implemented</c>.</returns>
+    Task<bool> CanOverwriteFileAsync(ClaimsPrincipal user, IWopiFile existingFile, CancellationToken cancellationToken = default)
+        => Task.FromResult(true);
 }

--- a/src/WopiHost.Abstractions/WopiNewChildFileRequest.cs
+++ b/src/WopiHost.Abstractions/WopiNewChildFileRequest.cs
@@ -1,8 +1,12 @@
+using System.Security.Claims;
+
 namespace WopiHost.Abstractions;
 
 /// <summary>
 /// Input to <see cref="IWopiNewChildFileNegotiator.NegotiateAsync"/>. Captures the WOPI
-/// PutRelativeFile / CreateChildFile request inputs as a pure POCO — no HTTP context, no
+/// PutRelativeFile / CreateChildFile request inputs as a near-POCO — only the authenticated
+/// <see cref="ClaimsPrincipal"/> is carried (needed for per-operation authorization decisions
+/// like <see cref="IWopiPermissionProvider.CanOverwriteFileAsync"/>); no HTTP context, no
 /// ambient request state.
 /// </summary>
 /// <param name="ContainerId">
@@ -27,6 +31,12 @@ namespace WopiHost.Abstractions;
 /// source file in scope so passes a fresh GUID. The only spec-mandated difference between
 /// the two flows.
 /// </param>
+/// <param name="User">
+/// The authenticated principal making the request. Carried into the request so the negotiator
+/// can consult <see cref="IWopiPermissionProvider.CanOverwriteFileAsync"/> when the caller
+/// asked to overwrite an existing target — that authorization decision is per-operation and
+/// per-existing-file, so it can't be encoded into the access token at mint time.
+/// </param>
 /// <remarks>
 /// Both target parameters are plain <see langword="string"/>s; controllers binding the
 /// <c>UtfString</c>-typed WOPI headers can pass them in via the implicit
@@ -38,4 +48,5 @@ public sealed record WopiNewChildFileRequest(
     string? SuggestedTarget,
     string? RelativeTarget,
     bool OverwriteRelativeTarget,
-    string SuggestedExtensionFallbackStem);
+    string SuggestedExtensionFallbackStem,
+    ClaimsPrincipal User);

--- a/src/WopiHost.Abstractions/WopiNewChildFileResult.cs
+++ b/src/WopiHost.Abstractions/WopiNewChildFileResult.cs
@@ -61,6 +61,12 @@ public sealed class WopiNewChildFileResult
     /// from a create call that's contractually expected to succeed).</summary>
     public static WopiNewChildFileResult InternalError() =>
         new() { Outcome = WopiNewChildFileOutcome.InternalError };
+
+    /// <summary>Shorthand factory for the 501-not-implemented path — the user is authorized to
+    /// call <c>PutRelativeFile</c> but is not authorized to overwrite the existing target file.
+    /// See <see cref="IWopiPermissionProvider.CanOverwriteFileAsync"/> for the gating decision.</summary>
+    public static WopiNewChildFileResult NotImplemented() =>
+        new() { Outcome = WopiNewChildFileOutcome.NotImplemented };
 }
 
 /// <summary>
@@ -85,4 +91,10 @@ public enum WopiNewChildFileOutcome
     /// <summary>The storage provider returned <see langword="null"/> from a create call. Shouldn't
     /// happen with the in-tree providers but guarded defensively.</summary>
     InternalError,
+
+    /// <summary>The caller is authorized to invoke <c>PutRelativeFile</c> (passed the endpoint-level
+    /// <c>Permission.Create</c> gate) but the target name resolves to an existing file the caller
+    /// is not allowed to overwrite. Maps to <c>501 Not Implemented</c> per the
+    /// <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/putrelativefile">PutRelativeFile spec</see>.</summary>
+    NotImplemented,
 }

--- a/src/WopiHost.Core/Endpoints/ContainerMutatingEndpoints.cs
+++ b/src/WopiHost.Core/Endpoints/ContainerMutatingEndpoints.cs
@@ -192,7 +192,8 @@ internal static class ContainerMutatingEndpoints
             SuggestedTarget: req.SuggestedTarget,
             RelativeTarget: req.RelativeTarget,
             OverwriteRelativeTarget: req.OverwriteRelativeTarget ?? false,
-            SuggestedExtensionFallbackStem: Guid.NewGuid().ToString("N")), req.CancellationToken).ConfigureAwait(false);
+            SuggestedExtensionFallbackStem: Guid.NewGuid().ToString("N"),
+            User: req.Http.User), req.CancellationToken).ConfigureAwait(false);
         if (negotiation.ToErrorResult(req.Http.Response) is { } error)
         {
             return error switch

--- a/src/WopiHost.Core/Endpoints/FileMutatingEndpoints.cs
+++ b/src/WopiHost.Core/Endpoints/FileMutatingEndpoints.cs
@@ -295,7 +295,8 @@ internal static class FileMutatingEndpoints
             SuggestedTarget: req.SuggestedTarget,
             RelativeTarget: req.RelativeTarget,
             OverwriteRelativeTarget: req.OverwriteRelativeTarget ?? false,
-            SuggestedExtensionFallbackStem: file.Name), req.CancellationToken).ConfigureAwait(false);
+            SuggestedExtensionFallbackStem: file.Name,
+            User: req.Http.User), req.CancellationToken).ConfigureAwait(false);
         if (negotiation.ToErrorResult(req.Http.Response) is { } error)
         {
             // Negotiator surfaces failure modes as IResult — destructure into the typed union.

--- a/src/WopiHost.Core/Infrastructure/DefaultWopiNewChildFileNegotiator.cs
+++ b/src/WopiHost.Core/Infrastructure/DefaultWopiNewChildFileNegotiator.cs
@@ -11,6 +11,7 @@ namespace WopiHost.Core.Infrastructure;
 public sealed class DefaultWopiNewChildFileNegotiator(
     IWopiStorageProvider storage,
     IWopiWritableStorageProvider writable,
+    IWopiPermissionProvider permissions,
     IWopiLockProvider? lockProvider = null) : IWopiNewChildFileNegotiator
 {
     /// <inheritdoc />
@@ -68,6 +69,19 @@ public sealed class DefaultWopiNewChildFileNegotiator(
             // correct containerId in one place.
             var suggestedName = await writable.GetSuggestedFileName(request.ContainerId, relativeTarget, cancellationToken).ConfigureAwait(false);
             return WopiNewChildFileResult.Conflict(suggestedName);
+        }
+
+        // Spec-mandated 501-gate: the caller passed the endpoint-level Permission.Create check
+        // and asked to overwrite, but the host's ACL may still deny overwrite of THIS specific
+        // existing file. The decision is per-target and only resolvable now that `existing` is
+        // in scope (it isn't known at token-mint time, so it can't be encoded as a
+        // WopiFilePermissions flag on the access token). See #455 and
+        // https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/putrelativefile —
+        // "If the user is not authorized to overwrite the target file, the host must respond
+        // with a 501 Not Implemented."
+        if (!await permissions.CanOverwriteFileAsync(request.User, existing, cancellationToken).ConfigureAwait(false))
+        {
+            return WopiNewChildFileResult.NotImplemented();
         }
 
         // Overwrite is allowed — a file matching the target name might still be locked.

--- a/src/WopiHost.Core/Infrastructure/WopiNewChildFileResultExtensions.cs
+++ b/src/WopiHost.Core/Infrastructure/WopiNewChildFileResultExtensions.cs
@@ -41,6 +41,12 @@ internal static class WopiNewChildFileResultExtensions
                 return new WopiLockMismatchResult(result.ExistingLockId!, reason: "File already exists and is currently locked");
             case WopiNewChildFileOutcome.InternalError:
                 return TypedResults.StatusCode(StatusCodes.Status500InternalServerError);
+            case WopiNewChildFileOutcome.NotImplemented:
+                // Spec: PutRelativeFile returns 501 specifically when the caller is authorized
+                // to invoke the operation but not authorized to overwrite the existing target.
+                // No spec-defined response headers for this path; the status code carries the
+                // signal on its own. See #455.
+                return TypedResults.StatusCode(StatusCodes.Status501NotImplemented);
             default:
                 throw new InvalidOperationException($"Unknown {nameof(WopiNewChildFileOutcome)}: {result.Outcome}");
         }

--- a/test/WopiHost.Core.Tests/Infrastructure/DefaultWopiNewChildFileNegotiatorTests.cs
+++ b/test/WopiHost.Core.Tests/Infrastructure/DefaultWopiNewChildFileNegotiatorTests.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Moq;
 using WopiHost.Abstractions;
 using WopiHost.Core.Infrastructure;
@@ -13,19 +14,31 @@ namespace WopiHost.Core.Tests.Infrastructure;
 public class DefaultWopiNewChildFileNegotiatorTests
 {
     private const string Container = "container-1";
+    private static readonly ClaimsPrincipal s_anonymous = new();
     private readonly Mock<IWopiStorageProvider> _storage = new();
     private readonly Mock<IWopiWritableStorageProvider> _writable = new();
+    private readonly Mock<IWopiPermissionProvider> _permissions = new();
     private readonly Mock<IWopiLockProvider> _lockProvider = new();
 
+    public DefaultWopiNewChildFileNegotiatorTests()
+    {
+        // Default permission stance for every test: allow overwrite. The 501-unauthorized-
+        // overwrite path has its own dedicated test that overrides this setup.
+        _permissions
+            .Setup(p => p.CanOverwriteFileAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<IWopiFile>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+    }
+
     private DefaultWopiNewChildFileNegotiator CreateNegotiator(bool withLockProvider = true)
-        => new(_storage.Object, _writable.Object, withLockProvider ? _lockProvider.Object : null);
+        => new(_storage.Object, _writable.Object, _permissions.Object, withLockProvider ? _lockProvider.Object : null);
 
     private static WopiNewChildFileRequest Request(
         string? suggested = null,
         string? relative = null,
         bool overwrite = false,
-        string fallbackStem = "Untitled")
-        => new(Container, suggested, relative, overwrite, fallbackStem);
+        string fallbackStem = "Untitled",
+        ClaimsPrincipal? user = null)
+        => new(Container, suggested, relative, overwrite, fallbackStem, user ?? s_anonymous);
 
     [Fact]
     public async Task BothTargetsMissing_ReturnsBadRequest()
@@ -114,6 +127,35 @@ public class DefaultWopiNewChildFileNegotiatorTests
 
         Assert.Equal(WopiNewChildFileOutcome.Conflict, result.Outcome);
         Assert.Equal("doc (1).docx", result.ValidRelativeTargetSuggestion);
+    }
+
+    [Fact]
+    public async Task RelativeTarget_Collision_Overwrite_PermissionProviderDenies_ReturnsNotImplemented()
+    {
+        // Spec (#455): "If the user is not authorized to overwrite the target file, the host must
+        // respond with a 501 Not Implemented." The endpoint-level Permission.Create gate already
+        // passed (we're inside the negotiator), but the per-target permission provider rules out
+        // overwriting THIS specific file. The lock probe must NOT run — denying overwrite is a
+        // strictly stronger signal than "the existing file is locked," so 501 wins.
+        var existing = Mock.Of<IWopiFile>(f => f.Identifier == "existing-id");
+        var deniedUser = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, "alice")], "test"));
+        _writable.Setup(w => w.CheckValidFileName("doc.docx", It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _storage.Setup(s => s.GetWopiFileByName(Container, "doc.docx", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+        _permissions
+            .Setup(p => p.CanOverwriteFileAsync(deniedUser, existing, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await CreateNegotiator().NegotiateAsync(Request(relative: "doc.docx", overwrite: true, user: deniedUser));
+
+        Assert.Equal(WopiNewChildFileOutcome.NotImplemented, result.Outcome);
+        _lockProvider.Verify(
+            l => l.GetLockAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "Permission denial must short-circuit before the lock probe.");
+        _writable.Verify(
+            w => w.GetWritableFile(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "Permission denial must short-circuit before the writable-file resolution.");
     }
 
     [Fact]

--- a/test/WopiHost.IntegrationTests/PutRelativeFileOverwrite501Tests.cs
+++ b/test/WopiHost.IntegrationTests/PutRelativeFileOverwrite501Tests.cs
@@ -1,0 +1,195 @@
+using System.Net;
+using System.Security.Claims;
+using WopiHost.Abstractions;
+using WopiHost.IntegrationTests.Fixtures;
+using Xunit;
+
+namespace WopiHost.IntegrationTests;
+
+/// <summary>
+/// Spec-correctness test for the PutRelativeFile 501 path described in #455.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <a href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/putrelativefile">The PutRelativeFile spec</a>
+/// distinguishes "user is unauthorized to call this endpoint" (401/403) from "user is authorized
+/// to call this endpoint but not authorized to overwrite the existing target" (501):
+/// </para>
+/// <para>
+/// "If the user is not authorized to overwrite the target file, the host must respond with a
+/// 501 Not Implemented."
+/// </para>
+/// <para>
+/// The decision is per-existing-file so it can't live on the access-token's <c>wopi:fperms</c>
+/// claim (the existing file isn't known at token-mint time). The contract on
+/// <see cref="IWopiPermissionProvider.CanOverwriteFileAsync"/> is the host's seam — return
+/// <see langword="false"/> and the negotiator surfaces <see cref="WopiNewChildFileOutcome.NotImplemented"/>
+/// which the endpoint translates into <c>501</c>.
+/// </para>
+/// <para>
+/// Has its own backend fixture (not the shared <see cref="MutatingEndpointsFixture"/>) so the
+/// deny-overwrite permission provider doesn't taint sibling tests that rely on the default
+/// allow-everything behaviour.
+/// </para>
+/// </remarks>
+public sealed class PutRelativeFileOverwrite501Tests : IClassFixture<PutRelativeFileOverwrite501Tests.Fixture>
+{
+    private const string SharedSigningSecret = "putrelativefile-501-tests-key-32!";
+    private readonly Fixture _fixture;
+
+    public PutRelativeFileOverwrite501Tests(Fixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task PutRelativeFile_OverwriteExisting_PermissionDenied_Returns_501()
+    {
+        // Arrange: parent file, plus an EXISTING file in the same container with the name the
+        // PUT_RELATIVE call will target. The custom IWopiPermissionProvider registered on the
+        // fixture denies CanOverwriteFileAsync for any (user, existingFile) pair, so the
+        // overwrite path must surface 501 Not Implemented rather than 200 / 401 / 409.
+        var parentFileId = await _fixture.CreateTempFileAsync("anchor"u8.ToArray(), extension: ".txt");
+        const string TargetName = "to-be-overwritten.txt";
+        await _fixture.CreateSpecificFileAsync(TargetName, "old"u8.ToArray());
+
+        var token = await _fixture.MintFileTokenAsync(parentFileId, WopiFilePermissions.UserCanWrite);
+        using var client = _fixture.WopiBackend.CreateClient();
+
+        var req = new HttpRequestMessage(HttpMethod.Post, $"/wopi/files/{parentFileId}?access_token={Uri.EscapeDataString(token)}")
+        {
+            Content = new ByteArrayContent("new-content"u8.ToArray()),
+        };
+        req.Headers.Add("X-WOPI-Override", "PUT_RELATIVE");
+        req.Headers.Add("X-WOPI-RelativeTarget", TargetName);
+        req.Headers.Add("X-WOPI-OverwriteRelativeTarget", "true");
+
+        // Act
+        var resp = await client.SendAsync(req);
+
+        // Assert: spec-mandated 501.
+        Assert.Equal(HttpStatusCode.NotImplemented, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task PutRelativeFile_NoExistingTarget_StillSucceeds_When_PermissionProviderDeniesOverwrite()
+    {
+        // Sanity check: the deny-overwrite provider must NOT affect the new-file path. The 501
+        // gate only fires when there's an existing target to overwrite — fresh-name creates
+        // continue to return 200. Without this assertion, a future refactor that calls
+        // CanOverwriteFileAsync unconditionally would break the create-new flow silently.
+        var parentFileId = await _fixture.CreateTempFileAsync("anchor"u8.ToArray(), extension: ".txt");
+        var token = await _fixture.MintFileTokenAsync(parentFileId, WopiFilePermissions.UserCanWrite);
+        using var client = _fixture.WopiBackend.CreateClient();
+
+        // Use a name we know doesn't exist — GUID-stemmed so it can't collide.
+        var freshName = $"fresh-{Guid.NewGuid():N}.txt";
+        var req = new HttpRequestMessage(HttpMethod.Post, $"/wopi/files/{parentFileId}?access_token={Uri.EscapeDataString(token)}")
+        {
+            Content = new ByteArrayContent("body"u8.ToArray()),
+        };
+        req.Headers.Add("X-WOPI-Override", "PUT_RELATIVE");
+        req.Headers.Add("X-WOPI-RelativeTarget", freshName);
+        req.Headers.Add("X-WOPI-OverwriteRelativeTarget", "true");
+
+        var resp = await client.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    /// <summary>
+    /// Backend fixture with an <see cref="IWopiPermissionProvider"/> that denies overwrite —
+    /// every other authorization path follows the default permission provider shape.
+    /// Isolated from <see cref="MutatingEndpointsFixture"/> so the deny doesn't reach sibling tests.
+    /// </summary>
+    public sealed class Fixture : IDisposable
+    {
+        private readonly string _tempRoot;
+        public WopiBackendFactory WopiBackend { get; }
+        public string RootContainerId { get; }
+
+        public Fixture()
+        {
+            _tempRoot = Path.Combine(Path.GetTempPath(), $"wopi-pr501-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(_tempRoot);
+
+            WopiBackend = new WopiBackendFactory(
+                SharedSigningSecret,
+                storageRootPath: _tempRoot,
+                configureServices: services =>
+                {
+                    // Replace the default provider with the deny-overwrite variant. AddWopi()
+                    // uses TryAddSingleton for IWopiPermissionProvider, so removing + re-adding
+                    // is the cleanest way to override.
+                    services.RemoveAll<IWopiPermissionProvider>();
+                    services.AddSingleton<IWopiPermissionProvider, DenyOverwritePermissionProvider>();
+                });
+
+            using var scope = WopiBackend.Services.CreateScope();
+            var storage = scope.ServiceProvider.GetRequiredService<IWopiStorageProvider>();
+            RootContainerId = storage.RootContainer.Identifier;
+        }
+
+        public async Task<string> MintFileTokenAsync(string fileId, WopiFilePermissions permissions)
+        {
+            using var scope = WopiBackend.Services.CreateScope();
+            var tokens = scope.ServiceProvider.GetRequiredService<IWopiAccessTokenService>();
+            var token = await tokens.IssueAsync(new WopiAccessTokenRequest
+            {
+                UserId = "pr501-user",
+                UserDisplayName = "PutRelativeFile 501 User",
+                UserEmail = "pr501@example.test",
+                ResourceId = fileId,
+                ResourceType = WopiResourceType.File,
+                FilePermissions = permissions,
+            });
+            return token.Token;
+        }
+
+        public async Task<string> CreateTempFileAsync(byte[] contents, string extension = ".bin")
+        {
+            var fileName = $"anchor-{Guid.NewGuid():N}{extension}";
+            return await CreateSpecificFileAsync(fileName, contents);
+        }
+
+        public async Task<string> CreateSpecificFileAsync(string fileName, byte[] contents)
+        {
+            using var scope = WopiBackend.Services.CreateScope();
+            var writable = scope.ServiceProvider.GetRequiredService<IWopiWritableStorageProvider>();
+            var file = await writable.CreateWopiChildFile(RootContainerId, fileName)
+                ?? throw new InvalidOperationException($"CreateWopiChildFile returned null for {fileName}");
+            if (contents.Length > 0)
+            {
+                await using var stream = await file.OpenWriteAsync();
+                await stream.WriteAsync(contents);
+            }
+            return file.Identifier;
+        }
+
+        public void Dispose()
+        {
+            WopiBackend.Dispose();
+            try { Directory.Delete(_tempRoot, recursive: true); } catch { /* best-effort */ }
+        }
+
+        /// <summary>
+        /// Permission provider that allows everything except <see cref="CanOverwriteFileAsync"/>,
+        /// which always denies. Mirrors the default permission shape for <c>GetFilePermissionsAsync</c> /
+        /// <c>GetContainerPermissionsAsync</c> so the endpoint-level authorization gate still
+        /// passes — the only thing this provider changes is the per-existing-file overwrite check.
+        /// </summary>
+        private sealed class DenyOverwritePermissionProvider : IWopiPermissionProvider
+        {
+            public Task<WopiFilePermissions> GetFilePermissionsAsync(ClaimsPrincipal user, IWopiFile file, CancellationToken cancellationToken = default)
+                // Match what the access token claim carries (UserCanWrite). The token-side
+                // claim is what's actually consulted by WopiAuthorizationHandler for the
+                // Permission.Create gate on PutRelativeFile — this method is called for
+                // CheckFileInfo population. Returning the same shape keeps observable
+                // behaviour close to DefaultWopiPermissionProvider.
+                => Task.FromResult(WopiFilePermissions.UserCanWrite);
+
+            public Task<WopiContainerPermissions> GetContainerPermissionsAsync(ClaimsPrincipal user, IWopiContainer container, CancellationToken cancellationToken = default)
+                => Task.FromResult(WopiContainerPermissions.UserCanCreateChildFile | WopiContainerPermissions.UserCanCreateChildContainer);
+
+            public Task<bool> CanOverwriteFileAsync(ClaimsPrincipal user, IWopiFile existingFile, CancellationToken cancellationToken = default)
+                => Task.FromResult(false);
+        }
+    }
+}


### PR DESCRIPTION
Closes #455.

## What the spec asks for

[PutRelativeFile spec](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/putrelativefile) (emphasis added):

> *X-WOPI-OverwriteRelativeTarget* — A Boolean value that specifies whether the host must overwrite the file name if it exists. ... **If the user is not authorized to overwrite the target file, the host must respond with a 501 Not Implemented.**

That's `501` (not `401`/`403`/`404`) specifically when:
1. The request is in specific mode (`X-WOPI-RelativeTarget` set),
2. `X-WOPI-OverwriteRelativeTarget: true` was sent,
3. A file with the requested name already exists, AND
4. The current user lacks permission to overwrite that existing file.

## Pre-fix gap

The `PutRelativeFile` endpoint is gated by `WopiAuthorizeAttribute(WopiResourceType.File, Permission.Create)`. There was no distinct permission for "overwrite this specific existing file":

- A user with `Permission.Create` could overwrite any existing file in the parent container (no extra check).
- A user without `Permission.Create` got the standard authorization rejection from the auth pipeline (401 / 403).

Neither path produced 501.

## Where the new permission lives — and why

Per the [#455 design discussion](https://github.com/petrsvihlik/WopiHost/issues/455), three options were on the table:

| | Approach | Verdict |
|---|---|---|
| A | New flag on `WopiFilePermissions` | Pollutes the spec-mirror enum (every flag there 1:1-mirrors a CheckFileInfo response property; non-spec additions break that contract). |
| B | **New `IWopiPermissionProvider.CanOverwriteFileAsync` method, DIM default true** | ✅ Adopted. |
| C | New JWT claim + extend `WopiAccessTokenRequest` | Decision can only be made when the existing target file is in scope — token-mint time doesn't know which file the user will eventually attempt to overwrite. Token-bound flag would only express "user may overwrite anything in the container," which is strictly weaker than the spec. |

Option B models the semantic accurately:

\`\`\`csharp
public interface IWopiPermissionProvider
{
    Task<WopiFilePermissions> GetFilePermissionsAsync(...);            // unchanged
    Task<WopiContainerPermissions> GetContainerPermissionsAsync(...);  // unchanged

    /// <summary>
    /// Decides whether <paramref name="user"/> may overwrite <paramref name="existingFile"/>
    /// via PutRelativeFile when X-WOPI-OverwriteRelativeTarget=true. Default is true to
    /// preserve historical behaviour; hosts with stricter ACLs override.
    /// </summary>
    Task<bool> CanOverwriteFileAsync(ClaimsPrincipal user, IWopiFile existingFile, CancellationToken ct = default)
        => Task.FromResult(true);
}
\`\`\`

Why this is the right shape:

1. **The decision is per-existing-file, evaluated mid-request.** A token claim can't carry the answer because the target file's identity isn't known at mint time.
2. **`WopiFilePermissions` stays a clean spec mirror.** No non-spec flags.
3. **DIM default = zero breaking changes for existing implementations.** Production hosts compile and behave identically without recompiling. Hosts that want to enforce the 501 path override the method.
4. **No JWT claim coordination** between the frontend and backend. Token shape unchanged.

## The full plumbing

| File | Change |
|---|---|
| `IWopiPermissionProvider.cs` | New DIM `CanOverwriteFileAsync`, defaults to `true`. |
| `WopiNewChildFileResult.cs` | New `WopiNewChildFileOutcome.NotImplemented` + matching `NotImplemented()` factory. |
| `WopiNewChildFileRequest.cs` | New required `ClaimsPrincipal User` parameter so the negotiator can consult the permission provider. |
| `DefaultWopiNewChildFileNegotiator.cs` | Constructor gains `IWopiPermissionProvider`. In `NegotiateRelativeAsync`, after locating the existing target and confirming overwrite was requested, calls `CanOverwriteFileAsync` BEFORE the lock probe (permission denial is a strictly stronger signal than "file is locked," so 501 wins over 409). |
| `WopiNewChildFileResultExtensions.cs` | New `case WopiNewChildFileOutcome.NotImplemented => TypedResults.StatusCode(501)`. No spec-defined response headers for this path; the status carries the signal. |
| `FileMutatingEndpoints.cs` / `ContainerMutatingEndpoints.cs` | Both negotiator call sites pass `req.Http.User` into the new `WopiNewChildFileRequest.User` parameter. |

## Surface-level breaking changes

Two constructor signatures change. Both are internal-ish — `IWopiNewChildFileNegotiator` is rarely overridden outside the sample:

- `WopiNewChildFileRequest` — new required `ClaimsPrincipal User` positional parameter (now the 6th).
- `DefaultWopiNewChildFileNegotiator` — new required `IWopiPermissionProvider` constructor arg (3rd position, before the optional lock provider). DI is automatic since `AddWopi()` already TryAdds `IWopiPermissionProvider`.

## Tests

**Unit** (`DefaultWopiNewChildFileNegotiatorTests`): adds `RelativeTarget_Collision_Overwrite_PermissionProviderDenies_ReturnsNotImplemented` — asserts the outcome AND that the lock probe + writable-file resolution short-circuit when the permission denies. All 13 existing branch tests still pass against the new constructor + request shape (default-allow setup in the test fixture's constructor).

**Integration** (`PutRelativeFileOverwrite501Tests`): owns its own `WopiBackendFactory` with a deny-overwrite `IWopiPermissionProvider` in DI — sibling tests are unaffected. Two scenarios:

1. **`PutRelativeFile_OverwriteExisting_PermissionDenied_Returns_501`** — real PUT_RELATIVE against an EXISTING file name with `X-WOPI-OverwriteRelativeTarget: true` → 501.
2. **`PutRelativeFile_NoExistingTarget_StillSucceeds_When_PermissionProviderDeniesOverwrite`** — sanity check: PUT_RELATIVE to a FRESH name with `overwrite=true` still returns 200. Guards against a future refactor that unconditionally calls `CanOverwriteFileAsync` (which would break the create-new flow silently).

## Test plan

- [x] CI build clean
- [x] Solution build clean (0 warnings, 0 errors)
- [x] `dotnet test WOPI.slnx` (excluding Collabora E2E): **910 passing** (was 907 — +1 unit, +2 integration).
- [x] No existing integration tests regressed by the `WopiNewChildFileRequest` constructor change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)