### PR TITLE
refactor(core): extract EnsureExactlyOneOf helper for spec mutex headers

### DIFF
--- a/src/WopiHost.Core/Endpoints/ContainerMutatingEndpoints.cs
+++ b/src/WopiHost.Core/Endpoints/ContainerMutatingEndpoints.cs
@@ -81,11 +81,9 @@ internal static class ContainerMutatingEndpoints
         ArgumentNullException.ThrowIfNull(req.WritableStorage);
         if (await req.Storage.GetWopiContainer(req.Id, req.CancellationToken).ConfigureAwait(false) is null) return TypedResults.NotFound();
 
-        // Mutually exclusive headers per spec: 501 when both present or both missing.
-        if ((!string.IsNullOrWhiteSpace(req.SuggestedTarget) && !string.IsNullOrWhiteSpace(req.RelativeTarget))
-            || (string.IsNullOrWhiteSpace(req.SuggestedTarget) && string.IsNullOrWhiteSpace(req.RelativeTarget)))
+        if (EndpointHelpers.EnsureExactlyOneOf(req.SuggestedTarget, req.RelativeTarget) is { } mutex)
         {
-            return TypedResults.StatusCode(StatusCodes.Status501NotImplemented);
+            return mutex;
         }
 
         // Spec branches on which header is set:
@@ -178,10 +176,9 @@ internal static class ContainerMutatingEndpoints
         var container = await req.Storage.GetWopiContainer(req.Id, req.CancellationToken).ConfigureAwait(false);
         if (container is null) return TypedResults.NotFound();
 
-        if ((!string.IsNullOrWhiteSpace(req.SuggestedTarget) && !string.IsNullOrWhiteSpace(req.RelativeTarget))
-            || (string.IsNullOrWhiteSpace(req.SuggestedTarget) && string.IsNullOrWhiteSpace(req.RelativeTarget)))
+        if (EndpointHelpers.EnsureExactlyOneOf(req.SuggestedTarget, req.RelativeTarget) is { } mutex)
         {
-            return TypedResults.StatusCode(StatusCodes.Status501NotImplemented);
+            return mutex;
         }
 
         // Suggested-target / relative-target negotiation — protocol shared with PutRelativeFile.

--- a/src/WopiHost.Core/Endpoints/EndpointHelpers.cs
+++ b/src/WopiHost.Core/Endpoints/EndpointHelpers.cs
@@ -136,6 +136,25 @@ internal static partial class EndpointHelpers
     }
 
     /// <summary>
+    /// Enforces the WOPI "exactly one of header A or header B" contract used by name-negotiation
+    /// endpoints (PutRelativeFile, CreateChildFile, CreateChildContainer). The spec mandates
+    /// <c>501 Not Implemented</c> — not 400 — when both headers are present or both are absent,
+    /// because the host has not chosen which negotiation mode (suggested vs specific) to support.
+    /// Returns <see langword="null"/> when exactly one is set so the call site can proceed; the
+    /// caller dispatches on which one was set via subsequent <c>!= null</c> checks.
+    /// </summary>
+    /// <remarks>
+    /// Whitespace-only header values count as absent (matches the
+    /// <c>string.IsNullOrWhiteSpace</c> semantics the hand-rolled call sites used). .NET 10's
+    /// <c>Microsoft.Extensions.Validation</c> doesn't fit this seam — see #466 for the
+    /// investigation; the validation pipeline is 400-shaped only and can't express 501 NI.
+    /// </remarks>
+    public static StatusCodeHttpResult? EnsureExactlyOneOf(string? a, string? b)
+        => string.IsNullOrWhiteSpace(a) == string.IsNullOrWhiteSpace(b)
+            ? TypedResults.StatusCode(StatusCodes.Status501NotImplemented)
+            : null;
+
+    /// <summary>
     /// Parses the <c>X-WOPI-WopiSrc</c> header into a <see cref="WopiResourceType"/> and the
     /// resource identifier. Accepts absolute URIs whose path ends with <c>/files/{id}</c> or
     /// <c>/containers/{id}</c> (case-insensitive). When the path contains multiple candidate

--- a/src/WopiHost.Core/Endpoints/FileMutatingEndpoints.cs
+++ b/src/WopiHost.Core/Endpoints/FileMutatingEndpoints.cs
@@ -277,11 +277,9 @@ internal static class FileMutatingEndpoints
             return tooLarge;
         }
 
-        // Mutually exclusive headers per spec: 501 when both present or both missing.
-        if ((!string.IsNullOrWhiteSpace(req.SuggestedTarget) && !string.IsNullOrWhiteSpace(req.RelativeTarget))
-            || (string.IsNullOrWhiteSpace(req.SuggestedTarget) && string.IsNullOrWhiteSpace(req.RelativeTarget)))
+        if (EndpointHelpers.EnsureExactlyOneOf(req.SuggestedTarget, req.RelativeTarget) is { } mutex)
         {
-            return TypedResults.StatusCode(StatusCodes.Status501NotImplemented);
+            return mutex;
         }
 
         var ancestors = await req.Storage.GetFileAncestors(req.Id, req.CancellationToken).ConfigureAwait(false);

--- a/test/WopiHost.Core.Tests/Endpoints/EndpointHelpersTests.cs
+++ b/test/WopiHost.Core.Tests/Endpoints/EndpointHelpersTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using WopiHost.Abstractions;
 using WopiHost.Core.Endpoints;
 
@@ -48,5 +49,38 @@ public class EndpointHelpersTests
         var ok = EndpointHelpers.TryParseWopiSrc(url, out _, out _);
 
         Assert.False(ok);
+    }
+
+    // EnsureExactlyOneOf — replaces the hand-rolled mutex check used in name-negotiation
+    // endpoints (PutRelativeFile, CreateChildFile, CreateChildContainer). The spec mandates
+    // 501 — not 400 — when both targets are present OR both are absent; whitespace-only values
+    // count as absent so a header sent with an empty token doesn't sneak past the gate.
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("", "")]
+    [InlineData("   ", "   ")]
+    [InlineData("a", "b")]
+    [InlineData(null, "")]
+    [InlineData("   ", null)]
+    public void EnsureExactlyOneOf_BothPresentOrBothAbsent_Returns501(string? a, string? b)
+    {
+        var result = EndpointHelpers.EnsureExactlyOneOf(a, b);
+
+        Assert.NotNull(result);
+        Assert.Equal(StatusCodes.Status501NotImplemented, result!.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("a", null)]
+    [InlineData(null, "b")]
+    [InlineData("a", "")]
+    [InlineData("", "b")]
+    [InlineData("a", "   ")] // whitespace-only treated as absent — exactly-one rule still satisfied
+    [InlineData("   ", "b")]
+    public void EnsureExactlyOneOf_ExactlyOneSet_ReturnsNull(string? a, string? b)
+    {
+        var result = EndpointHelpers.EnsureExactlyOneOf(a, b);
+
+        Assert.Null(result);
     }
 }


### PR DESCRIPTION
## Summary

- Closes the open question in #466 by **Rejecting** .NET 10's `Microsoft.Extensions.Validation` for the WOPI surface — full investigation in [#466 comment](https://github.com/petrsvihlik/WopiHost/issues/466#issuecomment-4547792266). Three structural mismatches: (1) the mutex contract returns **501**, not 400 — the validation pipeline can rewrite the body but not the status line; (2) the `X-WOPI-Lock`-required check is conditional on `X-WOPI-Override`, which is also the dispatch key (`WopiOverrideMatcherPolicy`), so attribute-driven validation runs against the wrong endpoint's contract on the multiplex; (3) every WOPI failure carries a distinct response header + empty body, which would require a custom `IProblemDetailsService` that re-derives the WOPI semantic — more indirection than the current 3-line `if`.
- Picks off the "Header mutual-exclusivity pattern duplicated" item from #457: three near-identical xor checks in `PutRelativeFile`, `CreateChildFile`, and `CreateChildContainer` collapse to a single `EndpointHelpers.EnsureExactlyOneOf` call. Whitespace-only header values continue to count as absent (matches the prior `IsNullOrWhiteSpace` semantics).
- Adds focused unit tests covering both branches of the helper (both-present/both-absent → 501, exactly-one-set → null).

## Test plan

- [x] `dotnet build WOPI.slnx` — 0 warnings, 0 errors
- [x] `dotnet test test/WopiHost.Core.Tests` — 333/333 passed (includes new `EnsureExactlyOneOf_*` tests)
- [x] `dotnet test test/WopiHost.IntegrationTests` — 115/115 passed (covers the three affected handlers end-to-end)
- [ ] CI runs the container-dependent suites (Redis / Azurite) that aren't runnable in this dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)