### PR TITLE
refactor(apphost): switch wopi-locks Redis to Session lifetime

### DIFF
--- a/infra/WopiHost.AppHost/Program.cs
+++ b/infra/WopiHost.AppHost/Program.cs
@@ -91,10 +91,17 @@ if (builder.Configuration.GetValue<bool>("AppHost:UseAzureStorage"))
 // reconfigured to load WopiHost.RedisLockProvider with the Aspire-allocated connection string.
 // WaitFor ensures the WOPI backend doesn't try to acquire a lock before Redis is accepting
 // connections.
+//
+// Lifetime defaults to Session (Aspire's default) so the container is torn down on AppHost
+// shutdown. Persistent lifetime was tried but accumulated orphaned containers across runs:
+// Aspire's persistent-resource identity is fingerprinted from the resource config (including
+// the auto-generated REDIS_PASSWORD), so a fresh password each session produces a fresh
+// fingerprint and a fresh container while the previous one lingers as `Exited`. Lock state is
+// short-lived by design (30-min WOPI spec expiry), so there's no data-survival need that
+// would justify pinning the password to stabilise the fingerprint.
 if (builder.Configuration.GetValue("AppHost:UseRedisLocks", defaultValue: true))
 {
-    var redis = builder.AddRedis("wopi-locks")
-                       .WithLifetime(ContainerLifetime.Persistent);
+    var redis = builder.AddRedis("wopi-locks");
     wopiHost
         // Flip the sample's lock-provider discriminator so AddSampleLockProvider() dispatches to
         // Redis. Sample:LockProvider lives in the sample's appsettings (not WopiHost.Core's


### PR DESCRIPTION
## Summary

- Drops `ContainerLifetime.Persistent` from the `wopi-locks` Redis resource — Aspire's default Session lifetime is the right fit for the dev loop and avoids the orphaned-container drift we'd been accumulating.
- **Why Persistent was leaking containers:** Aspire fingerprints the persistent-resource identity from the resource config, which includes Aspire's auto-generated `REDIS_PASSWORD`. A fresh password each AppHost session produces a fresh fingerprint and a fresh container, while the previous one stays around as `Exited`. Four were observed on a single dev machine over the past week, all bit-identical except for the fingerprint hash.
- **Why not pin the password to stabilise the fingerprint:** lock state is short-lived by design (30-min WOPI spec expiry), so there's no real data-survival benefit to keeping Redis data across AppHost restarts. Session lifetime gets us a clean tear-down for free.

## Test plan

- [x] `dotnet build infra/WopiHost.AppHost` — 0 warnings, 0 errors
- [ ] Manual: `dotnet run --project infra/WopiHost.AppHost`, exercise an edit through the dashboard, then stop the AppHost — verify the `wopi-locks-*` container is gone (not just `Exited`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)