### PR TITLE
fix(redis): proactively evict expired locks on the CAS read path

### DIFF
--- a/src/WopiHost.RedisLockProvider/WopiRedisLockProvider.cs
+++ b/src/WopiHost.RedisLockProvider/WopiRedisLockProvider.cs
@@ -183,6 +183,18 @@ public sealed partial class WopiRedisLockProvider(
         var snapshot = Deserialize(raw!);
         if (snapshot.IsExpiredAt(_timeProvider.GetUtcNow()))
         {
+            // Proactively evict the stale record rather than waiting for Redis's TTL to reap it,
+            // so this CAS path cleans up on read like GetLockAsync and the Azure/Memory providers.
+            // (Under the fake-clock conformance tests the Redis server clock never moves, so the
+            // server-side EX would not evict at all.) The delete is guarded by the same
+            // value-equality condition the mutation path uses, so a sibling that refreshed or
+            // recreated the lock between our GET and here is never clobbered: the condition fails
+            // and the delete is skipped.
+            var evict = Db.CreateTransaction();
+            evict.AddCondition(Condition.StringEqual(key, raw));
+            _ = evict.KeyDeleteAsync(key);
+            _ = await evict.ExecuteAsync().ConfigureAwait(false);
+            LogLockExpired(_logger, fileId, snapshot.LockId);
             return false;
         }
         if (!_lockComparer.AreEqual(snapshot.LockId, expectedExistingLockId))

--- a/test/WopiHost.RedisLockProvider.Tests/WopiRedisLockProviderEvictionTests.cs
+++ b/test/WopiHost.RedisLockProvider.Tests/WopiRedisLockProviderEvictionTests.cs
@@ -1,0 +1,66 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using StackExchange.Redis;
+using WopiHost.Abstractions;
+using WopiHost.Abstractions.Testing;
+using Xunit;
+
+namespace WopiHost.RedisLockProvider.Tests;
+
+/// <summary>
+/// Redis-specific coverage that the compare-and-swap paths (<see cref="WopiRedisLockProvider.RefreshLockAsync"/>
+/// and <see cref="WopiRedisLockProvider.TryUnlockAndRelockAsync"/>) <em>proactively evict</em> an expired
+/// record instead of leaving it for Redis's TTL to reap.
+/// </summary>
+/// <remarks>
+/// The shared <see cref="LockProviderConformanceTests"/> already asserts these paths return <c>false</c>
+/// past expiry and that a follow-up <c>GetLockAsync</c> returns <c>null</c> — but <c>GetLockAsync</c>
+/// evicts on read too, so that black-box assertion can't tell whether the CAS path itself cleaned up.
+/// These tests reach past the abstraction and check the raw Redis key directly, so they fail if the CAS
+/// path regresses to relying on TTL / the next read. Under the fake clock the Redis server clock never
+/// moves, so the server-side <c>EX</c> would not evict at all — the only thing that can delete the key
+/// here is the provider's own eviction.
+/// </remarks>
+[Collection(RedisCollection.Name)]
+public sealed class WopiRedisLockProviderEvictionTests(RedisFixture redis)
+{
+    private async Task<(WopiRedisLockProvider Sut, IDatabase Db, RedisKey Key)> CreateAsync(
+        string fileId, ControllableTimeProvider clock)
+    {
+        var multiplexer = await redis.CreateMultiplexerAsync();
+        var prefix = $"wopi:lock:evict-test:{Guid.NewGuid():N}:";
+        var sut = new WopiRedisLockProvider(
+            multiplexer, NullLogger<WopiRedisLockProvider>.Instance, prefix, clock);
+        return (sut, multiplexer.GetDatabase(), prefix + fileId);
+    }
+
+    [Fact]
+    public async Task RefreshLockAsync_PastExpiry_DeletesTheRedisKey()
+    {
+        var clock = new ControllableTimeProvider(DateTimeOffset.UtcNow);
+        var fileId = $"refresh-evict-{Guid.NewGuid()}";
+        var (sut, db, key) = await CreateAsync(fileId, clock);
+        await sut.AddLockAsync(fileId, "lock-A");
+        Assert.True(await db.KeyExistsAsync(key));
+
+        clock.Now = clock.Now.AddMinutes(WopiLockInfo.ExpirationMinutes + 1);
+
+        Assert.False(await sut.RefreshLockAsync(fileId, expectedExistingLockId: "lock-A"));
+        // Key is gone because the CAS path evicted it — not because anything read it back.
+        Assert.False(await db.KeyExistsAsync(key));
+    }
+
+    [Fact]
+    public async Task TryUnlockAndRelockAsync_PastExpiry_DeletesTheRedisKey()
+    {
+        var clock = new ControllableTimeProvider(DateTimeOffset.UtcNow);
+        var fileId = $"swap-evict-{Guid.NewGuid()}";
+        var (sut, db, key) = await CreateAsync(fileId, clock);
+        await sut.AddLockAsync(fileId, "old-lock");
+        Assert.True(await db.KeyExistsAsync(key));
+
+        clock.Now = clock.Now.AddMinutes(WopiLockInfo.ExpirationMinutes + 1);
+
+        Assert.False(await sut.TryUnlockAndRelockAsync(fileId, "new-lock", expectedExistingLockId: "old-lock"));
+        Assert.False(await db.KeyExistsAsync(key));
+    }
+}


### PR DESCRIPTION
## Summary

Resolves one Low-severity item in #456 (the Redis "doesn''t proactively delete expired keys" finding). #456 is a multi-finding audit tracker, so this uses a non-closing reference and ticks the single checkbox rather than auto-closing the whole issue.

`RefreshLockAsync` / `TryUnlockAndRelockAsync` (both routed through `TryAtomicCasAsync`) detected an expired snapshot and returned `false`, but left the stale key resident — relying on Redis''s TTL, or the next `GetLockAsync`, to reap it. `GetLockAsync` (and the Azure / Memory providers) all clean up on read, so the Redis CAS path was the odd one out.

## Change

Evict the stale record inside `TryAtomicCasAsync`, **guarded by the same `Condition.StringEqual(key, raw)` CAS** the mutation path already uses — so a sibling that refreshed or recreated the lock between our `GET` and the delete is never clobbered (the condition fails, the delete is skipped). Also emits `LogLockExpired`, matching `GetLockAsync`.

This keeps TTL as the safety net but makes proactive cleanup consistent across all read paths and all three providers.

## Tests

The shared `LockProviderConformanceTests` already assert these paths return `false` past expiry and that a follow-up `GetLockAsync` returns `null` — but `GetLockAsync` evicts on read too, so that black-box check can''t prove the CAS path itself cleaned up.

Added `WopiRedisLockProviderEvictionTests` with two cases (`RefreshLockAsync` + `TryUnlockAndRelockAsync`) that inspect the **raw Redis key** via `KeyExistsAsync` after a past-expiry call. Under the fake clock the server-side `EX` never fires, so only the provider''s own delete can remove the key — the tests fail if the CAS path regresses to relying on TTL.

- `dotnet test test/WopiHost.RedisLockProvider.Tests` — **43 passed, 0 failed** (41 existing + 2 new), real Redis 7 container via Testcontainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)