### PR TITLE
refactor(core): extract PutUserInfo bounded body read into a ReadBytesAsync overload

### DIFF
--- a/src/WopiHost.Core/Endpoints/FileMutatingEndpoints.cs
+++ b/src/WopiHost.Core/Endpoints/FileMutatingEndpoints.cs
@@ -336,11 +336,11 @@ internal static class FileMutatingEndpoints
             return TypedResults.BadRequest();
         }
 
-        // Bounded read: returns null the moment the body exceeds the spec cap mid-stream (chunked
-        // transfer-encoding with no Content-Length, or clients that lie about it), so a malicious
-        // or buggy client can't push an unbounded body into our MemoryCache.
-        var bytes = await req.Http.Request.Body.ReadBytesAsync(PutUserInfoMaxBytes, req.CancellationToken).ConfigureAwait(false);
-        if (bytes is null)
+        // Bounded read: WithinLimit goes false the moment the body exceeds the spec cap mid-stream
+        // (chunked transfer-encoding with no Content-Length, or clients that lie about it), so a
+        // malicious or buggy client can't push an unbounded body into our MemoryCache.
+        var (withinLimit, bytes) = await req.Http.Request.Body.ReadBytesAsync(PutUserInfoMaxBytes, req.CancellationToken).ConfigureAwait(false);
+        if (!withinLimit)
         {
             return TypedResults.BadRequest();
         }

--- a/src/WopiHost.Core/Endpoints/FileMutatingEndpoints.cs
+++ b/src/WopiHost.Core/Endpoints/FileMutatingEndpoints.cs
@@ -336,23 +336,16 @@ internal static class FileMutatingEndpoints
             return TypedResults.BadRequest();
         }
 
-        // Read up to MAX+1 so we can detect bodies that exceed the cap mid-stream (chunked
-        // transfer-encoding with no Content-Length, or clients that lie about it). Single
-        // backing buffer — ReadAsync writes directly at the running offset, no intermediate
-        // chunk array or MemoryStream copy.
-        var buffer = new byte[PutUserInfoMaxBytes + 1];
-        var total = 0;
-        int read;
-        while ((read = await req.Http.Request.Body.ReadAsync(buffer.AsMemory(total), req.CancellationToken).ConfigureAwait(false)) > 0)
+        // Bounded read: returns null the moment the body exceeds the spec cap mid-stream (chunked
+        // transfer-encoding with no Content-Length, or clients that lie about it), so a malicious
+        // or buggy client can't push an unbounded body into our MemoryCache.
+        var bytes = await req.Http.Request.Body.ReadBytesAsync(PutUserInfoMaxBytes, req.CancellationToken).ConfigureAwait(false);
+        if (bytes is null)
         {
-            total += read;
-            if (total > PutUserInfoMaxBytes)
-            {
-                return TypedResults.BadRequest();
-            }
+            return TypedResults.BadRequest();
         }
 
-        var userInfo = System.Text.Encoding.UTF8.GetString(buffer, 0, total);
+        var userInfo = System.Text.Encoding.UTF8.GetString(bytes);
 
         req.MemoryCache.Set(
             $"{UserInfoCacheKeyPrefix}{req.Http.User.GetUserId()}",

--- a/src/WopiHost.Core/Extensions/Extensions.cs
+++ b/src/WopiHost.Core/Extensions/Extensions.cs
@@ -23,6 +23,42 @@ internal static class Extensions
     }
 
     /// <summary>
+    /// Reads the stream into a byte array but bails out as soon as it sees more than
+    /// <paramref name="maxBytes"/> bytes, returning <c>null</c> — so an oversized (or unbounded
+    /// chunked) body can be rejected without ever buffering it in full. Prefer this over the
+    /// unbounded <see cref="ReadBytesAsync(Stream, CancellationToken)"/> whenever the caller
+    /// enforces a size cap (e.g. the spec-defined PutUserInfo limit).
+    /// </summary>
+    /// <param name="input">Stream to read from.</param>
+    /// <param name="maxBytes">Maximum number of bytes to accept.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The body bytes (length &lt;= <paramref name="maxBytes"/>), or <c>null</c> if the stream
+    /// yielded more than <paramref name="maxBytes"/> bytes.
+    /// </returns>
+    public static async Task<byte[]?> ReadBytesAsync(this Stream input, int maxBytes, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentOutOfRangeException.ThrowIfNegative(maxBytes);
+
+        // Single backing buffer sized to maxBytes+1 so the read that pushes us past the cap trips
+        // the limit — ReadAsync writes directly at the running offset, no intermediate chunk array
+        // or MemoryStream copy, and the allocation can never exceed maxBytes+1.
+        var buffer = new byte[maxBytes + 1];
+        var total = 0;
+        int read;
+        while ((read = await input.ReadAsync(buffer.AsMemory(total), cancellationToken).ConfigureAwait(false)) > 0)
+        {
+            total += read;
+            if (total > maxBytes)
+            {
+                return null;
+            }
+        }
+        return buffer[..total];
+    }
+
+    /// <summary>
     /// Tries to parse integer from string. Returns null if parsing fails.
     /// </summary>
     /// <param name="s">String to parse</param>

--- a/src/WopiHost.Core/Extensions/Extensions.cs
+++ b/src/WopiHost.Core/Extensions/Extensions.cs
@@ -24,19 +24,21 @@ internal static class Extensions
 
     /// <summary>
     /// Reads the stream into a byte array but bails out as soon as it sees more than
-    /// <paramref name="maxBytes"/> bytes, returning <c>null</c> — so an oversized (or unbounded
-    /// chunked) body can be rejected without ever buffering it in full. Prefer this over the
-    /// unbounded <see cref="ReadBytesAsync(Stream, CancellationToken)"/> whenever the caller
-    /// enforces a size cap (e.g. the spec-defined PutUserInfo limit).
+    /// <paramref name="maxBytes"/> bytes — so an oversized (or unbounded chunked) body can be
+    /// rejected without ever buffering it in full. Prefer this over the unbounded
+    /// <see cref="ReadBytesAsync(Stream, CancellationToken)"/> whenever the caller enforces a
+    /// size cap (e.g. the spec-defined PutUserInfo limit).
     /// </summary>
     /// <param name="input">Stream to read from.</param>
     /// <param name="maxBytes">Maximum number of bytes to accept.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>
-    /// The body bytes (length &lt;= <paramref name="maxBytes"/>), or <c>null</c> if the stream
-    /// yielded more than <paramref name="maxBytes"/> bytes.
+    /// <c>WithinLimit</c> is <c>true</c> with the body bytes (length &lt;= <paramref name="maxBytes"/>)
+    /// when the stream stayed within the cap; <c>false</c> with an empty array when it yielded more
+    /// than <paramref name="maxBytes"/> bytes. A value-tuple rather than a nullable array so the
+    /// result never carries a null that callers (or static analysis) have to reason about.
     /// </returns>
-    public static async Task<byte[]?> ReadBytesAsync(this Stream input, int maxBytes, CancellationToken cancellationToken = default)
+    public static async Task<(bool WithinLimit, byte[] Bytes)> ReadBytesAsync(this Stream input, int maxBytes, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(input);
         ArgumentOutOfRangeException.ThrowIfNegative(maxBytes);
@@ -52,10 +54,10 @@ internal static class Extensions
             total += read;
             if (total > maxBytes)
             {
-                return null;
+                return (false, []);
             }
         }
-        return buffer[..total];
+        return (true, buffer[..total]);
     }
 
     /// <summary>

--- a/test/WopiHost.Core.Tests/Extensions/ExtensionsTests.cs
+++ b/test/WopiHost.Core.Tests/Extensions/ExtensionsTests.cs
@@ -34,6 +34,53 @@ public class ExtensionsTests
     }
 
     [Fact]
+    public async Task ReadBytesAsync_WithCap_WithinLimit_ReturnsContents()
+    {
+        var content = "hello"u8.ToArray();
+        using var input = new MemoryStream(content);
+
+        var result = await input.ReadBytesAsync(maxBytes: 1024);
+
+        Assert.Equal(content, result);
+    }
+
+    [Fact]
+    public async Task ReadBytesAsync_WithCap_ExactlyAtLimit_ReturnsContents()
+    {
+        // A body whose length equals the cap must be accepted (the cap is inclusive).
+        var content = new byte[16];
+        using var input = new MemoryStream(content);
+
+        var result = await input.ReadBytesAsync(maxBytes: 16);
+
+        Assert.NotNull(result);
+        Assert.Equal(16, result!.Length);
+    }
+
+    [Fact]
+    public async Task ReadBytesAsync_WithCap_OverLimit_ReturnsNull()
+    {
+        // One byte past the cap trips the limit and yields null — without buffering the rest.
+        var content = new byte[17];
+        using var input = new MemoryStream(content);
+
+        var result = await input.ReadBytesAsync(maxBytes: 16);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ReadBytesAsync_WithCap_EmptyStream_ReturnsEmpty()
+    {
+        using var input = new MemoryStream([]);
+
+        var result = await input.ReadBytesAsync(maxBytes: 16);
+
+        Assert.NotNull(result);
+        Assert.Empty(result!);
+    }
+
+    [Fact]
     public void ToNullableInt_ValidInteger_ReturnsParsedValue()
     {
         Assert.Equal(42, "42".ToNullableInt());

--- a/test/WopiHost.Core.Tests/Extensions/ExtensionsTests.cs
+++ b/test/WopiHost.Core.Tests/Extensions/ExtensionsTests.cs
@@ -39,9 +39,10 @@ public class ExtensionsTests
         var content = "hello"u8.ToArray();
         using var input = new MemoryStream(content);
 
-        var result = await input.ReadBytesAsync(maxBytes: 1024);
+        var (withinLimit, bytes) = await input.ReadBytesAsync(maxBytes: 1024);
 
-        Assert.Equal(content, result);
+        Assert.True(withinLimit);
+        Assert.Equal(content, bytes);
     }
 
     [Fact]
@@ -51,22 +52,23 @@ public class ExtensionsTests
         var content = new byte[16];
         using var input = new MemoryStream(content);
 
-        var result = await input.ReadBytesAsync(maxBytes: 16);
+        var (withinLimit, bytes) = await input.ReadBytesAsync(maxBytes: 16);
 
-        Assert.NotNull(result);
-        Assert.Equal(16, result!.Length);
+        Assert.True(withinLimit);
+        Assert.Equal(16, bytes.Length);
     }
 
     [Fact]
-    public async Task ReadBytesAsync_WithCap_OverLimit_ReturnsNull()
+    public async Task ReadBytesAsync_WithCap_OverLimit_ReturnsNotWithinLimit()
     {
-        // One byte past the cap trips the limit and yields null — without buffering the rest.
+        // One byte past the cap trips the limit — WithinLimit is false and the rest isn't buffered.
         var content = new byte[17];
         using var input = new MemoryStream(content);
 
-        var result = await input.ReadBytesAsync(maxBytes: 16);
+        var (withinLimit, bytes) = await input.ReadBytesAsync(maxBytes: 16);
 
-        Assert.Null(result);
+        Assert.False(withinLimit);
+        Assert.Empty(bytes);
     }
 
     [Fact]
@@ -74,10 +76,10 @@ public class ExtensionsTests
     {
         using var input = new MemoryStream([]);
 
-        var result = await input.ReadBytesAsync(maxBytes: 16);
+        var (withinLimit, bytes) = await input.ReadBytesAsync(maxBytes: 16);
 
-        Assert.NotNull(result);
-        Assert.Empty(result!);
+        Assert.True(withinLimit);
+        Assert.Empty(bytes);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Resolves one Low-severity item in #456 (the "`PutUserInfo` reads request body with manual buffer loop" finding). #456 is a multi-finding audit tracker, so this uses a non-closing reference and ticks the single checkbox rather than auto-closing the whole issue.

## The subtlety

The audit suggested reusing the existing `ReadBytesAsync` helper. But that helper does an **unbounded** `CopyToAsync` into a `MemoryStream` — whereas `PutUserInfo`''s manual loop is deliberately **bounded** at the spec''s 1024-byte cap, rejecting oversized bodies mid-stream so a malicious/buggy client can''t push an unbounded body into `MemoryCache`. A naive swap to the existing helper would have **removed the size cap** — a security regression.

## Change

Instead of dropping the cap, I lifted the bounded-read loop into a new **`ReadBytesAsync(this Stream, int maxBytes, …)`** overload on the same `Extensions` helper:

- Single backing buffer of `maxBytes + 1`; `ReadAsync` writes at the running offset — no intermediate chunk array or `MemoryStream`, allocation can never exceed `maxBytes + 1`.
- Returns a non-nullable value-tuple `(bool WithinLimit, byte[] Bytes)`; `WithinLimit` goes `false` the moment the body exceeds the cap (handles chunked transfer-encoding with no `Content-Length`, or a lying `Content-Length`). A tuple rather than `byte[]?` so no null value flows to the caller — this also keeps Infer# clean (awaiting a static async helper that can return null, then dereferencing past an `is null` guard, is a documented Infer# false-positive pattern the project fixes by restructuring, per `.github/infer-allowlist.txt`).

`PutUserInfo` now destructures the tuple and maps `!WithinLimit` → `BadRequest`, keeping the cheap `Content-Length` fast-fail as an early-out. The endpoint loses its hand-rolled loop **without** losing the cap, and the bounded read becomes a reusable, unit-tested primitive (the unbounded overload stays for the file-content callers that legitimately need the whole body).

## Tests

- **4 new `ExtensionsTests`** for the overload: within-limit, exactly-at-limit (inclusive), over-limit → `null`, empty stream.
- `dotnet test test/WopiHost.Core.Tests` — **57 passed, 0 failed**.
- `dotnet test test/WopiHost.IntegrationTests --filter PutUserInfo` — **3 passed, 0 failed** (200 happy-path, over-limit 400, 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
