### PR TITLE
Align FileSystem storage provider on Singleton DI lifetime

### DIFF
--- a/src/WopiHost.FileSystemProvider/ServiceCollectionExtensions.cs
+++ b/src/WopiHost.FileSystemProvider/ServiceCollectionExtensions.cs
@@ -33,9 +33,13 @@ public static class ServiceCollectionExtensions
             .ValidateOnStart();
 
         services.TryAddSingleton<InMemoryFileIds>();
-        services.AddScoped<WopiFileSystemProvider>();
-        services.AddScoped<IWopiStorageProvider>(sp => sp.GetRequiredService<WopiFileSystemProvider>());
-        services.AddScoped<IWopiWritableStorageProvider>(sp => sp.GetRequiredService<WopiFileSystemProvider>());
+        // Singleton, matching AddAzureStorageProvider. The provider is a stateless wrapper:
+        // after construction it holds only immutable fields, depends solely on singletons
+        // (InMemoryFileIds, IHostEnvironment, IConfiguration, ILogger) — so no scoped captive
+        // dependency — and routes all mutable state through the thread-safe InMemoryFileIds.
+        services.AddSingleton<WopiFileSystemProvider>();
+        services.AddSingleton<IWopiStorageProvider>(sp => sp.GetRequiredService<WopiFileSystemProvider>());
+        services.AddSingleton<IWopiWritableStorageProvider>(sp => sp.GetRequiredService<WopiFileSystemProvider>());
 
         return services;
     }

--- a/test/WopiHost.FileSystemProvider.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,118 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using WopiHost.Abstractions;
+
+namespace WopiHost.FileSystemProvider.Tests;
+
+public class ServiceCollectionExtensionsTests : IDisposable
+{
+    private readonly DirectoryInfo _tempDir = Directory.CreateTempSubdirectory("FsProviderDiTest_");
+
+    public void Dispose()
+    {
+        _tempDir.Refresh();
+        if (_tempDir.Exists) _tempDir.Delete(recursive: true);
+        GC.SuppressFinalize(this);
+    }
+
+    private static IConfiguration BuildConfig(Dictionary<string, string?> values)
+        => new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+
+    private IServiceCollection BuildServices(out IConfiguration config)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddSingleton<IHostEnvironment>(new FakeHostEnvironment { ContentRootPath = _tempDir.FullName });
+        config = BuildConfig(new()
+        {
+            ["Wopi:StorageProvider:RootPath"] = _tempDir.FullName,
+        });
+        // The provider constructor resolves IConfiguration from DI (separate from the options
+        // binding wired up inside AddFileSystemStorageProvider), so it must be registered too.
+        services.AddSingleton(config);
+        return services;
+    }
+
+    [Fact]
+    public void AddFileSystemStorageProvider_RegistersProviderAndInterfacesAsSingleton()
+    {
+        // The whole point of this test: the FS provider must be a singleton, matching
+        // AddAzureStorageProvider. Guards against re-introducing the scoped/singleton drift.
+        var services = BuildServices(out var config);
+
+        services.AddFileSystemStorageProvider(config);
+
+        foreach (var serviceType in new[]
+                 {
+                     typeof(WopiFileSystemProvider),
+                     typeof(IWopiStorageProvider),
+                     typeof(IWopiWritableStorageProvider),
+                 })
+        {
+            var descriptor = Assert.Single(services, d => d.ServiceType == serviceType);
+            Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+        }
+    }
+
+    [Fact]
+    public void AddFileSystemStorageProvider_BothInterfaces_ResolveSameInstanceAcrossScopes()
+    {
+        var services = BuildServices(out var config);
+        services.AddFileSystemStorageProvider(config);
+
+        using var sp = services.BuildServiceProvider();
+        using var scope1 = sp.CreateScope();
+        using var scope2 = sp.CreateScope();
+
+        var storage = scope1.ServiceProvider.GetRequiredService<IWopiStorageProvider>();
+        var writable = scope1.ServiceProvider.GetRequiredService<IWopiWritableStorageProvider>();
+        var storageOtherScope = scope2.ServiceProvider.GetRequiredService<IWopiStorageProvider>();
+
+        Assert.IsType<WopiFileSystemProvider>(storage);
+        // Both interfaces resolve to the one provider instance...
+        Assert.Same(storage, writable);
+        // ...and that instance is shared across scopes (singleton semantics, not scoped).
+        Assert.Same(storage, storageOtherScope);
+    }
+
+    [Fact]
+    public void AddFileSystemStorageProvider_MissingRootPath_FailsValidation()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        var config = BuildConfig([]);
+
+        services.AddFileSystemStorageProvider(config);
+
+        using var sp = services.BuildServiceProvider();
+        var ex = Assert.Throws<Microsoft.Extensions.Options.OptionsValidationException>(
+            () => sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<WopiFileSystemProviderOptions>>().Value);
+        Assert.Contains("RootPath", ex.Message);
+    }
+
+    [Fact]
+    public void AddFileSystemStorageProvider_NullArgs_Throw()
+    {
+        var services = new ServiceCollection();
+        var config = BuildConfig([]);
+
+        Assert.Throws<ArgumentNullException>(
+            () => ServiceCollectionExtensions.AddFileSystemStorageProvider(null!, config));
+        Assert.Throws<ArgumentNullException>(
+            () => services.AddFileSystemStorageProvider(null!));
+    }
+
+    private sealed class FakeHostEnvironment : IHostEnvironment
+    {
+        public string ApplicationName { get; set; } = "tests";
+        public string EnvironmentName { get; set; } = "Development";
+        public string ContentRootPath { get; set; } = "";
+        public IFileProvider ContentRootFileProvider { get; set; } = null!;
+    }
+}

--- a/test/WopiHost.FileSystemProvider.Tests/WopiHost.FileSystemProvider.Tests.csproj
+++ b/test/WopiHost.FileSystemProvider.Tests/WopiHost.FileSystemProvider.Tests.csproj
@@ -8,6 +8,8 @@
 	<ItemGroup>
 		<PackageReference Include="Moq" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
 	</ItemGroup>
 	<ItemGroup>
 	  <PackageReference Update="coverlet.collector">


### PR DESCRIPTION
## Problem

Storage providers diverged on DI lifetime (from the #493 backlog, flagged **[verified]**):

- `WopiHost.FileSystemProvider/ServiceCollectionExtensions.cs` registered with **`AddScoped`**
- `WopiHost.AzureStorageProvider/ServiceCollectionExtensions.cs` registered with **`AddSingleton`**

Same interfaces (`IWopiStorageProvider` / `IWopiWritableStorageProvider`), both stateless wrappers around external state — no reason to differ.

## Fix

Align the FileSystem provider on **`Singleton`**, matching Azure. This is safe:

- `WopiFileSystemProvider` holds only immutable fields after construction (`_wopiAbsolutePath`, `RootContainer`, injected singletons).
- Its constructor depends solely on singletons — `InMemoryFileIds`, `IHostEnvironment`, `IConfiguration`, `ILogger` — so there's **no scoped captive dependency**.
- All mutable state lives in `InMemoryFileIds`, which is already a thread-safe singleton (`ConcurrentDictionary` + a write lock), so concurrent access through a single provider instance is fine.

Added a brief comment at the registration site documenting why the lifetime is Singleton.

## Tests

New `WopiHost.FileSystemProvider.Tests/ServiceCollectionExtensionsTests` (mirrors the Azure provider's DI test) that:

- **Locks in the lifetime** — asserts the provider and both interfaces are registered `Singleton` (the regression guard for this issue).
- Verifies both interfaces resolve to **one instance shared across scopes** (singleton semantics, not scoped).
- Covers options validation (missing `RootPath`) and null-arg guards.

All FS provider tests (116) and integration tests (120, 5 OIDC skipped) pass; full solution builds clean under warnings-as-errors.

Refs #493 (resolves the "Storage providers diverge on DI lifetime" item; tracker has other open items so this PR doesn't close it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)