### PR TITLE
Codebase-wide comment cleanup + comment style rules

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -40,16 +40,13 @@ jobs:
       with:
         oidc: true
         # Coverlet's MSBuild integration emits `coverage.info` per project at
-        # `test/<Project>/coverage.info`. The earlier `**/coverage.*.info` pattern silently
-        # matched nothing (required a label between the dots); `**/coverage.info` also
-        # didn't match through qlty-action's @actions/glob layer despite codecov's own
-        # discovery finding the same files. Root the glob explicitly under `test/` so
-        # the @actions/glob library has an anchored starting directory.
+        # `test/<Project>/coverage.info`. Root the glob explicitly under `test/` so
+        # qlty-action's @actions/glob layer has an anchored starting directory.
         files: "test/**/coverage.info"
         # Coverlet's lcov references source-generated files (LoggerMessage.g.cs,
         # LibraryImports.g.cs, etc.) under artifacts/obj/, which don't exist at
-        # publish time. Without this flag Qlty counts them as 0% covered, hence
-        # the ~74% vs Codecov's ~93% disparity. See also .qlty/qlty.toml.
+        # publish time. Without this flag Qlty counts them as 0% covered. See also
+        # .qlty/qlty.toml.
         skip-missing-files: true
     - name: Codecov
       uses: codecov/codecov-action@v6
@@ -73,8 +70,6 @@ jobs:
       matrix:
         # windows-latest: ACL owner path.
         # macos-latest: Apple Silicon (arm64) -> plain `stat` symbol.
-        # The Intel (x86_64) `stat$INODE64` path is exercised only via Rosetta and is
-        # left untested here — the macos-13 runner was dropped to keep CI lean.
         os: [windows-latest, macos-latest]
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -81,8 +81,6 @@ jobs:
       matrix:
         # windows-latest: ACL owner path.
         # macos-latest: Apple Silicon (arm64) -> plain `stat` symbol.
-        # The Intel (x86_64) `stat$INODE64` path is exercised only via Rosetta and is
-        # left untested here — the macos-13 runner was dropped to keep CI lean.
         os: [windows-latest, macos-latest]
     environment:
       name: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'Integrate Pull Request' || '' }}
@@ -122,7 +120,7 @@ jobs:
       run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> $GITHUB_ENV
     - name: Pack PR nupkgs
       # Use a high version so AssemblyVersion sorts above any baseline release (avoids CP0003 noise).
-      # PackageValidation is intentionally disabled here — we run ApiCompat directly below.
+      # PackageValidation is disabled here because ApiCompat runs directly below.
       run: |
         dotnet pack --configuration Release \
           -p:ContinuousIntegrationBuild=true \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,13 @@ dotnet run --project sample/WopiHost
 ## Code Style & Build Rules
 
 - **Warnings as errors** is enabled globally (`TreatWarningsAsErrors`).
+- **Comment style** (applies to `//` comments and the prose inside `///` XML docs):
+  - Write in third person. Never "we"/"our"/"let's" — describe what the code does ("Resolves the owner"), not what the author did.
+  - Comment only what is genuinely non-obvious or surprising to a new reader: a gotcha, an ABI/spec quirk, a non-local invariant. If the code is self-explanatory, leave no comment.
+  - No meta-commentary: don't justify a choice to a reviewer, don't narrate how the code used to be, don't say "matching X" / "changed to Y".
+  - Never reference GitHub issues or PRs by number (`#123`). If the context matters, inline the explanation itself.
+  - Keep comments short and concrete; prefer deleting a comment to padding it.
+  - Keep the `///` XML doc tags on public APIs (warnings-as-errors require them), but trim their wording to the same bar.
 - .NET analyzers and code style enforcement are on (`EnforceCodeStyleInBuild`).
 - Follow [.NET Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/).
 - Centralized package management via `Directory.Packages.props` — specify versions there, not in individual `.csproj` files.

--- a/infra/WopiHost.AppHost/Program.cs
+++ b/infra/WopiHost.AppHost/Program.cs
@@ -12,10 +12,9 @@ var builder = DistributedApplication.CreateBuilder(args);
 //
 // ASPNETCORE_HOSTINGSTARTUPEXCLUDEASSEMBLIES is the documented opposite of the include list
 // (https://learn.microsoft.com/aspnet/core/fundamentals/host/platform-specific-configuration):
-// the host removes named assemblies from the discovered set before attempting to load. We use
-// it here in preference to clearing the include list outright so any legitimate hosting-startup
-// assembly an Aspire user (or a child project's own appsettings) adds keeps working — the fix
-// is scoped to the two known dev-tooling offenders.
+// the host removes named assemblies from the discovered set before attempting to load. Excluding
+// the two known dev-tooling offenders (rather than clearing the include list outright) keeps any
+// legitimate hosting-startup assembly an Aspire user or child project adds working.
 static IResourceBuilder<ProjectResource> ExcludeVsHostingStartups(IResourceBuilder<ProjectResource> p) =>
     p.WithEnvironment(
         "ASPNETCORE_HOSTINGSTARTUPEXCLUDEASSEMBLIES",
@@ -23,7 +22,7 @@ static IResourceBuilder<ProjectResource> ExcludeVsHostingStartups(IResourceBuild
 
 // WOPI backend.
 //
-// Port: pinned to 5050. Kestrel binds directly (isProxied: false) so the URL we hand other
+// Port: pinned to 5050. Kestrel binds directly (isProxied: false) so the URL handed to other
 // resources is the real host-side TCP socket. Direct binding matters for the Collabora dev
 // loop specifically — Collabora-in-Docker reaches the backend via host.docker.internal:5050,
 // and that has to be a port the host kernel is actually listening on (Aspire's reverse proxy
@@ -34,21 +33,20 @@ static IResourceBuilder<ProjectResource> ExcludeVsHostingStartups(IResourceBuild
 // `SocketException 10013 (WSAEACCES) — An attempt was made to access a socket in a way
 // forbidden by its access permissions`, even though `netstat` shows nothing listening. Check
 // the local exclusions with `netsh int ipv4 show excludedportrange protocol=tcp` if 5050 is
-// also unavailable on your machine; move to another free port and update Collabora's "domain"
-// regex below in lockstep.
+// also unavailable; move to another free port and update Collabora's "domain" regex below in
+// lockstep.
 //
 // Why pin the port at all rather than let Aspire allocate? In Aspire 13.x, WithHttpEndpoint
 // with isProxied: false and no port silently hangs the AppHost during graph construction —
-// the dashboard's web server never starts. Reproduced cleanly: removing port: here leaves
-// startup stuck after "Application host directory is: …" with no further output. Pinning a
-// port is the only working combo today. Downstream consumers still read this through a
-// ReferenceExpression so the literal port only appears in two colocated places.
+// startup sticks after "Application host directory is: …" and the dashboard's web server never
+// starts. Downstream consumers still read this through a ReferenceExpression so the literal
+// port only appears in two colocated places.
 //
 // launchProfileName: null bypasses sample/WopiHost/Properties/launchSettings.json so the
-// AppHost is the single source of truth for backend configuration. We re-inject the one
-// load-bearing setting — ASPNETCORE_ENVIRONMENT=Development — explicitly, because
-// sample/WopiHost's Program.cs refuses to honour Wopi:Security:DisableProofValidation
-// outside Development (and the Collabora block below flips that flag on).
+// AppHost is the single source of truth for backend configuration. ASPNETCORE_ENVIRONMENT=
+// Development is re-injected explicitly because sample/WopiHost's Program.cs refuses to honour
+// Wopi:Security:DisableProofValidation outside Development (and the Collabora block below flips
+// that flag on).
 var wopiHost = ExcludeVsHostingStartups(builder.AddProject<Projects.WopiHost>("wopihost", launchProfileName: null))
                       .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Development")
                       .WithHttpEndpoint(name: "wopihost-http", port: 5050, isProxied: false)
@@ -93,12 +91,12 @@ if (builder.Configuration.GetValue<bool>("AppHost:UseAzureStorage"))
 // connections.
 //
 // Lifetime defaults to Session (Aspire's default) so the container is torn down on AppHost
-// shutdown. Persistent lifetime was tried but accumulated orphaned containers across runs:
-// Aspire's persistent-resource identity is fingerprinted from the resource config (including
-// the auto-generated REDIS_PASSWORD), so a fresh password each session produces a fresh
-// fingerprint and a fresh container while the previous one lingers as `Exited`. Lock state is
-// short-lived by design (30-min WOPI spec expiry), so there's no data-survival need that
-// would justify pinning the password to stabilise the fingerprint.
+// shutdown. Persistent lifetime accumulates orphaned containers across runs: Aspire's
+// persistent-resource identity is fingerprinted from the resource config (including the
+// auto-generated REDIS_PASSWORD), so a fresh password each session produces a fresh fingerprint
+// and a fresh container while the previous one lingers as `Exited`. Lock state is short-lived by
+// design (30-min WOPI spec expiry), so there's no data-survival need that would justify pinning
+// the password to stabilise the fingerprint.
 if (builder.Configuration.GetValue("AppHost:UseRedisLocks", defaultValue: true))
 {
     var redis = builder.AddRedis("wopi-locks");
@@ -123,8 +121,8 @@ var useCollabora = builder.Configuration.GetValue<bool>("AppHost:UseCollabora");
 var wopiBackendHostForFrontends = useCollabora ? "host.docker.internal" : "localhost";
 
 // Frontends: project references via WithReference give Aspire's service-discovery env vars
-// (services__wopihost__http__0=...), but the existing frontend code reads Wopi:HostUrl directly
-// from IConfiguration — so we ALSO inject Wopi__HostUrl pointing at the same backend port. That
+// (services__wopihost__http__0=...), but the frontend code reads Wopi:HostUrl directly from
+// IConfiguration — so Wopi__HostUrl is ALSO injected, pointing at the same backend port. That
 // way the AppHost owns the URL end-to-end and the frontend's appsettings.json HostUrl entry is
 // only the production default.
 //
@@ -204,26 +202,22 @@ if (useCollabora)
            .WithContainerRuntimeArgs("--add-host", "host.docker.internal:host-gateway")
            // WOPI hosts Collabora is allowed to call back to. coolwsd matches this regex against
            // the WopiSrc host with std::regex_match (full-string match), and the host it sees
-           // carries the port — "host.docker.internal:5050". That's why earlier iterations with
-           // a bare "host\.docker\.internal" 401'd ("websocketunauthorized" / "Unauthorized WOPI
-           // host"): the ":5050" suffix left the full match unsatisfied. Anchoring the known dev
-           // host as a prefix and absorbing the port (or any path) with a trailing ".*" keeps the
-           // pattern scoped to host.docker.internal instead of waving through every hostname.
-           // The "host\.docker\.internal:5050" attempt that also 401'd predates the trace logging
-           // below; if this narrowed form ever regresses, that trace surfaces the exact host
-           // string coolwsd matched against so the regex can be fixed against real data rather
-           // than guessed — see the --o:logging.level=trace note.
+           // carries the port — "host.docker.internal:5050". A bare "host\.docker\.internal" 401s
+           // ("websocketunauthorized" / "Unauthorized WOPI host") because the ":5050" suffix
+           // leaves the full match unsatisfied. Anchoring the known dev host as a prefix and
+           // absorbing the port (or any path) with a trailing ".*" keeps the pattern scoped to
+           // host.docker.internal instead of waving through every hostname. If this narrowed form
+           // regresses, the trace logging below surfaces the exact host string coolwsd matched
+           // against — see the --o:logging.level=trace note.
            .WithEnvironment("domain", @"host\.docker\.internal.*")
            // --o:logging.level=trace so the container log shows the actual host string being
            // matched against (and why the match fails). The CI workflow captures container
-           // logs on failure, so a future run with this trace level will surface coolwsd's
-           // own diagnosis instead of leaving us guessing.
+           // logs on failure, so a failing run surfaces coolwsd's own diagnosis.
            //
-           // Earlier iteration also set --o:logging.protocol=true. That flag traces HTTP
-           // request and response bodies, including the /hosting/discovery response — which
-           // is ~600+ lines of <app>/<action> XML. With docker logs --tail set to anything
-           // reasonable, the XML pushed coolwsd's own WebSocket-auth log lines off the tail
-           // and left us blind. Trace level alone is enough to surface the matching attempt.
+           // Do NOT also set --o:logging.protocol=true: that flag traces HTTP request and response
+           // bodies, including the /hosting/discovery response (~600+ lines of <app>/<action>
+           // XML), which pushes coolwsd's own WebSocket-auth log lines off the docker logs --tail.
+           // Trace level alone is enough to surface the matching attempt.
            .WithEnvironment("extra_params", "--o:ssl.enable=false --o:ssl.termination=false --o:logging.level=trace")
            .WithHttpEndpoint(targetPort: 9980, port: 9980, name: "collabora")
            .WithHttpHealthCheck("/hosting/discovery", endpointName: "collabora");
@@ -235,9 +229,9 @@ if (useCollabora)
     // port even though the AppHost asks for 9980. With a reference, the URL the projects see
     // tracks whatever Aspire actually allocated, in both normal and test runs.
     //
-    // This is the OPPOSITE direction of the documented "container env var → project endpoint
-    // port reference wedges Aspire 13.x" footgun (the `domain` literal above). Here we're
-    // referencing a container endpoint from a project env var, which works fine.
+    // This is the OPPOSITE direction of the "container env var → project endpoint port reference
+    // wedges Aspire 13.x" footgun (the `domain` literal above): referencing a container endpoint
+    // from a project env var works fine.
     var collaboraUrl = collabora.GetEndpoint("collabora");
 
     // Backend: fetches /hosting/discovery from Collabora at startup. Collabora does not sign WOPI

--- a/sample/WopiHost.Validator/Infrastructure/SentinelOrJwtAccessTokenService.cs
+++ b/sample/WopiHost.Validator/Infrastructure/SentinelOrJwtAccessTokenService.cs
@@ -12,10 +12,8 @@ namespace WopiHost.Validator.Infrastructure;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The Microsoft WOPI validator harness in <c>.github/workflows/wopi-validator.yml</c> is
-/// configured (on the master branch) to pass the literal string <c>"Anonymous"</c> as
-/// <c>--token</c>. The <c>pull_request_target</c> trigger uses the workflow from master, so
-/// until that file is updated we need the host to accept that sentinel — otherwise
+/// The Microsoft WOPI validator harness passes the literal string <c>"Anonymous"</c> as
+/// <c>--token</c>, so the host must accept that sentinel — otherwise
 /// CheckFileInfo returns 401 on every WOPI test and nothing runs.
 /// </para>
 /// <para>

--- a/sample/WopiHost.Validator/Infrastructure/ServiceCollectionExtensions.cs
+++ b/sample/WopiHost.Validator/Infrastructure/ServiceCollectionExtensions.cs
@@ -33,27 +33,22 @@ public static class ServiceCollectionExtensions
     }
     public static IServiceCollection AddWopiServer(this IServiceCollection services, IConfiguration configuration)
     {
-        // ------ add Wopi Server .Core services
-
-        // Configuration
         services.Configure<WopiHostOptions>(configuration.GetSection(WopiHostOptions.SectionName));
-        // Add file provider
         services.AddSingleton<InMemoryFileIds>();
         services.AddSingleton<IWopiStorageProvider, WopiFileSystemProvider>();
         services.AddSingleton<IWopiWritableStorageProvider, WopiFileSystemProvider>();
-        // Add lock provider
         services.AddSingleton<IWopiLockProvider, MemoryLockProvider.MemoryLockProvider>();
-        // Add WOPI; the validator plugs in its own IWopiHostExtensions to populate the
-        // optional CheckFileInfo URLs the Microsoft validator probes for.
+        // The validator plugs in its own IWopiHostExtensions to populate the optional
+        // CheckFileInfo URLs the Microsoft validator probes for.
         services.AddSingleton<IWopiHostExtensions, WopiValidatorExtensions>();
         services.AddWopi();
-        // Validator runs against a known fixed signing key so tests are reproducible across restarts.
+        // A fixed signing key keeps tests reproducible across restarts.
         services.ConfigureWopiSecurity(o =>
         {
             o.SigningKey = JwtAccessTokenService.DeriveHmacKey("wopi-validator-dev-key");
         });
         // Wrap the default JwtAccessTokenService so the Microsoft WOPI validator's literal-string
-        // token (configured in the GitHub workflow on master) is accepted alongside real JWTs.
+        // token is accepted alongside real JWTs.
         services.AddSingleton<JwtAccessTokenService>();
         services.AddSingleton<IWopiAccessTokenService, SentinelOrJwtAccessTokenService>();
         return services;
@@ -61,7 +56,6 @@ public static class ServiceCollectionExtensions
 
     public static IServiceCollection AddWopiHostPages(this IServiceCollection services, IConfiguration configuration)
     {
-        // ------- add Wopi Host services
         services.Configure<DiscoveryOptions>(configuration.GetSection(DiscoveryOptions.SectionName));
         services.Configure<WopiOptions>(configuration.GetSection(WopiOptions.SectionName));
 

--- a/sample/WopiHost.Validator/Infrastructure/WopiValidatorExtensions.cs
+++ b/sample/WopiHost.Validator/Infrastructure/WopiValidatorExtensions.cs
@@ -5,8 +5,7 @@ namespace WopiHost.Validator.Infrastructure;
 /// <summary>
 /// Validator-specific <see cref="IWopiHostExtensions"/>. The Microsoft WOPI-Validator suite
 /// checks for several optional CheckFileInfo URLs (<c>HostEditUrl</c>, <c>BreadcrumbBrandUrl</c>,
-/// etc.) on the canonical <c>.wopitest</c> probe file; populating them here keeps the test
-/// matrix green.
+/// etc.) on the canonical <c>.wopitest</c> probe file, which are populated here.
 /// </summary>
 public class WopiValidatorExtensions : WopiHostExtensions
 {
@@ -18,7 +17,7 @@ public class WopiValidatorExtensions : WopiHostExtensions
         wopiCheckFileInfo.AllowAdditionalMicrosoftServices = true;
         wopiCheckFileInfo.AllowErrorReportPrompt = true;
 
-        // ##183 required for WOPI-Validator
+        // Required for the WOPI-Validator probe file.
         if (wopiCheckFileInfo.BaseFileName.EndsWith(".wopitest", StringComparison.OrdinalIgnoreCase))
         {
             wopiCheckFileInfo.CloseUrl = new("https://example.com/close");

--- a/sample/WopiHost.Validator/Models/WopiOptions.cs
+++ b/sample/WopiHost.Validator/Models/WopiOptions.cs
@@ -3,7 +3,7 @@
 namespace WopiHost.Validator.Models;
 
 /// <summary>
-/// Configuration object for the the WopiHost.Web application.
+/// Configuration object for the WopiHost.Web application.
 /// </summary>
 public class WopiOptions
 {

--- a/sample/WopiHost.Validator/Pages/Index.cshtml.cs
+++ b/sample/WopiHost.Validator/Pages/Index.cshtml.cs
@@ -27,11 +27,9 @@ public class IndexModel(
     {
         ViewData["Title"] = "Welcome to WOPI HOST test page";
 
-        // setup title
         ContainerId ??= storageProvider.RootContainer.Identifier;
         ContainerName = (await storageProvider.GetWopiContainer(ContainerId, cancellationToken))?.Name
             ?? throw new InvalidOperationException("Container not found");
-        // calc breadcrumb
         if (ContainerId != storageProvider.RootContainer.Identifier)
         {
             var ancestors = await storageProvider.GetContainerAncestors(ContainerId, cancellationToken);
@@ -59,7 +57,6 @@ public class IndexModel(
             }
         }
 
-        // allow to navigate to parent container
         if (!string.IsNullOrWhiteSpace(ParentContainerId))
         {
             var parentContainer = await storageProvider.GetWopiContainer(ParentContainerId, cancellationToken)
@@ -70,7 +67,6 @@ public class IndexModel(
                 Name = ".."
             });
         }
-        // get child containers
         await foreach (var container in storageProvider.GetWopiContainers(ContainerId, cancellationToken))
         {
             Containers.Add(new ContainerViewModel
@@ -80,7 +76,6 @@ public class IndexModel(
             });
         }
 
-        // get files
         await foreach (var file in storageProvider.GetWopiFiles(ContainerId, cancellationToken: cancellationToken))
         {
             Files.Add(new FileViewModel

--- a/sample/WopiHost.Validator/Program.cs
+++ b/sample/WopiHost.Validator/Program.cs
@@ -7,10 +7,8 @@ using WopiHost.Validator.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add health checks
 builder.Services.AddHealthChecks();
 
-// Add service discovery
 builder.Services.AddServiceDiscovery();
 
 if (builder.Environment.IsDevelopment())
@@ -19,7 +17,6 @@ if (builder.Environment.IsDevelopment())
 }
 builder.Services.AddRazorPages();
 
-// --------- Add Wopi Server and Host pages
 builder.Services.AddWopiLogging();
 builder.Services.AddWopiServer(builder.Configuration);
 builder.Services.AddWopiHostPages(builder.Configuration);
@@ -28,10 +25,8 @@ builder.Services.AddWopiHostPages(builder.Configuration);
 // requests, so the default WopiProofValidator would reject every call.
 builder.Services.AddScoped<IWopiProofValidator, NoOpProofValidator>();
 
-// ---------
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/Error");
@@ -39,11 +34,8 @@ if (!app.Environment.IsDevelopment())
 app.UseStaticFiles();
 
 app.UseAuthorization();
-// HostPages
 app.MapRazorPages();
-// WOPI protocol endpoints
 app.MapWopiEndpoints();
-// Map health checks
 app.MapHealthChecks("/health");
 
 // Test-only token-issuance endpoint used by the WOPI validator harness. Mints a real signed
@@ -83,7 +75,7 @@ namespace WopiHost.Validator
             var anonymous = new System.Security.Claims.ClaimsPrincipal();
             var filePerms = await permissions.GetFilePermissionsAsync(anonymous, file, ct);
             // The Microsoft WOPI validator uses a single token for both file and container ops, so
-            // we mint one with both surfaces pre-authorized. Real hosts typically issue narrower
+            // this mints one with both surfaces pre-authorized. Real hosts typically issue narrower
             // tokens per session.
             var rootContainer = storage.RootContainer;
             var containerPerms = await permissions.GetContainerPermissionsAsync(anonymous, rootContainer, ct);

--- a/sample/WopiHost.Web.Oidc/Endpoints/AccountEndpoints.cs
+++ b/sample/WopiHost.Web.Oidc/Endpoints/AccountEndpoints.cs
@@ -5,12 +5,9 @@ using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 namespace WopiHost.Web.Oidc.Endpoints;
 
 /// <summary>
-/// Sign-in and sign-out endpoints. Replaces the legacy <c>AccountController</c> after the
-/// Razor Components migration — Razor Components static SSR can't issue auth challenges from
+/// Sign-in and sign-out endpoints. Razor Components static SSR can't issue auth challenges from
 /// component code, so the OIDC scheme is invoked via <see cref="Results.Challenge"/> /
-/// <see cref="Results.SignOut"/>. URL shapes (<c>/account/login</c>, <c>/account/logout</c>)
-/// stay identical so IdP redirect-URI config and the layout's sign-in/out form actions don't
-/// need to change.
+/// <see cref="Results.SignOut"/>.
 /// </summary>
 internal static class AccountEndpoints
 {

--- a/sample/WopiHost.Web.Oidc/Program.cs
+++ b/sample/WopiHost.Web.Oidc/Program.cs
@@ -47,7 +47,7 @@ builder.Services.AddScoped<IWopiStorageProvider, WopiFileSystemProvider>();
 
 // WOPI access-token signer must use the same key as the WOPI backend. Bind a project-local
 // WopiSigningOptions pointed at the same configuration path (Wopi:Security) — pure frontends
-// don't take a project reference on WopiHost.Core, so we keep our own typed shape for the
+// don't take a project reference on WopiHost.Core, so each keeps its own typed shape for the
 // shared key.
 builder.Services
     .AddOptions<WopiSigningOptions>()
@@ -130,8 +130,7 @@ else
 
 app.UseStaticFiles();
 
-// Auth middleware now has to be wired explicitly — AddRazorComponents doesn't add it the way
-// AddControllersWithViews did via MapControllerRoute.
+// AddRazorComponents does not add the auth middleware, so it must be wired explicitly.
 app.UseAuthentication();
 app.UseAuthorization();
 

--- a/sample/WopiHost.Web/Program.cs
+++ b/sample/WopiHost.Web/Program.cs
@@ -8,10 +8,8 @@ using WopiHost.Web.Shared;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add service defaults from Aspire
 builder.AddServiceDefaults();
 
-// Add logging
 builder.Logging.AddConsole();
 builder.Logging.AddDebug();
 
@@ -25,7 +23,6 @@ builder.Services.AddRazorComponents();
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddSingleton<WopiAccessTokenMinter>();
 
-// Configuration
 builder.Services
     .AddOptionsWithValidateOnStart<WopiOptions>()
     .Bind(builder.Configuration.GetRequiredSection(WopiOptions.SectionName))
@@ -39,9 +36,8 @@ builder.Services.AddScoped<IWopiStorageProvider, WopiFileSystemProvider>();
 
 var app = builder.Build();
 
-// Configure the HTTP request pipeline. The developer exception page leaks stack traces and
-// configuration values, so gate it behind the Development environment — production deployments
-// fall through to the /Error handler below.
+// The developer exception page leaks stack traces and configuration values, so gate it behind
+// the Development environment — production deployments fall through to the /Error handler below.
 if (app.Environment.IsDevelopment())
 {
     app.UseDeveloperExceptionPage();
@@ -53,7 +49,6 @@ else
 
 //app.UseHttpsRedirection();
 
-// Add static files to the request pipeline
 app.UseStaticFiles();
 
 // Razor Components stamp anti-forgery metadata on each endpoint, so app.UseAntiforgery() must
@@ -64,10 +59,8 @@ app.UseAntiforgery();
 
 app.MapRazorComponents<App>();
 
-// Map health check endpoints
 app.MapHealthChecks("/health");
 
-// Map default endpoints from Aspire
 app.MapDefaultEndpoints();
 
 app.Run();

--- a/sample/WopiHost.Web/Services/WopiAccessTokenMinter.cs
+++ b/sample/WopiHost.Web/Services/WopiAccessTokenMinter.cs
@@ -14,7 +14,7 @@ namespace WopiHost.Web.Services;
 /// </summary>
 /// <remarks>
 /// The token format is a contract with the WopiHost server's <c>JwtAccessTokenService</c>: same
-/// HMAC key, same claim layout. We sign the JWT inline here rather than depending on the
+/// HMAC key, same claim layout. The JWT is signed inline here rather than depending on the
 /// server's Core library so this sample stays a thin frontend (no controllers/auth pipeline).
 /// </remarks>
 public sealed class WopiAccessTokenMinter

--- a/sample/WopiHost/Program.cs
+++ b/sample/WopiHost/Program.cs
@@ -35,21 +35,17 @@ public partial class Program
 
             var builder = WebApplication.CreateBuilder(args);
 
-            // Add Serilog
             builder.Host.UseSerilog();
 
-            // Add service defaults from Aspire
             builder.AddServiceDefaults();
 
-            // Add services to the container
             builder.Services.AddLogging(loggingBuilder =>
             {
                 loggingBuilder.AddConsole();
                 loggingBuilder.AddDebug();
             });
 
-            // Configuration
-            // this makes sure that the configuration exists and is valid
+            // Fails fast if the configuration section is missing or invalid.
             var wopiHostOptionsSection = builder.Configuration.GetRequiredSection(WopiHostOptions.SectionName);
             builder.Services
                 .AddOptionsWithValidateOnStart<WopiHostOptions>()
@@ -59,40 +55,32 @@ public partial class Program
             var wopiHostOptions = wopiHostOptionsSection.Get<WopiHostOptions>();
 
             // Provider selection lives in the sample's own config section (Sample:*), not in
-            // WopiHost.Core's WopiHostOptions — choosing between bundled providers is composition-
-            // root concern. Real hosts reference one provider package and call its typed extension
-            // directly (services.AddFileSystemStorageProvider(cfg), etc.); the sample retains a
-            // small switch so the AppHost flag flow can flip providers at runtime.
+            // WopiHost.Core's WopiHostOptions — choosing between bundled providers is a composition-
+            // root concern. The sample retains a small switch so the AppHost flag flow can flip
+            // providers at runtime.
             var sampleStorage = builder.Configuration.GetValue("Sample:StorageProvider", ServiceCollectionExtensions.SampleStorageProvider.FileSystem);
             var sampleLock = builder.Configuration.GetValue("Sample:LockProvider", ServiceCollectionExtensions.SampleLockProvider.Memory);
             builder.Services.AddSampleStorageProvider(builder.Configuration, sampleStorage);
             builder.Services.AddSampleLockProvider(builder.Configuration, sampleLock);
 
-            // Add Discovery services
             builder.Services.AddWopiDiscovery<WopiHostOptions>(
                 options => builder.Configuration.GetSection(DiscoveryOptions.SectionName).Bind(options));
 
-            // Add Cobalt support
             if (wopiHostOptions.UseCobalt)
             {
-                // Add cobalt
                 builder.Services.AddCobalt();
             }
 
-            // Add OpenAPI
             builder.Services.AddOpenApi();
 
-            // Add WOPI
             builder.Services.AddWopi();
 
             // Signing key for WOPI access tokens. MUST match whatever the URL-generating
             // frontend (sample/WopiHost.Web) uses or every token will fail validation.
             // In production: load from a managed secret store, never hard-code.
             //
-            // Two-step binding: first read the configured values via Bind (gets SigningKey,
-            // DisableProofValidation, etc.), then PostConfigure to apply the dev-key fallback
-            // *after* configuration has been read — keeps the fallback out of the hot path of
-            // every option read and makes the precedence explicit.
+            // PostConfigure applies the dev-key fallback after configuration has been read,
+            // making the precedence explicit.
             builder.Services
                 .AddOptions<WopiSecurityOptions>()
                 .Bind(builder.Configuration.GetSection(WopiSecurityOptions.SectionName));
@@ -128,12 +116,10 @@ public partial class Program
 
             var app = builder.Build();
 
-            // Configure the HTTP request pipeline
             if (app.Environment.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
 
-                // Map OpenAPI endpoint (only in development)
                 app.MapOpenApi();
 
                 app.MapScalarApiReference(options => options.WithTitle(nameof(WopiHost)).WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient));
@@ -151,10 +137,10 @@ public partial class Program
             app.MapWopiEndpoints();
             app.MapGet("/", () => "This is just a WOPI server. You need a WOPI client to access it...").ShortCircuit(404);
 
-            // Map default endpoints from Aspire — owns /health and /alive (Development only,
-            // per the security note in WopiHost.ServiceDefaults.MapDefaultEndpoints). Hosts that
-            // need health endpoints in non-Development should add their own MapHealthChecks call
-            // here, gated by authn/authz appropriate to the deployment environment.
+            // Owns /health and /alive (Development only, per the security note in
+            // WopiHost.ServiceDefaults.MapDefaultEndpoints). Hosts that need health endpoints in
+            // non-Development should add their own MapHealthChecks call here, gated by appropriate
+            // authn/authz.
             app.MapDefaultEndpoints();
 
             app.Run();

--- a/sample/WopiHost/ServiceCollectionExtensions.cs
+++ b/sample/WopiHost/ServiceCollectionExtensions.cs
@@ -16,10 +16,10 @@ public static class ServiceCollectionExtensions
     /// providers is composition-root concern, not a contract the library should expose.
     /// </summary>
     /// <remarks>
-    /// Real hosts won't ship a discriminator at all — they reference one provider package and
-    /// call its typed extension directly (e.g. <c>services.AddFileSystemStorageProvider(cfg)</c>).
-    /// The enum-based switch exists here so the AppHost flag flow and Aspire orchestration can
-    /// flip providers at runtime without recompiling the sample.
+    /// Real hosts reference one provider package and call its typed extension directly
+    /// (e.g. <c>services.AddFileSystemStorageProvider(cfg)</c>). The enum-based switch exists here
+    /// so the AppHost flag flow and Aspire orchestration can flip providers at runtime without
+    /// recompiling the sample.
     /// </remarks>
     public enum SampleStorageProvider
     {

--- a/src/WopiHost.Abstractions/ICheckFolderInfoBuilder.cs
+++ b/src/WopiHost.Abstractions/ICheckFolderInfoBuilder.cs
@@ -8,11 +8,10 @@ namespace WopiHost.Abstractions;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Synchronous on purpose — see #363. The host-customization hook
+/// Synchronous on purpose. The host-customization hook
 /// <see cref="IWopiHostExtensions.OnCheckFolderInfoAsync"/> is fired by the controller after
 /// the builder returns, so the controller's only <c>await</c> on this path is the direct hook
-/// invocation. An async builder would re-introduce the Infer# null-deref FP that the issue
-/// tracks. Replacements should preserve the sync shape.
+/// invocation. Replacements should preserve the sync shape.
 /// </para>
 /// <para>
 /// Unlike the file and container builders, this contract does <em>not</em> invoke the

--- a/src/WopiHost.Abstractions/ICobaltProcessor.cs
+++ b/src/WopiHost.Abstractions/ICobaltProcessor.cs
@@ -11,7 +11,7 @@ public interface ICobaltProcessor
     /// Gets content of a MS-FSSHTTP update action.
     /// </summary>
     /// <param name="file">File to process. The MS-FSSHTTP protocol mutates content as part of
-    /// the round-trip, so the writable interface is required (#420 item 1.2).</param>
+    /// the round-trip, so the writable interface is required.</param>
     /// <param name="principal">User editing the file.</param>
     /// <param name="newContent">Partitions with new content (diffs).</param>
     /// <param name="cancellationToken">Cancellation token.</param>

--- a/src/WopiHost.Abstractions/IWopiAuthorizationRequirement.cs
+++ b/src/WopiHost.Abstractions/IWopiAuthorizationRequirement.cs
@@ -24,8 +24,7 @@ public enum WopiResourceType
 /// <remarks>
 /// The per-request resource id is <em>not</em> part of this requirement. It belongs to the
 /// authorization handler, which derives it from <c>HttpContext.Request.RouteValues["id"]</c>
-/// when needed. Mixing per-request state into the (shared) requirement was the cause of the
-/// race fixed alongside this contract — see #380 items 2.5 and 5.3.
+/// when needed. Mixing per-request state into the (shared) requirement races across requests.
 /// </remarks>
 public interface IWopiAuthorizationRequirement
 {

--- a/src/WopiHost.Abstractions/IWopiContainer.cs
+++ b/src/WopiHost.Abstractions/IWopiContainer.cs
@@ -4,9 +4,8 @@
 /// Object that represents a container with files.
 /// </summary>
 /// <remarks>
-/// #425 item 1.4: the type carries two metadata members (<see cref="Size"/>,
-/// <see cref="ChildCount"/>) so a marker interface doesn't just exist to tag the kind.
-/// The two members are implementable by every storage backend that can already enumerate
+/// The type carries two metadata members (<see cref="Size"/>, <see cref="ChildCount"/>).
+/// Both are implementable by every storage backend that can already enumerate
 /// (file system: <see cref="System.IO.DirectoryInfo"/>; blob: prefix-scan); providers may
 /// compute lazily or eagerly as the underlying store allows.
 /// </remarks>

--- a/src/WopiHost.Abstractions/IWopiFile.cs
+++ b/src/WopiHost.Abstractions/IWopiFile.cs
@@ -5,7 +5,7 @@ namespace WopiHost.Abstractions;
 /// when the caller only needs to enumerate metadata or stream content out.
 /// </summary>
 /// <remarks>
-/// Per #420 item 1.2, the write seam is split off into <see cref="IWopiWritableFile"/> so a
+/// The write seam is split off into <see cref="IWopiWritableFile"/> so a
 /// read-only flow can't accidentally call <c>OpenWriteAsync</c> on a file it fetched read-only.
 /// Callers that need to mutate file content fetch via
 /// <see cref="IWopiWritableStorageProvider.GetWritableFile"/> or take the writable file directly

--- a/src/WopiHost.Abstractions/IWopiHostExtensions.cs
+++ b/src/WopiHost.Abstractions/IWopiHostExtensions.cs
@@ -1,8 +1,7 @@
 namespace WopiHost.Abstractions;
 
 /// <summary>
-/// Host-customization seam for WOPI request handling. Replaces the per-callback delegate
-/// properties that previously lived on the host options. Hosts plug in audit, telemetry, and
+/// Host-customization seam for WOPI request handling. Hosts plug in audit, telemetry, and
 /// final response mutations here without replacing whole builders.
 /// </summary>
 /// <remarks>

--- a/src/WopiHost.Abstractions/IWopiResourceTokenMinter.cs
+++ b/src/WopiHost.Abstractions/IWopiResourceTokenMinter.cs
@@ -26,12 +26,6 @@ namespace WopiHost.Abstractions;
 /// revocable tokens, an external token-issuance service, or an extra audit step before issuing)
 /// can replace the default registration; the WOPI endpoints will pick up the override.
 /// </para>
-/// <para>
-/// Architecturally also a workaround for an Infer# precision loss: routing the per-resource
-/// token mint through an injected interface (this) instead of a static helper means the await
-/// at the call site lands on an injected dependency, which the analyzer tracks cleanly. See
-/// the historical notes in <c>.github/infer-allowlist.txt</c> and #471 for the full story.
-/// </para>
 /// </remarks>
 public interface IWopiResourceTokenMinter
 {

--- a/src/WopiHost.Abstractions/IWopiStorageProvider.cs
+++ b/src/WopiHost.Abstractions/IWopiStorageProvider.cs
@@ -6,10 +6,10 @@ namespace WopiHost.Abstractions;
 /// Implementation of read operations for an external storage provider.
 /// </summary>
 /// <remarks>
-/// Per #420 item 1.1, file and container access points are exposed as distinct typed methods
-/// rather than a single generic <c>GetWopiResource&lt;T&gt;</c> that used <c>typeof(T)</c> as a
-/// runtime discriminator. Each method returns the precise resource interface; there are no
-/// scenarios where a caller wants the union of both.
+/// File and container access points are exposed as distinct typed methods rather than a single
+/// generic <c>GetWopiResource&lt;T&gt;</c> with a runtime type discriminator. Each method
+/// returns the precise resource interface; there are no scenarios where a caller wants the
+/// union of both.
 /// </remarks>
 public interface IWopiStorageProvider
 {
@@ -109,7 +109,7 @@ public interface IWopiStorageProvider
     /// <remarks>
     /// Returns <see langword="null"/> when either the parent container itself does not exist
     /// or the file is not present under it. Consistent with <see cref="GetWopiFile"/>'s
-    /// null-on-missing behaviour (#380 item 4.2).
+    /// null-on-missing behaviour.
     /// </remarks>
     /// <param name="containerId">Parent container id to search within.</param>
     /// <param name="name">The exact name to look for.</param>
@@ -122,7 +122,7 @@ public interface IWopiStorageProvider
     /// <remarks>
     /// Returns <see langword="null"/> when either the parent container itself does not exist
     /// or the child container is not present under it. Consistent with <see cref="GetWopiContainer"/>'s
-    /// null-on-missing behaviour (#380 item 4.2).
+    /// null-on-missing behaviour.
     /// </remarks>
     /// <param name="containerId">Parent container id to search within.</param>
     /// <param name="name">The exact name to look for.</param>

--- a/src/WopiHost.Abstractions/IWopiWritableFile.cs
+++ b/src/WopiHost.Abstractions/IWopiWritableFile.cs
@@ -9,10 +9,9 @@ namespace WopiHost.Abstractions;
 /// so a read-only flow can't accidentally write through a file it fetched read-only.
 /// </summary>
 /// <remarks>
-/// Resolves #420 item 1.2 — pre-fix, <see cref="OpenWriteAsync"/> lived on <see cref="IWopiFile"/>
-/// itself, so any caller with a file handle could write to it regardless of how the handle was
-/// obtained. The split makes the write capability part of the type the storage layer hands out
-/// for writable flows, and the compiler enforces the gate.
+/// Keeping <see cref="OpenWriteAsync"/> off <see cref="IWopiFile"/> makes the write capability
+/// part of the type the storage layer hands out only for writable flows, so the compiler
+/// enforces the gate.
 /// </remarks>
 public interface IWopiWritableFile : IWopiFile
 {

--- a/src/WopiHost.Abstractions/IWopiWritableStorageProvider.cs
+++ b/src/WopiHost.Abstractions/IWopiWritableStorageProvider.cs
@@ -4,10 +4,10 @@ namespace WopiHost.Abstractions;
 /// Implementation of writable operations for an external storage provider.
 /// </summary>
 /// <remarks>
-/// Per #420 item 1.1, the file and container mutation methods are exposed as distinct typed
-/// pairs rather than a single generic <c>&lt;T&gt;</c> that used <c>typeof(T)</c> as a runtime
-/// discriminator. File-name and container-name validation rules differ (e.g. extension handling,
-/// allowed characters), so the split also makes the semantic mismatch visible in the API surface.
+/// The file and container mutation methods are exposed as distinct typed pairs rather than a
+/// single generic <c>&lt;T&gt;</c> with a runtime type discriminator. File-name and
+/// container-name validation rules differ (e.g. extension handling, allowed characters), so
+/// the split also makes the semantic mismatch visible in the API surface.
 /// </remarks>
 public interface IWopiWritableStorageProvider
 {
@@ -40,10 +40,8 @@ public interface IWopiWritableStorageProvider
     /// <see cref="IWopiStorageProvider.GetWopiFile"/> instead.
     /// </summary>
     /// <remarks>
-    /// Resolves the #420 item 1.2 leak: pre-fix the read-side <c>GetWopiFile</c> returned a
-    /// file that also exposed <c>OpenWriteAsync</c>, letting any caller mutate a file
-    /// they'd fetched in a read-only flow. After the split, writes require a deliberate
-    /// fetch through the writable storage provider.
+    /// Writes require a deliberate fetch through the writable storage provider; the read-side
+    /// <see cref="IWopiStorageProvider.GetWopiFile"/> returns a handle with no write seam.
     /// </remarks>
     /// <param name="identifier">File identifier.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -65,8 +63,7 @@ public interface IWopiWritableStorageProvider
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Contract for the missing/exception split (clarified in #380 item 4.2 so the two in-tree
-    /// providers and any future impl behave the same):
+    /// Contract for the missing/exception split (all providers behave the same):
     /// </para>
     /// <list type="bullet">
     /// <item>

--- a/src/WopiHost.Abstractions/WopiResourceId.cs
+++ b/src/WopiHost.Abstractions/WopiResourceId.cs
@@ -32,9 +32,9 @@ namespace WopiHost.Abstractions;
 ///   </description></item>
 /// </list>
 /// <para>
-/// The hash is SHA-256 (not MD5) so the id-minting path is FIPS-compatible and silent under the
-/// <c>CA5351</c> analyzer. Cryptographic strength is not required — these are opaque keys — but
-/// a non-weak primitive avoids policy/compliance friction on hosts that disable broken algorithms.
+/// The hash is SHA-256 (not MD5) so the id-minting path is FIPS-compatible. Cryptographic
+/// strength is not required — these are opaque keys — but a non-weak primitive avoids
+/// policy/compliance friction on hosts that disable broken algorithms.
 /// </para>
 /// </remarks>
 public static class WopiResourceId

--- a/src/WopiHost.AzureLockProvider/WopiAzureLockProvider.cs
+++ b/src/WopiHost.AzureLockProvider/WopiAzureLockProvider.cs
@@ -72,7 +72,7 @@ public partial class WopiAzureLockProvider(
             return info;
         }
 
-        // WOPI-expired. Break the lease so subsequent AddLock calls can take over, then evict.
+        // WOPI-expired: break the lease so subsequent AddLock calls can take over, then evict.
         await TryBreakLeaseAsync(blobClient, cancellationToken).ConfigureAwait(false);
         await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         LogLockExpired(_logger, fileId, info.LockId);
@@ -96,7 +96,7 @@ public partial class WopiAzureLockProvider(
                     LogLockAddRejected(_logger, fileId, lockId, existingInfo.LockId);
                     return null;
                 }
-                // Stale (>30 min old) — clean up so we can take over.
+                // Stale (>30 min old) — clean up so a new lock can take over.
                 await TryBreakLeaseAsync(blobClient, cancellationToken).ConfigureAwait(false);
                 await blobClient.DeleteIfExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             }
@@ -104,21 +104,20 @@ public partial class WopiAzureLockProvider(
             {
                 // Blob exists but metadata is missing/malformed. With the atomic upload-with-
                 // metadata flow below, healthy peers never observe this state — it can only mean
-                // a peer is mid-acquire RIGHT NOW (we lost the race) or a previous attempt
+                // a peer is mid-acquire right now (this call lost the race) or a previous attempt
                 // crashed between Upload and lease acquisition. Either way, treat it as
-                // "lock-attempt in progress" and yield. (Aggressive cleanup here was the prior
-                // bug that broke healthy peers via lease-break + delete in their acquire window.)
+                // "lock-attempt in progress" and yield. Aggressive cleanup here would break
+                // healthy peers via lease-break + delete inside their acquire window.
                 LogLockAddRaceLost(_logger, fileId, lockId);
                 return null;
             }
         }
 
         // Step 2: atomic upload-with-metadata. The blob is never observable in a "no metadata"
-        // state, so any peer's TryReadLock either gets a complete WopiLockInfo (we won) or the
-        // blob doesn't yet exist (their probe hits before our upload lands). IfNoneMatch=*
-        // serves as the create-if-not-exists conditional: a 412 means a sibling acquire raced
-        // ahead and we lost. Some Azure SDK paths surface 409 instead — we treat both as the
-        // race-lost outcome.
+        // state, so any peer's TryReadLock either gets a complete WopiLockInfo or the blob
+        // doesn't yet exist (its probe hits before the upload lands). IfNoneMatch=* serves as
+        // the create-if-not-exists conditional: a 412 means a sibling acquire raced ahead. Some
+        // Azure SDK paths surface 409 instead — both are treated as the race-lost outcome.
         var leaseId = Guid.NewGuid().ToString();
         var now = _timeProvider.GetUtcNow();
         var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
@@ -146,8 +145,8 @@ public partial class WopiAzureLockProvider(
         }
 
         // Step 3: acquire the infinite lease whose id is already announced via metadata. If
-        // this fails, delete the placeholder so we don't leave a no-op blob behind that claims
-        // a lease we don't actually hold.
+        // this fails, delete the placeholder so no no-op blob is left behind claiming a lease
+        // that isn't actually held.
         var leaseClient = blobClient.GetBlobLeaseClient(leaseId);
         try
         {
@@ -182,20 +181,18 @@ public partial class WopiAzureLockProvider(
     }
 
     /// <summary>
-    /// Shared "load → validate → renew lease → SetMetadata under ETag" flow that
-    /// <see cref="RefreshLockAsync"/> and <see cref="TryUnlockAndRelockAsync"/> both need. They
-    /// differ only in <em>which</em> metadata fields the mutation step writes; the load /
-    /// expected-lock-id check / lease renewal / ETag-conditional write / failure-handling
-    /// scaffolding is identical, so it lives here as a single transaction instead of being
-    /// duplicated across both methods.
+    /// Shared "load, validate, renew lease, SetMetadata under ETag" flow for
+    /// <see cref="RefreshLockAsync"/> and <see cref="TryUnlockAndRelockAsync"/>. They differ only
+    /// in <em>which</em> metadata fields the mutation step writes; the load, expected-lock-id
+    /// check, lease renewal, ETag-conditional write, and failure handling are identical.
     /// </summary>
     /// <remarks>
     /// <para>
     /// Atomicity: the ETag captured before lease renewal is the snapshot the
     /// <c>SetMetadataAsync</c> writes against (<c>IfMatch=etag</c>). Any concurrent mutation
-    /// between our load and our write — a sibling <c>UnlockAndRelock</c>, a <c>Remove</c>, even
-    /// another <c>Refresh</c> — changes the blob's ETag and Azure replies 412; we report
-    /// not-applied. Same atomicity guarantee in both call sites.
+    /// between the load and the write — a sibling <c>UnlockAndRelock</c>, a <c>Remove</c>, even
+    /// another <c>Refresh</c> — changes the blob's ETag and Azure replies 412, which is reported
+    /// as not-applied. Same atomicity guarantee in both call sites.
     /// </para>
     /// <para>
     /// Returns <see langword="false"/> on any abort condition: blob missing, malformed
@@ -212,11 +209,6 @@ public partial class WopiAzureLockProvider(
         await EnsureContainerAsync(cancellationToken).ConfigureAwait(false);
         var blobClient = GetLockBlob(fileId);
         var props = await TryGetPropertiesAsync(blobClient, cancellationToken).ConfigureAwait(false);
-        // Three short-circuiting guards collapsed into one if/else-if/else chain that assigns a
-        // single `result` and exits through one `return`. The earlier multi-return shape tripped
-        // qlty's return-count threshold (≤5); the combined-if shape tripped its boolean-logic
-        // threshold. The if/else-if/else preserves the short-circuit semantics with no compound
-        // boolean (each branch carries at most one `||`).
         bool result;
         if (props is null || !TryReadLock(fileId, props, out var info))
         {
@@ -239,9 +231,7 @@ public partial class WopiAzureLockProvider(
     }
 
     /// <summary>
-    /// Bundled "what to write to" inputs for <see cref="ExecuteMutationAsync"/>. Exists so that
-    /// helper can stay below qlty's 5-parameter threshold; passing four positional args plus the
-    /// mutation delegate and the cancellation token would otherwise put it at 6.
+    /// Bundled "what to write to" inputs for <see cref="ExecuteMutationAsync"/>.
     /// </summary>
     private readonly record struct MutationContext(
         BlobClient BlobClient,
@@ -252,8 +242,6 @@ public partial class WopiAzureLockProvider(
     /// <summary>
     /// Inner step of <see cref="TryAtomicLockUpdateAsync"/>: with a validated lease id in hand,
     /// renews the lease and writes the mutated metadata under <c>IfMatch=etag</c> + the lease id.
-    /// Lifted out so the outer validation path and the renew/write path each have a single
-    /// return — qlty's return-count threshold is ≤5, and the combined version exceeded it.
     /// </summary>
     /// <remarks>
     /// A <c>renewed</c> flag tracks which phase the exception fired in so the two failure modes
@@ -348,11 +336,8 @@ public partial class WopiAzureLockProvider(
         }
     }
 
-    // Visible to WopiHost.AzureLockProvider.Tests via InternalsVisibleTo (auto-wired in
-    // Directory.Build.props). The Azure-specific tests need to address the same blob from
-    // outside the provider (direct metadata seeding, lease takeover). Pre-#456 they reflected
-    // into the private method via BindingFlags.NonPublic; exposing it as internal keeps the
-    // production API surface unchanged while letting tests compile against a typed signature.
+    // Internal so the Azure-specific tests can address the same blob from outside the provider
+    // (direct metadata seeding, lease takeover) without changing the production API surface.
     internal BlobClient GetLockBlob(string fileId)
     {
         // Hash the fileId so any caller-supplied identifier is reduced to a safe blob name.
@@ -380,7 +365,7 @@ public partial class WopiAzureLockProvider(
         }
         catch (RequestFailedException)
         {
-            // Best-effort — if the lease is already gone or the blob disappeared, we don't care.
+            // Best-effort — a lease that is already gone or a vanished blob is fine.
         }
     }
 

--- a/src/WopiHost.AzureStorageProvider/BlobIdMap.cs
+++ b/src/WopiHost.AzureStorageProvider/BlobIdMap.cs
@@ -30,10 +30,8 @@ namespace WopiHost.AzureStorageProvider;
 /// <strong>Two dictionaries, kept in sync.</strong> <c>_idToPath</c> drives id→path lookups
 /// (which fire on every WOPI route that resolves <c>{id}</c>); <c>_pathToId</c> is the inverse
 /// for the listing path, where the provider walks the blob namespace and needs to look up the id
-/// for each blob name. Pre-#456 the inverse lookup was an O(n) linear scan of <c>_idToPath</c>;
-/// in containers with thousands of blobs, listing degenerated to O(n²) total work across the
-/// hydration loop. The reverse dict matches what <c>WopiHost.FileSystemProvider</c>'s
-/// <c>InMemoryFileIds</c> already does.
+/// for each blob name. The reverse dictionary keeps that lookup O(1); without it the listing
+/// hydration loop would degenerate to O(n^2) in containers with thousands of blobs.
 /// </para>
 /// </remarks>
 public sealed partial class BlobIdMap(ILogger<BlobIdMap> logger)
@@ -44,8 +42,8 @@ public sealed partial class BlobIdMap(ILogger<BlobIdMap> logger)
     /// <remarks>
     /// Plain Azure Blob Storage has no concept of an empty directory. To keep parity with
     /// <c>WopiFileSystemProvider</c>'s ability to create an empty folder via
-    /// <see cref="IWopiWritableStorageProvider.CreateWopiChildContainer"/>, we drop a 0-byte
-    /// blob with this name into the folder. The provider hides marker blobs from listings so
+    /// <see cref="IWopiWritableStorageProvider.CreateWopiChildContainer"/>, a 0-byte blob with
+    /// this name is dropped into the folder. The provider hides marker blobs from listings so
     /// callers never see them.
     /// </remarks>
     public const string FolderMarker = ".wopi.folder";

--- a/src/WopiHost.AzureStorageProvider/HashingBlobWriteStream.cs
+++ b/src/WopiHost.AzureStorageProvider/HashingBlobWriteStream.cs
@@ -5,7 +5,7 @@ namespace WopiHost.AzureStorageProvider;
 
 /// <summary>
 /// Wraps the blob upload stream returned by <see cref="BlobClient.OpenWriteAsync(bool, Azure.Storage.Blobs.Models.BlobOpenWriteOptions, System.Threading.CancellationToken)"/>
-/// so callers can stream large content while we incrementally compute SHA-256 of the new payload.
+/// so callers can stream large content while SHA-256 of the new payload is computed incrementally.
 /// On dispose, the hash is finalized and written back as the <see cref="WopiBlobFile.Sha256MetadataKey"/>
 /// metadata key, preserving the metadata that existed before the write.
 /// </summary>
@@ -71,16 +71,15 @@ internal sealed class HashingBlobWriteStream(Stream inner, BlobClient blobClient
         await blobClient.SetMetadataAsync(_metadataToWrite).ConfigureAwait(false);
 
         // Stream has a finalizer; skip it now that DisposeAsync has done the work. The sync
-        // Stream.Dispose() base already calls SuppressFinalize, but the async path is on us.
+        // Stream.Dispose() base already calls SuppressFinalize, but the async path must do so here.
         GC.SuppressFinalize(this);
     }
 
     protected override void Dispose(bool disposing)
     {
-        // Synchronous dispose is unavoidable for callers that don't await DisposeAsync; do the
-        // expensive bits inline. Intentionally no GetAwaiter().GetResult() on user-facing async
-        // calls here — we already removed sync-over-async from the lock provider; this stream is the
-        // last necessary sync-over-async boundary because Stream.Dispose can't be async.
+        // Synchronous dispose is unavoidable for callers that don't await DisposeAsync; the
+        // expensive bits run inline. No GetAwaiter().GetResult() on user-facing async calls here —
+        // this stream is a necessary sync-over-async boundary because Stream.Dispose can't be async.
         if (_disposed || !disposing)
         {
             return;
@@ -95,7 +94,7 @@ internal sealed class HashingBlobWriteStream(Stream inner, BlobClient blobClient
     /// <summary>
     /// Finalizes the SHA-256 hasher and stores the lowercase-hex digest under the blob metadata
     /// key. Shared between <see cref="Dispose(bool)"/> and <see cref="DisposeAsync"/> so the
-    /// two paths can never drift on the hex/casing/metadata-key contract (#409 item 2.12).
+    /// two paths can never drift on the hex/casing/metadata-key contract.
     /// </summary>
     private void FinalizeMetadataPayload()
     {

--- a/src/WopiHost.AzureStorageProvider/WopiAzureStorageProvider.cs
+++ b/src/WopiHost.AzureStorageProvider/WopiAzureStorageProvider.cs
@@ -96,8 +96,8 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
     /// <inheritdoc/>
     public async Task<IWopiWritableFile?> GetWritableFile(string identifier, CancellationToken cancellationToken = default)
     {
-        // Same WopiBlobFile instance the read-side returns — the concrete class implements
-        // IWopiWritableFile (extends IWopiFile), so the choice is purely about the static
+        // Same WopiBlobFile the read-side returns — the concrete class implements
+        // IWopiWritableFile (extends IWopiFile), so read vs. writable is purely the static
         // type the caller sees.
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
         if (!_idMap.TryGetPath(identifier, out var path))
@@ -133,7 +133,7 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
         // Azure Blob Storage's list API exposes only a prefix filter at the wire level — no
         // suffix / extension / regex support — so the extension filter is applied at the
         // streaming-list boundary inside the loop. Each non-matching blob is dropped before
-        // we allocate a WopiBlobFile for it. The hashset (OrdinalIgnoreCase) gives us O(1)
+        // a WopiBlobFile is allocated for it. The hashset (OrdinalIgnoreCase) gives O(1)
         // membership checks regardless of how many extensions the caller asked for.
         var extensionFilter = (fileExtensions is { Count: > 0 })
             ? new HashSet<string>(fileExtensions, StringComparer.OrdinalIgnoreCase)
@@ -534,12 +534,10 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
         var dest = _containerClient.GetBlobClient(destPath);
 
         // Atomic existence check via conditional-headers (IfNoneMatch="*") rather than a
-        // separate ExistsAsync + StartCopyFromUri pair. The prior shape had a TOCTOU window:
-        // a concurrent rename that landed between our existence probe and our copy could
-        // either silently overwrite the new neighbour or get partially applied. Setting
-        // IfNoneMatch=* tells Azure "fail if the destination already has any ETag" — the
-        // 409 Conflict comes from Blob Storage's own consistency layer, no client-side
-        // race possible.
+        // separate ExistsAsync + StartCopyFromUri pair, which would have a TOCTOU window where
+        // a concurrent rename could overwrite the destination. IfNoneMatch=* tells Azure to
+        // "fail if the destination already has any ETag" — the 409 Conflict comes from Blob
+        // Storage's own consistency layer, so no client-side race is possible.
         // https://learn.microsoft.com/rest/api/storageservices/specifying-conditional-headers-for-blob-service-operations
         try
         {
@@ -554,9 +552,9 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
         }
         catch (RequestFailedException ex) when (ex.Status == 409 || ex.ErrorCode == BlobErrorCode.BlobAlreadyExists)
         {
-            // Preserve the legacy exception shape so callers (RenameWopi{File,Container}) keep
-            // their existing 409-Conflict mapping. Status 409 covers the IfNoneMatch=* rejection
-            // and Azure's own BlobAlreadyExists path; both indicate "destination occupied."
+            // Callers (RenameWopi{File,Container}) map this to a 409 Conflict. Status 409 covers
+            // the IfNoneMatch=* rejection and Azure's own BlobAlreadyExists path; both indicate
+            // "destination occupied."
             throw new InvalidOperationException($"Target blob '{destPath}' already exists.", ex);
         }
 

--- a/src/WopiHost.Cobalt/CoauthoringSessionTracker.cs
+++ b/src/WopiHost.Cobalt/CoauthoringSessionTracker.cs
@@ -12,8 +12,8 @@ namespace WopiHost.Cobalt;
 /// and co-authoring status to OOS/OWA via the Cobalt protocol.
 /// </summary>
 /// <remarks>
-/// Fixes https://github.com/petrsvihlik/WopiHost/issues/139 — without shared session tracking,
-/// each Cobalt request creates a fresh <see cref="CobaltHostLockingStore"/> that always reports
+/// Without shared session tracking, each Cobalt request creates a fresh
+/// <see cref="CobaltHostLockingStore"/> that always reports
 /// <see cref="CoauthStatusType.Alone"/> and an empty editors table, causing older OOS versions
 /// to show duplicate user names when the same person opens a document in multiple tabs.
 /// </remarks>
@@ -60,7 +60,6 @@ public partial class CoauthoringSessionTracker(ILogger<CoauthoringSessionTracker
             {
                 LogEditorLeft(_logger, userId, fileId);
             }
-            // Clean up empty file entries
             if (files_sessions.IsEmpty)
             {
                 s_sessions.TryRemove(fileId, out _);
@@ -104,12 +103,10 @@ public partial class CoauthoringSessionTracker(ILogger<CoauthoringSessionTracker
     /// Returns the editors table for the Cobalt protocol.
     /// </summary>
     /// <remarks>
-    /// As of MS-FSSHTTP/CobaltCore 16.x the editors table is keyed by
-    /// <see cref="ArrayGuid"/> (per-editor ClientId) and entries are
-    /// <see cref="EditorsTableEntryNew"/>. We don't have a real Cobalt ClientId
-    /// in WopiHost, so we derive a stable one per-user by hashing the user id —
-    /// this preserves the dedup-by-user behavior that the older string-keyed
-    /// table provided.
+    /// The editors table is keyed by <see cref="ArrayGuid"/> (per-editor ClientId)
+    /// and entries are <see cref="EditorsTableEntryNew"/>. WopiHost has no real
+    /// Cobalt ClientId, so a stable one is derived per-user by hashing the user id,
+    /// which collapses a user's multiple tabs to a single editor row.
     /// </remarks>
     public EditorsTable GetEditorsTable(string fileId)
     {

--- a/src/WopiHost.Cobalt/CobaltHostLockingStore.cs
+++ b/src/WopiHost.Cobalt/CobaltHostLockingStore.cs
@@ -45,8 +45,6 @@ public class CobaltHostLockingStore(
 
     public override LockStatusRequest.OutputType HandleLockStatus(LockStatusRequest.InputType input)
     {
-        // Replaces the 15.x `HandleLockAndCheckOutStatus`. The output shape
-        // changed too: old (LockType, CheckOutType) → new (LockType, LockId, LockedBy).
         var result = new LockStatusRequest.OutputType
         {
             LockType = LockType.SchemaLock
@@ -259,8 +257,7 @@ public class CobaltHostLockingStore(
         return result;
     }
 
-    // The methods below were added to HostLockingStore in CobaltCore 16.x.
-    // They cover protocol features WopiHost doesn't implement yet (rename,
+    // The methods below cover protocol features WopiHost doesn't implement yet (rename,
     // delete, version history, editors-property metadata). Stubbed with
     // empty default outputs so the host accepts the request without erroring;
     // hosts that need the real behavior should override these.

--- a/src/WopiHost.Cobalt/CobaltSession.cs
+++ b/src/WopiHost.Cobalt/CobaltSession.cs
@@ -16,9 +16,9 @@ namespace WopiHost.Cobalt;
 /// <para>
 /// The Cobalt protocol is stateful: schema/exclusive locks, edit deltas, and
 /// co-authoring metadata live inside the <c>CobaltFile</c>'s in-memory blob
-/// stores and must persist across HTTP requests for the same file. Creating a
-/// fresh <c>CobaltFile</c> per request (the previous behavior) makes
-/// co-authoring and delta-based edits impossible.
+/// stores and must persist across HTTP requests for the same file. A fresh
+/// <c>CobaltFile</c> per request would make co-authoring and delta-based edits
+/// impossible.
 /// </para>
 /// <para>
 /// Sessions are cached in a <see cref="ConcurrentDictionary{TKey,TValue}"/>
@@ -48,12 +48,6 @@ public sealed partial class CobaltProcessor : ICobaltProcessor, IDisposable
     }
 
     /// <inheritdoc/>
-    // Binary-protocol orchestration: deserializes a CobaltCore RequestBatch, executes it
-    // against the cached CobaltFile, optionally flushes content via GenericFda, and
-    // serializes the response. Exercised end-to-end by the WOPI Validator + sample apps;
-    // unit-testing it would require constructing real Cobalt protocol bytes which is
-    // brittle and high-maintenance. The argument-validation and dispose contract above
-    // and below are unit-tested in CobaltProcessorTests.
     [ExcludeFromCodeCoverage(Justification = "Binary protocol; covered by integration tests")]
     public async Task<byte[]> ProcessCobalt(IWopiWritableFile file, ClaimsPrincipal principal, byte[] newContent, CancellationToken cancellationToken = default)
     {
@@ -63,8 +57,6 @@ public sealed partial class CobaltProcessor : ICobaltProcessor, IDisposable
 
         var entry = await GetOrCreateSession(file, cancellationToken).ConfigureAwait(false);
 
-        // Wrap the request bytes as a CobaltStream (16.x replaced the Atom-taking
-        // overload of DeserializeInputFromProtocol with one that takes CobaltStream).
         using var newContentStream = new MemoryStream(newContent, writable: false);
         var requestStream = CobaltStream.Get(newContentStream, streamIsImmutable: true);
         var requestBatch = new RequestBatch();
@@ -152,10 +144,8 @@ public sealed partial class CobaltProcessor : ICobaltProcessor, IDisposable
     {
         var disposal = new DisposalEscrow(file.Owner);
 
-        // CobaltCore 16.x retired `TemporaryHostBlobStore`; `LocalHostBlobStore` is
-        // the closest equivalent (in-memory by default; can be backed by a
-        // directory if a `dirPathForFileBackedBlobs` is supplied — left null here
-        // to match the old temp-only behavior).
+        // LocalHostBlobStore is in-memory by default; it can be backed by a
+        // directory if a `dirPathForFileBackedBlobs` is supplied — left null here.
         static CobaltFilePartitionConfig MakePartition(FilePartitionId partition, bool genericFda) => new()
         {
             IsNewFile = true,
@@ -173,8 +163,6 @@ public sealed partial class CobaltProcessor : ICobaltProcessor, IDisposable
             [FilePartitionId.CoauthMetadata] = MakePartition(FilePartitionId.CoauthMetadata, genericFda: false),
         };
 
-        // CobaltCore 16.x changed the CobaltFile ctor to take a
-        // `GetConfigForPartitionAndVersion` delegate instead of a Dictionary.
         var cobaltFile = new CobaltFile(
             disposal,
             (partition, _) => partitionConfigs.TryGetValue(partition, out var cfg) ? cfg : null,
@@ -184,9 +172,7 @@ public sealed partial class CobaltProcessor : ICobaltProcessor, IDisposable
         if (file.Exists)
         {
             using var stream = await file.OpenReadAsync(cancellationToken).ConfigureAwait(false);
-            // 16.x made `AtomFromStream` an internal sealed type; `Atom.CreateFromArray`
-            // is the public byte[] factory. Buffer the stream so we can hand a byte[]
-            // to it.
+            // Atom.CreateFromArray takes a byte[], so the stream must be buffered first.
             using var ms = new MemoryStream();
             await stream.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
             var srcAtom = Atom.CreateFromArray(ms.ToArray());

--- a/src/WopiHost.Core/Endpoints/BootstrapEndpoints.cs
+++ b/src/WopiHost.Core/Endpoints/BootstrapEndpoints.cs
@@ -82,8 +82,8 @@ internal static class BootstrapEndpoints
     /// </summary>
     /// <remarks>
     /// Both branches are inlined into this method rather than dispatched to separate <c>async</c>
-    /// helpers because awaits on same-class static async methods trip an Infer# null-deref FP
-    /// through the async state machine (#471, mirror of the EndpointHelpers refactor). Every
+    /// helpers because awaits on same-class static async methods trip a null-deref false positive
+    /// through the async state machine. Every
     /// <c>await</c> here lands directly on an injected dependency
     /// (<see cref="IWopiAccessTokenService"/>, <see cref="IWopiStorageProvider"/>,
     /// <see cref="IWopiPermissionProvider"/>, <see cref="ICheckContainerInfoBuilder"/>).

--- a/src/WopiHost.Core/Endpoints/ContainerEndpoints.cs
+++ b/src/WopiHost.Core/Endpoints/ContainerEndpoints.cs
@@ -82,9 +82,9 @@ internal static class ContainerEndpoints
 
         var ancestors = await req.Storage.GetContainerAncestors(req.Id, req.CancellationToken).ConfigureAwait(false);
         // Fresh container-scoped token per ancestor URL — see IWopiResourceTokenMinter for the
-        // token-trading prevention rationale. Going through the injected minter keeps Infer#'s
-        // async-state-machine analysis clean (#471): the await lands on an injected interface
-        // method, not a same-class or shared static async helper.
+        // token-trading prevention rationale. Going through the injected minter keeps the
+        // async-state-machine analysis precise: the await lands on an injected interface method,
+        // not a same-class or shared static async helper.
         var children = new List<ChildContainer>();
         foreach (var ancestor in ancestors)
         {
@@ -110,7 +110,7 @@ internal static class ContainerEndpoints
         // container's id, so reusing it for child URLs trips "preventing token trading"
         // (https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/security#preventing-token-trading).
         // Routed through IWopiResourceTokenMinter so the await lands on an injected interface
-        // method — see #471 for the Infer# precision-loss this shape avoids.
+        // method, which keeps the async-state-machine analysis precise.
         await foreach (var wopiFile in req.Storage.GetWopiFiles(req.Id, fileExtensions, req.CancellationToken).ConfigureAwait(false))
         {
             var fileToken = await req.TokenMinter.MintForFileAsync(req.Http.User, wopiFile, req.CancellationToken).ConfigureAwait(false);

--- a/src/WopiHost.Core/Endpoints/ContainerMutatingEndpoints.cs
+++ b/src/WopiHost.Core/Endpoints/ContainerMutatingEndpoints.cs
@@ -108,12 +108,10 @@ internal static class ContainerMutatingEndpoints
             }
         }
 
-        // Single exit for the resolve/build/respond tail — keeps the handler under qlty's
-        // return-statements threshold (specific-mode conflict, provider null, and success
-        // share one return via the switch). The success-arm body is in a local async
-        // function so the switch arm itself stays a single `await` expression, and the
-        // inner awaits land directly on injected dependencies (which Infer# tracks
-        // cleanly — see #471 history).
+        // Single exit for the resolve/build/respond tail (specific-mode conflict, provider null,
+        // and success share one return via the switch). The success-arm body is in a local async
+        // function so the switch arm itself stays a single `await` expression, and the inner
+        // awaits land directly on injected dependencies (which keeps static analysis precise).
         var resolved = await ResolveNewChildContainer(req.Http, req.Storage, req.WritableStorage, req.Id, requestedName, isSpecificMode: req.RelativeTarget is not null, req.CancellationToken).ConfigureAwait(false);
         return resolved switch
         {
@@ -159,7 +157,7 @@ internal static class ContainerMutatingEndpoints
 
     /// <summary>
     /// Sanitises a container name via <see cref="WopiFileNameSanitiser"/>. Container names have
-    /// no concept of extension, so we drop straight to the scrub helper — there's nothing to
+    /// no concept of extension, so this drops straight to the scrub helper — there's nothing to
     /// preserve on the right-hand side. Falls back to a fresh GUID when the scrubbed name is
     /// unusable (empty / path-nav).
     /// </summary>
@@ -261,9 +259,8 @@ internal static class ContainerMutatingEndpoints
     {
         try
         {
-            // Spec: response is JSON with a single required Name property — the NEW name. The
-            // pre-fix impl returned `container.Name` from the snapshot we fetched before the
-            // rename, so clients received the OLD name and got out-of-sync.
+            // Spec: response is JSON with a single required Name property — the NEW name.
+            // Returning the pre-rename snapshot's name would hand clients the OLD name.
             return await writableStorageProvider.RenameWopiContainer(id, requestedName, cancellationToken).ConfigureAwait(false)
                 ? TypedResults.Json(new RenameContainerResponse(requestedName))
                 : TypedResults.NotFound(); // false → missing resource (race with concurrent delete).

--- a/src/WopiHost.Core/Endpoints/EndpointHelpers.cs
+++ b/src/WopiHost.Core/Endpoints/EndpointHelpers.cs
@@ -20,8 +20,8 @@ internal static partial class EndpointHelpers
     /// tail. The <c>[^/?#]+</c> character class is defensive — <see cref="Uri.AbsolutePath"/>
     /// never includes query / fragment, but rejecting those characters costs nothing.
     /// <see cref="RegexOptions.CultureInvariant"/> pairs with <see cref="RegexOptions.IgnoreCase"/>
-    /// so the literal "files" / "containers" match is locale-independent (Turkish dotless-I
-    /// would otherwise surprise us).
+    /// so the literal "files" / "containers" match is locale-independent (the Turkish dotless-I
+    /// would otherwise break it).
     /// </summary>
     [GeneratedRegex(@"/(files|containers)/([^/?#]+)/?$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex WopiSrcPathRegex();
@@ -35,10 +35,9 @@ internal static partial class EndpointHelpers
     /// caller dispatches on which one was set via subsequent <c>!= null</c> checks.
     /// </summary>
     /// <remarks>
-    /// Whitespace-only header values count as absent (matches the
-    /// <c>string.IsNullOrWhiteSpace</c> semantics the hand-rolled call sites used). .NET 10's
-    /// <c>Microsoft.Extensions.Validation</c> doesn't fit this seam — see #466 for the
-    /// investigation; the validation pipeline is 400-shaped only and can't express 501 NI.
+    /// Whitespace-only header values count as absent (<c>string.IsNullOrWhiteSpace</c> semantics).
+    /// .NET 10's <c>Microsoft.Extensions.Validation</c> doesn't fit this seam: the validation
+    /// pipeline is 400-shaped only and can't express 501 NI.
     /// </remarks>
     public static StatusCodeHttpResult? EnsureExactlyOneOf(string? a, string? b)
         => string.IsNullOrWhiteSpace(a) == string.IsNullOrWhiteSpace(b)
@@ -50,8 +49,8 @@ internal static partial class EndpointHelpers
     /// resource identifier. Accepts absolute URIs whose path ends with <c>/files/{id}</c> or
     /// <c>/containers/{id}</c> (case-insensitive). When the path contains multiple candidate
     /// segments — e.g. <c>/files/archive/containers/abc</c> — the trailing pair wins, which
-    /// matches the WOPI spec's "the resource is at the URL tail" intent and avoids the
-    /// first-match-wins ambiguity of the previous segment-scan implementation.
+    /// matches the WOPI spec's "the resource is at the URL tail" intent and avoids
+    /// first-match-wins ambiguity.
     /// </summary>
     public static bool TryParseWopiSrc(string wopiSrc, out WopiResourceType resourceType, out string resourceId)
     {

--- a/src/WopiHost.Core/Endpoints/FileEndpoints.cs
+++ b/src/WopiHost.Core/Endpoints/FileEndpoints.cs
@@ -128,7 +128,7 @@ internal static class FileEndpoints
 
         var ancestors = await req.Storage.GetFileAncestors(req.Id, req.CancellationToken).ConfigureAwait(false);
         // Mint a fresh container-scoped token per ancestor URL — see IWopiResourceTokenMinter
-        // for the token-trading prevention rationale and the #471 Infer# context.
+        // for the token-trading prevention rationale.
         var children = new List<ChildContainer>();
         foreach (var ancestor in ancestors)
         {

--- a/src/WopiHost.Core/Endpoints/FileMutatingEndpoints.cs
+++ b/src/WopiHost.Core/Endpoints/FileMutatingEndpoints.cs
@@ -62,8 +62,7 @@ internal static class FileMutatingEndpoints
 
         // All POST overloads on /{id} share a route + verb and are discriminated by
         // X-WOPI-Override via WopiOverrideMatcherPolicy. Each is its own endpoint with its own
-        // RequireAuthorization — the security property the migration depends on (per-override
-        // permissions stay distinct).
+        // RequireAuthorization so per-override permissions stay distinct.
         mutating.MapPost("/{id}", RenameFile)
             .WithMetadata(new WopiOverrideMetadata(WopiFileOperations.RenameFile))
             .WithSummary("RenameFile (X-WOPI-Override: RENAME_FILE).")
@@ -128,10 +127,9 @@ internal static class FileMutatingEndpoints
 
         // PutFile branches on the FILE'S current lock state, not on whether X-WOPI-Lock was
         // sent. Spec: "When a host receives a PutFile request on a file that's not locked, the
-        // host checks the current size of the file." Earlier impl keyed off the request header
-        // (string.IsNullOrEmpty(requestLockId)) — which silently overwrote locked 0-byte files
-        // when the client omitted the header (#A) and acquired locks as a side effect when the
-        // client sent one against an unlocked file (#B). Both deviated from
+        // host checks the current size of the file." Keying off the request header instead would
+        // overwrite locked 0-byte files when the client omits the header and acquire locks as a
+        // side effect when the client sends one against an unlocked file. Spec:
         // https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/putfile.
         var existingLock = req.LockProvider is not null
             ? await req.LockProvider.GetLockAsync(req.Id, req.CancellationToken).ConfigureAwait(false)
@@ -188,8 +186,7 @@ internal static class FileMutatingEndpoints
         var requestedFullName = req.RequestedName + '.' + file.Extension;
 
         // Parent container id is the dedup scope for GetSuggestedFileName — passing the file id
-        // here is a long-standing bug that degenerates the provider into echoing the requested
-        // name back. Same fix shape as the pre-#420 PutRelativeFile correction; the storage
+        // here degenerates the provider into echoing the requested name back. The storage
         // contract is GetSuggestedFileName(CONTAINER, name).
         var ancestors = await req.Storage.GetFileAncestors(req.Id, req.CancellationToken).ConfigureAwait(false);
         var parentContainer = ancestors.LastOrDefault()
@@ -306,7 +303,7 @@ internal static class FileMutatingEndpoints
         // Mint a fresh token bound to the NEW file's resource id; reusing the inbound token
         // (scoped to the source file) violates the WOPI "preventing token trading" guidance and
         // would fail downstream authorization for any host whose tokens encode resource id.
-        // See IWopiResourceTokenMinter for the centralized mint + the #471 Infer# context.
+        // See IWopiResourceTokenMinter for the centralized mint.
         var newFileToken = await req.TokenMinter.MintForFileAsync(req.Http.User, newFile, req.CancellationToken).ConfigureAwait(false);
         return TypedResults.Json(new ChildFile(newFile.Name + '.' + newFile.Extension, req.Http.GetWopiSrc(newFile, newFileToken.Token))
         {
@@ -320,7 +317,7 @@ internal static class FileMutatingEndpoints
     /// <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/putuserinfo"/>.
     /// "The UserInfo string is provided in the body of the request, and has a maximum size of
     /// 1024 ASCII characters." Cap the read so a malicious or buggy client can't push an
-    /// unbounded body into our MemoryCache.
+    /// unbounded body into the MemoryCache.
     /// </summary>
     private const int PutUserInfoMaxBytes = 1024;
 
@@ -338,7 +335,7 @@ internal static class FileMutatingEndpoints
 
         // Bounded read: WithinLimit goes false the moment the body exceeds the spec cap mid-stream
         // (chunked transfer-encoding with no Content-Length, or clients that lie about it), so a
-        // malicious or buggy client can't push an unbounded body into our MemoryCache.
+        // malicious or buggy client can't push an unbounded body into the MemoryCache.
         var (withinLimit, bytes) = await req.Http.Request.Body.ReadBytesAsync(PutUserInfoMaxBytes, req.CancellationToken).ConfigureAwait(false);
         if (!withinLimit)
         {
@@ -438,8 +435,7 @@ internal static class FileMutatingEndpoints
 
     /// <summary>
     /// Spec validation gate: enforces lock-id max length and X-WOPI-Lock-required-for-mutation
-    /// rules <em>before</em> dispatching to the per-operation handler. Pre-#456 this lived inline
-    /// in ProcessLockCore (50-line method, two coupled guard chains). Splitting it out leaves
+    /// rules <em>before</em> dispatching to the per-operation handler. Keeping it separate leaves
     /// ProcessLockCore as a pure dispatch state machine and lets the validation rules be tested
     /// or audited in isolation.
     /// </summary>
@@ -520,12 +516,10 @@ internal static class FileMutatingEndpoints
     {
         if (existingLock is not null)
         {
-            // Pre-#456 this hardcoded OrdinalWopiLockComparer.Instance, ignoring the runtime
-            // comparer threaded through ProcessLockCore. Hosts that registered a JSON-shaped
-            // comparer to absorb OOS-style lock-id mutations would silently fall back to
-            // ordinal here — locks acquired via Lock-on-existing-lock would mismatch even
-            // when the configured comparer would have considered them equal. Now uses the
-            // runtime comparer like every sibling Handle* method.
+            // Uses the runtime comparer threaded through ProcessLockCore. Hardcoding ordinal here
+            // would make hosts that registered a JSON-shaped comparer (to absorb OOS-style
+            // lock-id mutations) silently mismatch locks acquired via Lock-on-existing-lock even
+            // when the configured comparer would consider them equal.
             return await LockOrRefresh(newLockIdentifier, existingLock, lockProvider, comparer, ct).ConfigureAwait(false);
         }
         return await lockProvider.AddLockAsync(id, newLockIdentifier, ct).ConfigureAwait(false) is not null
@@ -566,8 +560,8 @@ internal static class FileMutatingEndpoints
             return new WopiLockMismatchResult(existingLock.LockId);
         }
         // Atomic compare-and-refresh: provider receives expected lock id; if a concurrent
-        // UnlockAndRelock swapped the stored id between our snapshot and this call, the refresh
-        // aborts cleanly. Pre-fix this was a check-then-act race.
+        // UnlockAndRelock swapped the stored id between the snapshot and this call, the refresh
+        // aborts cleanly (avoids a check-then-act race).
         return await lockProvider.RefreshLockAsync(existingLock.FileId, newLock, ct).ConfigureAwait(false)
             ? TypedResults.Ok()
             : new WopiLockMismatchResult(reason: "Could not refresh lock");
@@ -638,10 +632,9 @@ public sealed record RenameFileResponse(string Name);
 // IWopiLockComparer is NOT in that bucket — AddWopi() unconditionally TryAddSingleton's an
 // OrdinalWopiLockComparer (hosts override with JsonShapedWopiLockComparer if needed). The
 // service is always present in the container by the time MapWopiEndpoints runs, so the
-// parameter is plain (non-nullable, no [FromServices]). Pre-#456 the records carried
-// IWopiLockComparer? + a null-coalesce fallback at the call sites, which silently masked a
-// host's choice to register JsonShapedWopiLockComparer — every lock-compare went through
-// Ordinal even when the configured comparer was JSON-aware.
+// parameter is plain (non-nullable, no [FromServices]). Declaring it nullable with a
+// null-coalesce fallback at the call sites would silently mask a host's choice to register
+// JsonShapedWopiLockComparer, routing every lock-compare through Ordinal.
 
 /// <summary>Parameter bundle for <see cref="FileMutatingEndpoints.PutFile"/>.</summary>
 internal readonly record struct PutFileRequest(

--- a/src/WopiHost.Core/Endpoints/FolderEndpoints.cs
+++ b/src/WopiHost.Core/Endpoints/FolderEndpoints.cs
@@ -45,7 +45,7 @@ internal static class FolderEndpoints
         if (folder is null) return TypedResults.NotFound();
 
         // Build sync, then fire the host hook — keeps the only `await` on a direct interface
-        // call, mirroring the controller version's structure to avoid the Infer# FP at #363.
+        // call, which keeps static analysis of the async state machine precise.
         var checkFolderInfo = req.Builder.Build(folder, req.Http.User);
         checkFolderInfo = await req.Extensions.OnCheckFolderInfoAsync(
             new WopiCheckFolderInfoContext(req.Http.User, folder, checkFolderInfo),
@@ -64,7 +64,7 @@ internal static class FolderEndpoints
         var files = new List<ChildFile>();
         var fileExtensions = req.FileExtensionFilterList?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         // Mint per-file resource-scoped tokens — see IWopiResourceTokenMinter for the
-        // token-trading prevention rationale and the #471 Infer# context.
+        // token-trading prevention rationale.
         await foreach (var wopiFile in req.Storage.GetWopiFiles(req.Id, fileExtensions, req.CancellationToken).ConfigureAwait(false))
         {
             var fileToken = await req.TokenMinter.MintForFileAsync(req.Http.User, wopiFile, req.CancellationToken).ConfigureAwait(false);
@@ -76,8 +76,7 @@ internal static class FolderEndpoints
             });
         }
 
-        // Folder shape matches the legacy FoldersController.EnumerateChildren payload
-        // (only ChildFiles — no ChildContainers, by design of the historic folder surface).
+        // The folder surface returns only ChildFiles — no ChildContainers, by design.
         return TypedResults.Json(new FolderChildrenResponse(files));
     }
 }

--- a/src/WopiHost.Core/Extensions/Extensions.cs
+++ b/src/WopiHost.Core/Extensions/Extensions.cs
@@ -43,8 +43,8 @@ internal static class Extensions
         ArgumentNullException.ThrowIfNull(input);
         ArgumentOutOfRangeException.ThrowIfNegative(maxBytes);
 
-        // Single backing buffer sized to maxBytes+1 so the read that pushes us past the cap trips
-        // the limit — ReadAsync writes directly at the running offset, no intermediate chunk array
+        // Single backing buffer sized to maxBytes+1 so the read that crosses the cap trips the
+        // limit — ReadAsync writes directly at the running offset, no intermediate chunk array
         // or MemoryStream copy, and the allocation can never exceed maxBytes+1.
         var buffer = new byte[maxBytes + 1];
         var total = 0;
@@ -137,9 +137,9 @@ internal static class Extensions
             ["access_token"] = accessToken,
         };
         // Preserve identifier casing. The global routing option set by AddWopi()
-        // (`AddRouting(o => o.LowercaseUrls = true)` — introduced in PR #253 / commit 8baf8844
-        // for "spec-compliant lowercase paths" like /wopi/files/{id} instead of
-        // /wopi/Files/{id}) lowercases BOTH route literals AND route parameter values, but the
+        // (`AddRouting(o => o.LowercaseUrls = true)` for spec-compliant lowercase paths like
+        // /wopi/files/{id} instead of /wopi/Files/{id}) lowercases BOTH route literals AND route
+        // parameter values, but the
         // JWT `wopi:resource_id` claim is minted verbatim from file.Identifier /
         // container.Identifier. Without this override, a host with mixed-case ids (think a
         // SharePoint-style provider returning `01ABCDEF`) would build URLs containing

--- a/src/WopiHost.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/WopiHost.Core/Extensions/ServiceCollectionExtensions.cs
@@ -26,8 +26,8 @@ public static class ServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         services.AddMemoryCache();
         services.AddRouting(options => options.LowercaseUrls = true);
-        // AddAuthorization (not AddAuthorizationCore) — middleware-tier services for
-        // app.UseAuthorization() were previously brought in by AddControllers.
+        // AddAuthorization (not AddAuthorizationCore) — brings in the middleware-tier services
+        // that app.UseAuthorization() needs.
         services.AddAuthorization();
 
         services.AddSingleton<IAuthorizationHandler, WopiAuthorizationHandler>();

--- a/src/WopiHost.Core/Extensions/WopiExtensions.cs
+++ b/src/WopiHost.Core/Extensions/WopiExtensions.cs
@@ -16,10 +16,9 @@ public static class WopiExtensions
     /// <returns>base64 encoded sha256 checksum</returns>
     /// <remarks>
     /// Uses the static <see cref="SHA256.HashDataAsync(Stream, CancellationToken)"/> one-shot
-    /// API rather than an instance-cached <see cref="SHA256"/>. A previous revision held a static
-    /// <see cref="SHA256"/> instance and called <c>ComputeHashAsync</c> on it from concurrent
-    /// CheckFileInfo requests; <see cref="SHA256"/> instance methods are not thread-safe, so that
-    /// pattern could corrupt the hash or throw under load.
+    /// API rather than an instance-cached <see cref="SHA256"/>. <see cref="SHA256"/> instance
+    /// methods are not thread-safe, so a shared instance called from concurrent CheckFileInfo
+    /// requests could corrupt the hash or throw under load.
     /// </remarks>
     public static async Task<string> GetEncodedSha256(this IWopiFile file, CancellationToken cancellationToken = default)
     {

--- a/src/WopiHost.Core/Infrastructure/DefaultCheckContainerInfoBuilder.cs
+++ b/src/WopiHost.Core/Infrastructure/DefaultCheckContainerInfoBuilder.cs
@@ -25,8 +25,7 @@ public class DefaultCheckContainerInfoBuilder(
 
         // Spec: IsAnonymousUser "should match the IsAnonymousUser value returned in
         // CheckFileInfo" — and the file / folder builders both set it from the auth state.
-        // CheckContainerInfo was previously omitting it (left as default `false`), so
-        // anonymous users were reported as authenticated in the container response.
+        // Omitting it would report anonymous users as authenticated in the container response.
         var isAnonymous = user.Identity?.IsAuthenticated != true;
 
         var checkContainerInfo = new WopiCheckContainerInfo

--- a/src/WopiHost.Core/Infrastructure/DefaultCheckFileInfoBuilder.cs
+++ b/src/WopiHost.Core/Infrastructure/DefaultCheckFileInfoBuilder.cs
@@ -29,7 +29,7 @@ public class DefaultCheckFileInfoBuilder(
         ArgumentNullException.ThrowIfNull(file);
         ArgumentNullException.ThrowIfNull(request);
 
-        // #181 make sure the BaseFileName always has an extension
+        // Make sure the BaseFileName always has an extension.
         var baseFileName = file.Name.EndsWith(file.Extension, StringComparison.OrdinalIgnoreCase)
             ? file.Name
             : file.Name + "." + file.Extension.TrimStart('.');
@@ -107,7 +107,7 @@ public class DefaultCheckFileInfoBuilder(
         // contract documents RequestUrl as nullable specifically for this case.
         if (linkGenerator is not null && request.RequestUrl is not null)
         {
-            // The Uri the adapter handed us already incorporates the proxy-aware scheme + host
+            // The Uri the adapter produced already incorporates the proxy-aware scheme + host
             // (X-Forwarded-Proto / X-Forwarded-Host honoured), so LinkGenerator receives the
             // upstream-facing values rather than the post-proxy hostname.
             var scheme = request.RequestUrl.Scheme;

--- a/src/WopiHost.Core/Infrastructure/DefaultCheckFolderInfoBuilder.cs
+++ b/src/WopiHost.Core/Infrastructure/DefaultCheckFolderInfoBuilder.cs
@@ -5,10 +5,10 @@ using WopiHost.Core.Extensions;
 namespace WopiHost.Core.Infrastructure;
 
 /// <summary>
-/// Default <see cref="ICheckFolderInfoBuilder"/>. Synchronous on purpose — see #363; the
-/// controller fires <see cref="IWopiHostExtensions.OnCheckFolderInfoAsync"/> afterwards so its
-/// only <c>await</c> on this path is the direct hook invocation, avoiding the Infer# null-deref
-/// FP that the issue tracks.
+/// Default <see cref="ICheckFolderInfoBuilder"/>. Synchronous on purpose: the caller fires
+/// <see cref="IWopiHostExtensions.OnCheckFolderInfoAsync"/> afterwards so its only <c>await</c>
+/// on this path is the direct hook invocation, which keeps static analysis of the async state
+/// machine precise.
 /// </summary>
 public class DefaultCheckFolderInfoBuilder : ICheckFolderInfoBuilder
 {

--- a/src/WopiHost.Core/Infrastructure/DefaultWopiNewChildFileNegotiator.cs
+++ b/src/WopiHost.Core/Infrastructure/DefaultWopiNewChildFileNegotiator.cs
@@ -45,7 +45,7 @@ public sealed class DefaultWopiNewChildFileNegotiator(
             // Compute a sanitised stem + original extension, then dedupe via GetSuggestedFileName.
             // The suggestion is best-effort — when the sanitised candidate still fails validation
             // (provider rules beyond forbidden-char swap, e.g. reserved names like CON on Windows),
-            // we omit the header rather than emit a name we know is invalid.
+            // the header is omitted rather than emitting a name known to be invalid.
             var sanitised = await TryBuildValidSuggestionAsync(request, relativeTarget, cancellationToken).ConfigureAwait(false);
             return WopiNewChildFileResult.BadRequest(sanitised);
         }
@@ -63,10 +63,8 @@ public sealed class DefaultWopiNewChildFileNegotiator(
         if (!request.OverwriteRelativeTarget)
         {
             // Suggest a deduplicated alternative for X-WOPI-ValidRelativeTarget.
-            // Pre-#420 #1.1: PutRelativeFile was passing the file id here instead of the
-            // parent container id, so GetSuggestedFileName resolved against the wrong location
-            // and degenerated to echoing the requested name back. Centralizing here pins the
-            // correct containerId in one place.
+            // GetSuggestedFileName must resolve against the parent container id; passing the file
+            // id would degenerate to echoing the requested name back.
             var suggestedName = await writable.GetSuggestedFileName(request.ContainerId, relativeTarget, cancellationToken).ConfigureAwait(false);
             return WopiNewChildFileResult.Conflict(suggestedName);
         }
@@ -75,7 +73,7 @@ public sealed class DefaultWopiNewChildFileNegotiator(
         // and asked to overwrite, but the host's ACL may still deny overwrite of THIS specific
         // existing file. The decision is per-target and only resolvable now that `existing` is
         // in scope (it isn't known at token-mint time, so it can't be encoded as a
-        // WopiFilePermissions flag on the access token). See #455 and
+        // WopiFilePermissions flag on the access token). Spec:
         // https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/putrelativefile —
         // "If the user is not authorized to overwrite the target file, the host must respond
         // with a 501 Not Implemented."
@@ -85,8 +83,8 @@ public sealed class DefaultWopiNewChildFileNegotiator(
         }
 
         // Overwrite is allowed — a file matching the target name might still be locked.
-        // Lock probe inlined (no helper method) so Infer# can see through it — cross-method
-        // async helpers trip its null-deref FP, see PR #424 review feedback and #363 / #412.
+        // Lock probe inlined (no helper method) so static analysis can see through it; cross-method
+        // async helpers trip a null-deref false positive.
         if (lockProvider is not null)
         {
             var existingLock = await lockProvider.GetLockAsync(existing.Identifier, cancellationToken).ConfigureAwait(false);
@@ -97,9 +95,9 @@ public sealed class DefaultWopiNewChildFileNegotiator(
         }
 
         // Overwrite-allowed + unlocked — upgrade the existing file (fetched via the read-side
-        // interface as IWopiFile) to IWopiWritableFile so the caller can mutate it. After
-        // #420 item 1.2 the write seam is gated by the writable interface; the read-side
-        // GetWopiFileByName intentionally returns the narrower IWopiFile.
+        // interface as IWopiFile) to IWopiWritableFile so the caller can mutate it. The write
+        // seam is gated by the writable interface; the read-side GetWopiFileByName intentionally
+        // returns the narrower IWopiFile.
         var writableExisting = await writable.GetWritableFile(existing.Identifier, cancellationToken).ConfigureAwait(false);
         return writableExisting is not null
             ? WopiNewChildFileResult.Success(writableExisting)
@@ -123,8 +121,7 @@ public sealed class DefaultWopiNewChildFileNegotiator(
             // proposed name as needed to create a new file that's both legally named and doesn't
             // overwrite any existing file, while preserving the file extension."
             // Try sanitising the requested name first; if that still fails, fall back to the
-            // caller-supplied stem + original extension (the same shape we use for
-            // extension-only inputs).
+            // caller-supplied stem + original extension (the same shape as extension-only inputs).
             suggestedTarget = await TryBuildValidSuggestionAsync(request, suggestedTarget, cancellationToken).ConfigureAwait(false)
                 ?? request.SuggestedExtensionFallbackStem + WopiFileNameSanitiser.ExtractExtension(suggestedTarget);
         }

--- a/src/WopiHost.Core/Infrastructure/UtfString.cs
+++ b/src/WopiHost.Core/Infrastructure/UtfString.cs
@@ -106,8 +106,8 @@ public class UtfString : IParsable<UtfString>
         // X-WOPI-SuggestedTarget and X-WOPI-RelativeTarget headers — see
         // https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/putrelativefile#request-headers
         // and the MS-WOPI protocol spec section 2.2.5.1.5. The framework deprecation is unrelated
-        // to the protocol requirement; we cannot change to a different encoding without breaking
-        // interop with Office Online / Microsoft 365 for the Web.
+        // to the protocol requirement; a different encoding would break interop with Office
+        // Online / Microsoft 365 for the Web.
 #pragma warning disable SYSLIB0001 // Type or member is obsolete — required by WOPI spec
         Encoding utf7 = Encoding.UTF7;
 #pragma warning restore SYSLIB0001

--- a/src/WopiHost.Core/Infrastructure/WopiFileNameSanitiser.cs
+++ b/src/WopiHost.Core/Infrastructure/WopiFileNameSanitiser.cs
@@ -6,7 +6,7 @@ namespace WopiHost.Core.Infrastructure;
 /// Cross-platform forbidden-character sanitisation shared by the file-name + container-name
 /// negotiation paths. WOPI's spec is silent on which characters are forbidden — the upstream
 /// provider's <see cref="IWopiWritableStorageProvider.CheckValidFileName"/> is the source of
-/// truth — but every concrete provider we ship rejects the same Windows-portable set, so a
+/// truth — but every concrete provider in this repo rejects the same Windows-portable set, so a
 /// central best-effort scrub lets the spec's "host should try to generate a different name based
 /// on the requested name" branch land at a candidate that's almost always acceptable to the
 /// provider on the second swing.

--- a/src/WopiHost.Core/Infrastructure/WopiHeaders.cs
+++ b/src/WopiHost.Core/Infrastructure/WopiHeaders.cs
@@ -30,9 +30,9 @@ public static class WopiHeaders
     /// tests that pin the spec-compliant default.
     /// </para>
     /// <para>
-    /// Hosting under IIS in-process strips empty header values before they reach the wire (see
-    /// issue #208). Hosts on that path should set <c>WopiHostOptions.EmptyLockHeaderValue = " "</c>
-    /// to opt into the historic single-space workaround.
+    /// Hosting under IIS in-process strips empty header values before they reach the wire.
+    /// Hosts on that path should set <c>WopiHostOptions.EmptyLockHeaderValue = " "</c>
+    /// to opt into the single-space workaround.
     /// </para>
     /// </remarks>
     public const string EMPTY_LOCK_VALUE = "";

--- a/src/WopiHost.Core/Infrastructure/WopiLockAwareWritableStorageProvider.cs
+++ b/src/WopiHost.Core/Infrastructure/WopiLockAwareWritableStorageProvider.cs
@@ -67,11 +67,9 @@ public sealed class WopiLockAwareWritableStorageProvider(
         => _inner.GetSuggestedContainerName(containerId, name, cancellationToken);
 
     // The lock probe (GetLockAsync + throw-if-locked) is inlined into each of the four
-    // mutating methods below rather than extracted into a private async helper. Infer# can't
-    // see through cross-method async calls and flags the helper's returned Task as potentially
-    // null at every caller (verified again on PR #424 — 4 NULLPTR_DEREFERENCE findings when
-    // the four bodies shared a `private async Task GuardLockAsync(...)`). Same trade-off the
-    // codebase made earlier for the lock provider — see #363, #412.
+    // mutating methods below rather than extracted into a private async helper. Static analysis
+    // can't see through cross-method async calls and flags a shared helper's returned Task as
+    // potentially null at every caller, so inlining avoids the false positive.
 
     /// <inheritdoc />
     public async Task<bool> DeleteWopiFile(string identifier, CancellationToken cancellationToken = default)

--- a/src/WopiHost.Core/Infrastructure/WopiNewChildFileResultExtensions.cs
+++ b/src/WopiHost.Core/Infrastructure/WopiNewChildFileResultExtensions.cs
@@ -45,7 +45,7 @@ internal static class WopiNewChildFileResultExtensions
                 // Spec: PutRelativeFile returns 501 specifically when the caller is authorized
                 // to invoke the operation but not authorized to overwrite the existing target.
                 // No spec-defined response headers for this path; the status code carries the
-                // signal on its own. See #455.
+                // signal on its own.
                 return TypedResults.StatusCode(StatusCodes.Status501NotImplemented);
             default:
                 throw new InvalidOperationException($"Unknown {nameof(WopiNewChildFileOutcome)}: {result.Outcome}");

--- a/src/WopiHost.Core/Infrastructure/WopiOverrideMatcherPolicy.cs
+++ b/src/WopiHost.Core/Infrastructure/WopiOverrideMatcherPolicy.cs
@@ -18,8 +18,7 @@ namespace WopiHost.Core.Infrastructure;
 /// (Order ≈ -1000) discards verb mismatches; URL template matching populates the candidate set.
 /// By the time this policy runs, the surviving candidates share both route template and verb,
 /// so header-based discrimination is the last cut and per-endpoint authorization is evaluated
-/// against the single selected endpoint (the property the migration depends on — see
-/// <see href="https://github.com/petrsvihlik/WopiHost/issues/430">issue #430</see>).
+/// against the single selected endpoint.
 /// </para>
 /// <para>
 /// <strong>Selection failure mode.</strong> When the request header is missing or its value is

--- a/src/WopiHost.Core/Infrastructure/WopiTelemetryEndpointFilter.Logging.cs
+++ b/src/WopiHost.Core/Infrastructure/WopiTelemetryEndpointFilter.Logging.cs
@@ -5,14 +5,12 @@ namespace WopiHost.Core.Infrastructure;
 /// <summary>
 /// Source-generated <see cref="LoggerMessageAttribute"/> declarations for
 /// <see cref="WopiTelemetryEndpointFilter"/>. Lives in a partial so the source generator
-/// can emit the strongly-typed delegate without us paying the per-call allocation of
+/// can emit the strongly-typed delegate without the per-call allocation of
 /// <c>logger.LogX(string, params object?[])</c>.
 /// </summary>
 /// <remarks>
 /// <c>userId</c> intentionally stays out of the message template — the telemetry filter
-/// already pushes it into the log scope under <see cref="WopiTelemetry.Tags.UserId"/>, and
-/// keeping it out of the positional parameter list pins the param count under qlty's
-/// function-parameters threshold without further structural gymnastics.
+/// already pushes it into the log scope under <see cref="WopiTelemetry.Tags.UserId"/>.
 /// </remarks>
 internal sealed partial class WopiTelemetryEndpointFilter
 {

--- a/src/WopiHost.Core/Infrastructure/WopiTelemetryEndpointFilter.cs
+++ b/src/WopiHost.Core/Infrastructure/WopiTelemetryEndpointFilter.cs
@@ -24,13 +24,12 @@ namespace WopiHost.Core.Infrastructure;
 /// <para>
 /// <strong>Resource kind dispatch.</strong> Read from
 /// <see cref="WopiResourceKindMetadata"/>; defaults to <see cref="WopiResourceType.File"/> when
-/// absent (matches the historic controller behaviour where files are the common case and
-/// Containers / Folders explicitly switch the dimension).
+/// absent (files are the common case; Containers / Folders explicitly switch the dimension).
 /// </para>
 /// <para>
 /// <strong>Outcome classification.</strong> Result types implementing
 /// <see cref="IWopiOutcomeResult"/> win (the lock-mismatch case — 409 is shared with generic
-/// conflict but dashboards need them separated). Otherwise we read the response status code,
+/// conflict but dashboards need them separated). Otherwise the response status code is read,
 /// which is set on <c>HttpResponse</c> by the time <c>next()</c> returns since Minimal-API
 /// results are executed synchronously inside the pipeline. Unhandled exceptions surface as
 /// <see cref="WopiTelemetry.Outcomes.Cancelled"/> when the request was aborted by the client,

--- a/src/WopiHost.Core/Models/WopiHostOptions.cs
+++ b/src/WopiHost.Core/Models/WopiHostOptions.cs
@@ -37,8 +37,8 @@ public class WopiHostOptions : IDiscoveryOptions
     /// </para>
     /// <para>
     /// Set to <c>" "</c> (a single space) when hosting under <em>IIS in-process</em>, which strips
-    /// empty header values before they reach the wire (see issue #208). The space is technically
-    /// non-spec but is the historic workaround and what every WOPI client treats as "no lock". Also
+    /// empty header values before they reach the wire. The space is technically
+    /// non-spec but is the established workaround and what every WOPI client treats as "no lock". Also
     /// useful as an escape hatch behind any other downstream component that drops empty headers.
     /// </para>
     /// </remarks>
@@ -64,10 +64,8 @@ public class WopiHostOptions : IDiscoveryOptions
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Resolves #425 item 2.7: pre-fix the entries were stored with
-    /// <see cref="Microsoft.Extensions.Caching.Memory.CacheItemPriority.NeverRemove"/> and no
-    /// expiry, pinning per-user data indefinitely — unbounded memory in any host that sees
-    /// many distinct users. With an absolute expiry, total memory is bounded by
+    /// Without an expiry the entries would pin per-user data indefinitely — unbounded memory in
+    /// any host that sees many distinct users. With an absolute expiry, total memory is bounded by
     /// <c>UserInfoCacheLifetime × distinct-active-users</c>.
     /// </para>
     /// <para>

--- a/src/WopiHost.Core/Security/Authentication/JwtAccessTokenService.cs
+++ b/src/WopiHost.Core/Security/Authentication/JwtAccessTokenService.cs
@@ -26,12 +26,12 @@ public partial class JwtAccessTokenService(
     private readonly JwtSecurityTokenHandler _handler = new() { MapInboundClaims = true };
 
     // Lazy<T> default is LazyThreadSafetyMode.ExecutionAndPublication: exactly one factory
-    // invocation across all threads, the rest block on the result. Pre-#409-item-2.4 the
-    // null-check + assignment in GetSigningKey raced on first request, so concurrent first
-    // callers each minted a *different* random key and tokens signed during the race window
-    // would fail validation under whichever key lost the publish (the log line also fired
-    // multiple times). Field-initializer form keeps the factory cold until first read so the
-    // production path (SecurityKey / SigningKey configured) never pays the entropy cost.
+    // invocation across all threads, the rest block on the result. A plain null-check +
+    // assignment would race on first request, so concurrent first callers would each mint a
+    // *different* random key and tokens signed during the race window would fail validation
+    // under whichever key lost the publish. Field-initializer form keeps the factory cold until
+    // first read so the production path (SecurityKey / SigningKey configured) never pays the
+    // entropy cost.
     private readonly Lazy<SymmetricSecurityKey> _ephemeralDevKey = new(() =>
     {
         var keyBytes = RandomNumberGenerator.GetBytes(64);

--- a/src/WopiHost.Core/Security/Authentication/WopiProofValidator.cs
+++ b/src/WopiHost.Core/Security/Authentication/WopiProofValidator.cs
@@ -37,8 +37,7 @@ public partial class WopiProofValidator(IDiscoverer discoverer, ILogger<WopiProo
     /// Validates the WOPI proof headers on the given request.
     /// </summary>
     /// <param name="request">Framework-neutral request envelope (proxy-aware URL + header
-    /// reader). Pre-#457 this was an <c>HttpContext</c>; refactored so
-    /// <c>WopiHost.Abstractions</c> no longer depends on ASP.NET.</param>
+    /// reader) so <c>WopiHost.Abstractions</c> does not depend on ASP.NET.</param>
     /// <param name="accessToken">The access token from the request.</param>
     /// <returns>True if the request's proof headers are valid, false otherwise.</returns>
     public async Task<bool> ValidateProofAsync(WopiRequestInfo request, string accessToken)
@@ -78,15 +77,14 @@ public partial class WopiProofValidator(IDiscoverer discoverer, ILogger<WopiProo
             }
 
             // WOPI spec signs the EXACT URL the client called, case-sensitive on path/query.
-            // The adapter built request.RequestUrl from the proxy-aware reconstruction (i.e.
-            // X-Forwarded-Proto / X-Forwarded-Host honoured); .OriginalString preserves it
-            // byte-for-byte. The .ToUpperInvariant() that follows matches WOPI's signature
-            // contract — case-folded uniformly across host case quirks.
+            // request.RequestUrl comes from the proxy-aware reconstruction (X-Forwarded-Proto /
+            // X-Forwarded-Host honoured); .OriginalString preserves it byte-for-byte. The
+            // .ToUpperInvariant() that follows matches WOPI's signature contract — case-folded
+            // uniformly across host case quirks.
             //
             // Null RequestUrl: the adapter couldn't reconstruct a usable URL (synthesised
             // context, blank scheme/host). Without a URL there's nothing to sign against —
-            // fail validation. Pre-#457 this produced "://" and signature mismatch; same
-            // observable outcome via a typed null check.
+            // fail validation.
             if (request.RequestUrl is null)
             {
                 LogProofHeadersMissing(logger);
@@ -143,7 +141,7 @@ public partial class WopiProofValidator(IDiscoverer discoverer, ILogger<WopiProo
     /// Returns true for exceptions that must NOT be silently coerced into "validation failed."
     /// These are the canonical async-rude / process-fatal exceptions: catching them here would
     /// mask a torn process state and let the request continue against a broken host. The
-    /// runtime considers them "always rethrow" — we mirror that convention for the proof gate.
+    /// runtime considers them "always rethrow"; the proof gate mirrors that convention.
     /// </summary>
     private static bool IsCriticalUnwindException(Exception ex) => ex is
         OutOfMemoryException or

--- a/src/WopiHost.Core/Security/Authorization/WopiAuthorizationHandler.cs
+++ b/src/WopiHost.Core/Security/Authorization/WopiAuthorizationHandler.cs
@@ -13,7 +13,7 @@ namespace WopiHost.Core.Security.Authorization;
 /// </summary>
 /// <remarks>
 /// <para>
-/// We intentionally do not enforce a strict route-id ↔ <see cref="WopiClaimTypes.ResourceId"/>
+/// This handler intentionally does not enforce a strict route-id ↔ <see cref="WopiClaimTypes.ResourceId"/>
 /// match. WOPI clients (including Office for the web) and the Microsoft WOPI validator use a
 /// single token to navigate from a file to its ancestor container, list siblings, etc. — so a
 /// strict per-resource binding would break the protocol's assumed cross-resource access.
@@ -38,7 +38,7 @@ public partial class WopiAuthorizationHandler(ILogger<WopiAuthorizationHandler> 
     protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, WopiAuthorizeAttribute requirement, HttpContext resource)
     {
         // Per-request resource id stays in a local — never written onto the (shared) requirement.
-        // See class doc and #380 items 2.5 / 5.3.
+        // See class doc for why.
         var routeResourceId = resource.Request.RouteValues.TryGetValue("id", out var fileIdRaw)
             ? fileIdRaw?.ToString()
             : null;
@@ -78,7 +78,7 @@ public partial class WopiAuthorizationHandler(ILogger<WopiAuthorizationHandler> 
         // Unlike the resource-route dispatch (Extensions.GetWopiSrc), this site can't route
         // through IWopiResource.Kind because the resource type comes from the
         // [WopiAuthorize(...)] attribute (compile-time metadata), not from a resolved
-        // resource instance. The explicit switch is the right shape here (#420 item 2.11).
+        // resource instance.
         return requirement.ResourceType switch
         {
             WopiResourceType.File => HasFilePermission(user, requirement.Permission),

--- a/src/WopiHost.Core/Security/ResourceTokenMinter.cs
+++ b/src/WopiHost.Core/Security/ResourceTokenMinter.cs
@@ -64,8 +64,8 @@ public sealed partial class ResourceTokenMinter(
     }
 
     /// <summary>
-    /// Synchronous request-shape builder. No async state machine on this path means Infer# stays
-    /// clean even when the await above it is on a same-class method (see #471 history).
+    /// Synchronous request-shape builder. No async state machine on this path means static
+    /// analysis stays clean even when the await above it is on a same-class method.
     /// <see cref="WopiAccessTokenRequest"/> exposes both <see cref="WopiAccessTokenRequest.FilePermissions"/>
     /// and <see cref="WopiAccessTokenRequest.ContainerPermissions"/>; the token-issuing path
     /// consults the set whose <see cref="WopiAccessTokenRequest.ResourceType"/> matches and

--- a/src/WopiHost.Discovery/AsyncExpiringLazy{T}.cs
+++ b/src/WopiHost.Discovery/AsyncExpiringLazy{T}.cs
@@ -15,7 +15,7 @@ public class AsyncExpiringLazy<T>(Func<TemporaryValue<T>, Task<TemporaryValue<T>
 {
     // Instance-scoped on purpose: a static lock would be shared across every
     // AsyncExpiringLazy<T> with the same closed generic type, serializing
-    // unrelated callers (also fixed in #303).
+    // unrelated callers.
     private readonly SemaphoreSlim _syncLock = new(initialCount: 1);
     private readonly Func<TemporaryValue<T>, Task<TemporaryValue<T>>> _valueProvider = valueProvider ?? throw new ArgumentNullException(nameof(valueProvider));
     private TemporaryValue<T> _value;
@@ -45,8 +45,8 @@ public class AsyncExpiringLazy<T>(Func<TemporaryValue<T>, Task<TemporaryValue<T>
     {
         // Hold the lock for the entire operation so concurrent first-time
         // callers do not each invoke the (typically network-bound) value
-        // provider. Releasing between the cache check and the fetch was the
-        // bug fixed in #303.
+        // provider. Releasing between the cache check and the fetch would let
+        // multiple callers fetch concurrently.
         await _syncLock.WaitAsync().ConfigureAwait(false);
         try
         {

--- a/src/WopiHost.Discovery/HttpDiscoveryFileProvider.cs
+++ b/src/WopiHost.Discovery/HttpDiscoveryFileProvider.cs
@@ -44,9 +44,8 @@ public partial class HttpDiscoveryFileProvider(HttpClient httpClient, ILogger<Ht
             throw new DiscoveryException($"The WOPI Client at '{_httpClient.BaseAddress}' did not respond within the configured HttpClient.Timeout.", e);
         }
         // Malformed XML from the WOPI client (or a server returning 200 with a non-XML body —
-        // e.g. an error page) used to propagate as XmlException, which callers couldn't catch
-        // cleanly alongside the rest of the discovery failure surface. Wrap to keep the
-        // single-exception-type contract.
+        // e.g. an error page) surfaces as XmlException. Wrap it so callers see a single
+        // discovery-failure exception type.
         catch (XmlException e)
         {
             LogDiscoveryFetchFailed(_logger, e, _httpClient.BaseAddress);

--- a/src/WopiHost.Discovery/ServiceCollectionExtensions.cs
+++ b/src/WopiHost.Discovery/ServiceCollectionExtensions.cs
@@ -20,17 +20,14 @@ public static class ServiceCollectionExtensions
         Action<DiscoveryOptions> configureDiscoveryOptions)
         where TOptions : class, IDiscoveryOptions
     {
-        // Configure discovery options
         services.Configure<DiscoveryOptions>(configureDiscoveryOptions);
 
-        // Add HTTP client for discovery with automatic configuration
         services.AddHttpClient<IDiscoveryFileProvider, HttpDiscoveryFileProvider>((sp, client) =>
         {
             var wopiOptions = sp.GetRequiredService<IOptions<TOptions>>();
             client.BaseAddress = wopiOptions.Value.ClientUrl;
         });
 
-        // Add discoverer
         services.AddSingleton<IDiscoverer, WopiDiscoverer>();
 
         return services;

--- a/src/WopiHost.Discovery/WopiDiscoverer.cs
+++ b/src/WopiHost.Discovery/WopiDiscoverer.cs
@@ -31,10 +31,8 @@ public partial class WopiDiscoverer : IDiscoverer, IDisposable
     private readonly IOptions<DiscoveryOptions> _discoveryOptions;
     private readonly ILogger<WopiDiscoverer> _logger;
 
-    // Eagerly constructed in the ctor (and stored in readonly fields) so
-    // Infer# can statically track the SemaphoreSlim allocation through to
-    // Dispose(). The previous lazy `??=` pattern hid ownership from the
-    // analyzer and was reported as PULSE_RESOURCE_LEAK.
+    // Eagerly constructed in the ctor and held in readonly fields so the
+    // SemaphoreSlim they own is deterministically released in Dispose().
     private readonly AsyncExpiringLazy<IEnumerable<XElement>> _apps;
     private readonly AsyncExpiringLazy<XElement> _proofKey;
     private bool _disposed;

--- a/src/WopiHost.FileSystemProvider/InMemoryFileIds.cs
+++ b/src/WopiHost.FileSystemProvider/InMemoryFileIds.cs
@@ -14,8 +14,8 @@ namespace WopiHost.FileSystemProvider;
 /// </para>
 /// <para>
 /// Backed by two <see cref="ConcurrentDictionary{TKey, TValue}"/> instances — the primary
-/// id→path map plus a path→id reverse-lookup map — so <see cref="TryGetFileId"/> is O(1) instead
-/// of the O(n) <c>FirstOrDefault</c> scan of the pre-#409-item-2.2 implementation. Reads
+/// id→path map plus a path→id reverse-lookup map — so <see cref="TryGetFileId"/> is O(1) rather
+/// than an O(n) scan. Reads
 /// (<see cref="TryGetFileId"/> / <see cref="TryGetPath"/> / <see cref="GetPath"/> /
 /// <see cref="WasScanned"/>) are lock-free. Mutations (<see cref="AddFile"/> /
 /// <see cref="UpdateFile"/> / <see cref="RemoveId"/> / <see cref="ScanAll"/>) serialize on a
@@ -77,7 +77,7 @@ public partial class InMemoryFileIds(ILogger<InMemoryFileIds> logger)
         {
             if (_idToPath.TryRemove(fileId, out var path))
             {
-                // Drop the reverse entry only if it still points at this id — otherwise we'd
+                // Drop the reverse entry only if it still points at this id — otherwise this would
                 // clobber a newer binding that re-attached the same path to a different id.
                 ((ICollection<KeyValuePair<string, string>>)_pathToId)
                     .Remove(new KeyValuePair<string, string>(path, fileId));

--- a/src/WopiHost.FileSystemProvider/LinuxFileOwner.cs
+++ b/src/WopiHost.FileSystemProvider/LinuxFileOwner.cs
@@ -32,8 +32,8 @@ internal static partial class LinuxFileOwner
         return UnixUserResolver.ResolveUserNameOrUid(stx.stx_uid);
     }
 
-    // Only the leading fields are read; allocate the full kernel-defined
-    // 256-byte size so statx has room to write the rest of the record.
+    // Only the leading fields are read; the full kernel-defined 256-byte
+    // size gives statx room to write the rest of the record.
     [StructLayout(LayoutKind.Sequential, Size = 256)]
     private struct StatxBuf
     {
@@ -45,11 +45,10 @@ internal static partial class LinuxFileOwner
         public uint stx_gid;
     }
 
-    // CA5392 wants explicit DLL search paths to limit the loader's search to safe directories
-    // and prevent DLL hijacking. The attribute is honored on Windows only — on Linux the dynamic
-    // loader uses LD_LIBRARY_PATH + system paths and ignores the attribute entirely. This whole
-    // class is [SupportedOSPlatform("linux")] so the attribute is effectively a no-op for us, but
-    // it satisfies the analyzer and documents intent.
+    // CA5392 wants explicit DLL search paths to prevent DLL hijacking. The attribute is honored
+    // on Windows only — on Linux the dynamic loader uses LD_LIBRARY_PATH + system paths and
+    // ignores it. This class is [SupportedOSPlatform("linux")] so the attribute is effectively a
+    // no-op here, but it satisfies the analyzer.
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
     [LibraryImport("libc", EntryPoint = "statx", SetLastError = true, StringMarshalling = StringMarshalling.Utf8)]
     private static partial int Statx(

--- a/src/WopiHost.FileSystemProvider/MacFileOwner.cs
+++ b/src/WopiHost.FileSystemProvider/MacFileOwner.cs
@@ -9,11 +9,11 @@ namespace WopiHost.FileSystemProvider;
 /// (UID → name).
 /// </summary>
 /// <remarks>
-/// macOS has no <c>statx</c>, so we P/Invoke <c>stat</c> directly. The wrinkle is the
+/// macOS has no <c>statx</c>, so this P/Invokes <c>stat</c> directly. The wrinkle is the
 /// 64-bit-inode ABI transition: on x86_64 the modern struct is exported under the
 /// <c>stat$INODE64</c> symbol (the bare <c>stat</c> is the deprecated 32-bit-inode
 /// variant), whereas arm64 — which never shipped a 32-bit-inode ABI — exports it as
-/// plain <c>stat</c>. We pick the right entry point by process architecture
+/// plain <c>stat</c>. The entry point is chosen by process architecture
 /// (Rosetta reports <see cref="Architecture.X64"/> and uses the x86_64 ABI, so the
 /// <c>$INODE64</c> symbol is still correct there). Both 64-bit ABIs share the same
 /// <c>struct stat</c> layout, so a single struct definition serves both — <c>st_uid</c>
@@ -39,7 +39,7 @@ internal static partial class MacFileOwner
     }
 
     // Leading fields of the 64-bit-inode `struct stat`; Size pads to the full 144-byte
-    // record so the kernel has room to write the trailing fields we don't read.
+    // record so the kernel has room to write the trailing unread fields.
     // st_dev(4) st_mode(2) st_nlink(2) st_ino(8) -> st_uid at offset 16.
     [StructLayout(LayoutKind.Sequential, Size = 144)]
     private struct StatBuf

--- a/src/WopiHost.FileSystemProvider/ServiceCollectionExtensions.cs
+++ b/src/WopiHost.FileSystemProvider/ServiceCollectionExtensions.cs
@@ -33,10 +33,10 @@ public static class ServiceCollectionExtensions
             .ValidateOnStart();
 
         services.TryAddSingleton<InMemoryFileIds>();
-        // Singleton, matching AddAzureStorageProvider. The provider is a stateless wrapper:
-        // after construction it holds only immutable fields, depends solely on singletons
-        // (InMemoryFileIds, IHostEnvironment, IConfiguration, ILogger) — so no scoped captive
-        // dependency — and routes all mutable state through the thread-safe InMemoryFileIds.
+        // The provider is a stateless wrapper: after construction it holds only immutable fields,
+        // depends solely on singletons (InMemoryFileIds, IHostEnvironment, IConfiguration, ILogger)
+        // — so no scoped captive dependency — and routes all mutable state through the thread-safe
+        // InMemoryFileIds.
         services.AddSingleton<WopiFileSystemProvider>();
         services.AddSingleton<IWopiStorageProvider>(sp => sp.GetRequiredService<WopiFileSystemProvider>());
         services.AddSingleton<IWopiWritableStorageProvider>(sp => sp.GetRequiredService<WopiFileSystemProvider>());

--- a/src/WopiHost.FileSystemProvider/UnixUserResolver.cs
+++ b/src/WopiHost.FileSystemProvider/UnixUserResolver.cs
@@ -7,7 +7,7 @@ namespace WopiHost.FileSystemProvider;
 /// <summary>
 /// Resolves a Unix user id (UID) to its login name via libc's <c>getpwuid_r</c>.
 /// Shared by the Linux and macOS file-owner helpers, which differ only in how they
-/// obtain the file's UID (<c>statx</c> on Linux, <c>stat</c> on macOS) — the UID → name
+/// obtain the file's UID (<c>statx</c> on Linux, <c>stat</c> on macOS); the UID → name
 /// step is identical POSIX on both.
 /// </summary>
 [SupportedOSPlatform("linux")]
@@ -59,25 +59,23 @@ internal static partial class UnixUserResolver
     }
 
     // getpwuid_r writes the platform's full `struct passwd` here, then points `result` at it.
-    // We only read pw_name — the FIRST field on both the glibc and the BSD/macOS layouts — so
-    // we declare just that field and pad the record with an explicit Size large enough for the
-    // largest platform. This sizing is load-bearing: glibc's struct passwd is 56 bytes, but
-    // macOS/BSD's is larger (extra pw_change/pw_class/pw_expire members). Declaring only the
-    // 7 glibc fields (as before) under-sizes the buffer on macOS, so getpwuid_r writes past the
-    // end and corrupts memory — a SIGSEGV (exit 139) on arm64 macOS. 128 bytes comfortably
-    // covers every supported Unix layout; over-allocating is harmless because getpwuid_r writes
-    // only sizeof(struct passwd) for the running platform.
+    // Only pw_name is read — the FIRST field on both the glibc and the BSD/macOS layouts — so
+    // just that field is declared and the record is padded with an explicit Size large enough
+    // for the largest platform. This sizing is load-bearing: glibc's struct passwd is 56 bytes,
+    // but macOS/BSD's is larger (extra pw_change/pw_class/pw_expire members). Under-sizing the
+    // buffer makes getpwuid_r write past the end and corrupt memory — a SIGSEGV on arm64 macOS.
+    // 128 bytes comfortably covers every supported Unix layout; over-allocating is harmless
+    // because getpwuid_r writes only sizeof(struct passwd) for the running platform.
     [StructLayout(LayoutKind.Sequential, Size = 128)]
     private struct Passwd
     {
         public IntPtr pw_name;
     }
 
-    // CA5392 wants explicit DLL search paths to limit the loader's search to safe directories
-    // and prevent DLL hijacking. The attribute is honored on Windows only — on Linux/macOS the
-    // dynamic loader uses its own search rules and ignores the attribute entirely. This whole
-    // class is [SupportedOSPlatform] linux/macos so the attribute is effectively a no-op for us,
-    // but it satisfies the analyzer and documents intent.
+    // CA5392 wants explicit DLL search paths to prevent DLL hijacking. The attribute is honored
+    // on Windows only — on Linux/macOS the dynamic loader uses its own search rules and ignores
+    // it. This class is [SupportedOSPlatform] linux/macos so the attribute is effectively a no-op
+    // here, but it satisfies the analyzer.
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
     [LibraryImport("libc", EntryPoint = "getpwuid_r", SetLastError = false)]
     private static partial int GetPwUid_R(

--- a/src/WopiHost.FileSystemProvider/WopiFile.cs
+++ b/src/WopiHost.FileSystemProvider/WopiFile.cs
@@ -81,13 +81,12 @@ public class WopiFile(string filePath, string fileIdentifier) : IWopiWritableFil
                 {
                     return MacFileOwner.GetOwnerName(_fileInfo.FullName);
                 }
-                // Any other platform: no ownership lookup is implemented.
                 return string.Empty;
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
                 // The file vanished, access was denied, or the native lookup failed. Ownership is
-                // non-essential metadata, so honour the contract and degrade to empty.
+                // non-essential metadata, so the contract degrades to empty rather than throwing.
                 return string.Empty;
             }
         }

--- a/src/WopiHost.FileSystemProvider/WopiFileSystemProvider.cs
+++ b/src/WopiHost.FileSystemProvider/WopiFileSystemProvider.cs
@@ -68,9 +68,8 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
     /// <inheritdoc/>
     public Task<IWopiWritableFile?> GetWritableFile(string identifier, CancellationToken cancellationToken = default)
     {
-        // Same WopiFile instance the read-side returns — the concrete class implements
-        // IWopiWritableFile (which extends IWopiFile), so the choice between read and writable
-        // is purely about the static type the caller sees.
+        // Same WopiFile the read-side returns — the concrete class implements IWopiWritableFile
+        // (which extends IWopiFile), so read vs. writable is purely the static type the caller sees.
         if (_fileIds.TryGetPath(identifier, out var fullPath))
         {
             return Task.FromResult<IWopiWritableFile?>(new WopiFile(fullPath, identifier));
@@ -102,12 +101,12 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
 
         // Push the extension filter into the OS-level enumeration: one Directory.EnumerateFiles
         // call per requested extension, each with its own glob. Distinct extensions produce
-        // disjoint result sets so no dedup is needed when we concatenate. With no filter, fall
-        // back to a single unfiltered enumeration.
+        // disjoint result sets so the concatenation needs no dedup. With no filter, a single
+        // unfiltered enumeration is used.
         //
         // MatchCasing.CaseInsensitive is explicit because the EnumerationOptions default is
         // PlatformDefault, which means case-sensitive matching on Linux. WOPI requires
-        // case-insensitive extension matching, so we force it here regardless of host OS.
+        // case-insensitive extension matching, so it is forced here regardless of host OS.
         var options = new EnumerationOptions { MatchCasing = MatchCasing.CaseInsensitive };
         var enumeration = (fileExtensions is { Count: > 0 })
             ? fileExtensions.SelectMany(ext => Directory.EnumerateFiles(absolutePath, "*" + ext, options))
@@ -149,7 +148,6 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
     /// <inheritdoc/>
     public async Task<ReadOnlyCollection<IWopiContainer>> GetFileAncestors(string fileId, CancellationToken cancellationToken = default)
     {
-        // Convert file identifier to its parent container's identifier, then walk up.
         var parentId = GetFileParentIdentifier(fileId);
         var result = new List<IWopiContainer>();
         var container = await GetWopiContainer(parentId, cancellationToken).ConfigureAwait(false)
@@ -190,7 +188,7 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         string name,
         CancellationToken cancellationToken = default)
     {
-        // Missing parent: return null (#380 item 4.2).
+        // Missing parent: return null.
         if (!_fileIds.TryGetPath(containerId, out var dirPath))
         {
             return null;
@@ -233,11 +231,9 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         => Task.FromResult(IsValidSingleSegmentName(name));
 
     // Unified validation for files and containers — on a file-system store the two share the
-    // same namespace (a directory entry is a directory entry) and the same constraints. Pre-fix
-    // CheckValidContainerName used Path.GetInvalidPathChars(), which omits the path separators
-    // GetInvalidFileNameChars() forbids — so "sub/sub" or "foo\bar" passed and broke downstream;
-    // and CheckValidFileName used `< FileNameMaxLength` (strict), rejecting names exactly at the
-    // documented limit. This implementation mirrors WopiBlobContainer's IsValidSingleSegmentName.
+    // same namespace (a directory entry is a directory entry) and the same constraints.
+    // GetInvalidFileNameChars() (not GetInvalidPathChars()) forbids the path separators that
+    // would otherwise let "sub/sub" or "foo\bar" through and break downstream.
     private bool IsValidSingleSegmentName(string name) =>
         !string.IsNullOrWhiteSpace(name)
         && name.Length <= FileNameMaxLength
@@ -304,7 +300,6 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
             throw new ArgumentException($"File '{newPath}' already exists.", nameof(name));
         }
 
-        // Create an empty 0-byte file
         using (new FileStream(newPath, FileMode.CreateNew))
         {
         }
@@ -337,7 +332,7 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
     /// <inheritdoc/>
     public Task<bool> DeleteWopiFile(string identifier, CancellationToken cancellationToken = default)
     {
-        // Missing identifier → return false (#380 item 4.2).
+        // Missing identifier → return false.
         if (!_fileIds.TryGetPath(identifier, out var fullPath) || !File.Exists(fullPath))
         {
             return Task.FromResult(false);
@@ -351,7 +346,7 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
     /// <inheritdoc/>
     public Task<bool> DeleteWopiContainer(string identifier, CancellationToken cancellationToken = default)
     {
-        // Missing identifier → return false (#380 item 4.2). The non-empty case still throws —
+        // Missing identifier → return false. The non-empty case still throws —
         // that's the WOPI 409 path, distinct from 404.
         if (!_fileIds.TryGetPath(identifier, out var fullPath) || !Directory.Exists(fullPath))
         {
@@ -374,7 +369,7 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         {
             throw new ArgumentException(message: "Invalid characters in the name.", paramName: nameof(requestedName));
         }
-        // Missing identifier → return false (#380 item 4.2). The target-already-exists case still
+        // Missing identifier → return false. The target-already-exists case still
         // throws — that's the WOPI 409 / X-WOPI-InvalidFileNameError path.
         if (!_fileIds.TryGetPath(identifier, out var fullPath) || !File.Exists(fullPath))
         {

--- a/src/WopiHost.MemoryLockProvider/MemoryLockProvider.cs
+++ b/src/WopiHost.MemoryLockProvider/MemoryLockProvider.cs
@@ -13,12 +13,10 @@ namespace WopiHost.MemoryLockProvider;
 /// Operations are inherently synchronous and are wrapped in <see cref="Task.FromResult{T}"/> to
 /// satisfy the async contract.
 /// <para>
-/// The dictionary was a static field in earlier versions, which meant two provider instances in
-/// the same process saw a shared store — surprising for a per-instance-shaped class and
-/// hostile to test isolation (#380 item 2.3). It's an instance field now; for processes that
-/// genuinely need a shared dictionary across providers, register a single
-/// <see cref="MemoryLockProvider"/> as <c>Singleton</c> (the default registration path does this
-/// via <c>services.AddMemoryLockProvider()</c>).
+/// The dictionary is an instance field, so two provider instances in the same process have
+/// independent stores. For processes that genuinely need a shared dictionary across providers,
+/// register a single <see cref="MemoryLockProvider"/> as <c>Singleton</c> (the default
+/// registration path does this via <c>services.AddMemoryLockProvider()</c>).
 /// </para>
 /// </remarks>
 public partial class MemoryLockProvider : IWopiLockProvider
@@ -37,10 +35,10 @@ public partial class MemoryLockProvider : IWopiLockProvider
     /// <remarks>
     /// When <paramref name="timeProvider"/> or <paramref name="lockComparer"/> is <see langword="null"/>,
     /// the provider falls back to the default implementation and emits a single Information-level
-    /// log line on construction. Pre-#456 the fallback was silent — users that registered a custom
-    /// <see cref="IWopiLockComparer"/> (e.g. <c>JsonShapedWopiLockComparer</c>) but accidentally
-    /// constructed the provider without DI would see ordinal comparison without any signal that
-    /// their override had been bypassed.
+    /// log line on construction. The log line signals the fallback so a custom
+    /// <see cref="IWopiLockComparer"/> (e.g. <c>JsonShapedWopiLockComparer</c>) that was registered
+    /// but bypassed by constructing the provider without DI does not silently revert to ordinal
+    /// comparison unnoticed.
     /// </remarks>
     public MemoryLockProvider(
         ILogger<MemoryLockProvider> logger,
@@ -113,8 +111,8 @@ public partial class MemoryLockProvider : IWopiLockProvider
         {
             DateCreated = _timeProvider.GetUtcNow(),
         };
-        // Same atomic CAS pattern as TryUnlockAndRelockAsync — without this, a concurrent
-        // UnlockAndRelock between our compare and our write would silently extend the wrong lock.
+        // Same atomic CAS pattern as TryUnlockAndRelockAsync — without it, a concurrent
+        // UnlockAndRelock between the compare and the write would silently extend the wrong lock.
         return Task.FromResult(_locks.TryUpdate(fileId, updated, existing));
     }
 
@@ -153,7 +151,7 @@ public partial class MemoryLockProvider : IWopiLockProvider
             LockId = newLockId,
         };
         // TryUpdate is the atomic CAS: succeeds only if the dictionary's current value still
-        // equals the snapshot we read. Any concurrent mutation (refresh, swap, removal) makes
+        // equals the snapshot just read. Any concurrent mutation (refresh, swap, removal) makes
         // the comparand stale and the swap returns false.
         return Task.FromResult(_locks.TryUpdate(fileId, updated, existing));
     }

--- a/src/WopiHost.RedisLockProvider/WopiRedisLockProvider.Logging.cs
+++ b/src/WopiHost.RedisLockProvider/WopiRedisLockProvider.Logging.cs
@@ -3,8 +3,7 @@ using Microsoft.Extensions.Logging;
 namespace WopiHost.RedisLockProvider;
 
 /// <summary>
-/// LoggerMessage-generated log sinks for <see cref="WopiRedisLockProvider"/>. Kept in a separate
-/// partial so the operational story (event ids, log levels, messages) is reviewable in one place.
+/// LoggerMessage-generated log sinks for <see cref="WopiRedisLockProvider"/>.
 /// </summary>
 public sealed partial class WopiRedisLockProvider
 {

--- a/src/WopiHost.RedisLockProvider/WopiRedisLockProvider.cs
+++ b/src/WopiHost.RedisLockProvider/WopiRedisLockProvider.cs
@@ -24,17 +24,14 @@ namespace WopiHost.RedisLockProvider;
 /// <para>
 /// <b>Atomicity.</b> Refresh and Unlock-and-relock use <c>IDatabase.CreateTransaction()</c> with
 /// an <c>AddCondition(Condition.StringEqual(key, snapshot))</c> guard — Redis's <c>WATCH</c>
-/// primitive aborts the <c>MULTI/EXEC</c> if the key's value changed between our read and our
-/// write. The conformance suite's
-/// <c>RefreshLockAsync_ConcurrentSwapBetweenObservationAndCAS_DoesNotRefresh</c> case (and the
-/// <c>TryUnlockAndRelockAsync</c> equivalent) exercise this path: a stale caller's snapshot
-/// no longer matches the resident value, so the transaction aborts and we return false.
+/// primitive aborts the <c>MULTI/EXEC</c> if the key's value changed between the read and the
+/// write. A stale caller's snapshot no longer matches the resident value, so the transaction
+/// aborts and the call returns false.
 /// </para>
 /// <para>
-/// An earlier implementation used Lua scripts (<c>EVAL</c>) to do the compare+set in one
-/// round-trip. The transaction shape costs one extra round-trip (GET, then MULTI/EXEC) but
-/// keeps the implementation in C#, removes the embedded scripting language, and reads more like
-/// the rest of the codebase. The WOPI lock path isn't hot enough to care about the extra hop.
+/// The transaction shape (GET, then MULTI/EXEC) costs one extra round-trip compared to a Lua
+/// <c>EVAL</c> compare+set, but keeps the implementation in C# with no embedded scripting
+/// language. The WOPI lock path isn't hot enough to care about the extra hop.
 /// </para>
 /// </remarks>
 /// <param name="multiplexer">StackExchange.Redis connection multiplexer.</param>
@@ -82,9 +79,9 @@ public sealed partial class WopiRedisLockProvider(
             return null;
         }
         var info = Deserialize(raw!);
-        // Even though we set EX on every write, the fake-clock conformance test advances the
-        // injected TimeProvider without the Redis server clock moving. Re-check expiry against
-        // the .NET-side clock so deterministic tests pass and we evict stale state for free.
+        // Even though every write sets EX, a fake-clock test can advance the injected
+        // TimeProvider without the Redis server clock moving. Re-checking expiry against the
+        // .NET-side clock keeps deterministic tests passing and evicts stale state for free.
         if (info.IsExpiredAt(_timeProvider.GetUtcNow()))
         {
             _ = await Db.KeyDeleteAsync(Key(fileId)).ConfigureAwait(false);
@@ -97,9 +94,9 @@ public sealed partial class WopiRedisLockProvider(
     /// <inheritdoc />
     public async Task<WopiLockInfo?> AddLockAsync(string fileId, string lockId, CancellationToken cancellationToken = default)
     {
-        // Probe + maybe evict if an expired lock is sitting on the key. GetLockAsync handles the
-        // eviction in the "advance fake clock past TTL" case (Redis hasn't really moved). Without
-        // this, the SET NX below would fail against the stale value.
+        // Probe and evict any expired lock sitting on the key. GetLockAsync handles eviction in
+        // the "fake clock advanced past TTL" case where the Redis server clock hasn't really
+        // moved; without it the SET NX below would fail against the stale value.
         var existing = await GetLockAsync(fileId, cancellationToken).ConfigureAwait(false);
         if (existing is not null)
         {
@@ -115,12 +112,12 @@ public sealed partial class WopiRedisLockProvider(
         };
         var ttl = TimeSpan.FromMinutes(WopiLockInfo.ExpirationMinutes);
 
-        // SET ... NX EX <ttl> — atomic create-if-not-exists with TTL. Returns true only if a
-        // sibling AddLock didn't race us.
+        // SET ... NX EX <ttl> — atomic create-if-not-exists with TTL. Returns true only if no
+        // sibling AddLock raced ahead.
         var ok = await Db.StringSetAsync(Key(fileId), Serialize(info), ttl, When.NotExists).ConfigureAwait(false);
         if (!ok)
         {
-            // Lost the race. Re-read to surface the winner's lock id for telemetry, then bail.
+            // Lost the race. Re-read to surface the winner's lock id for telemetry.
             var winner = await GetLockAsync(fileId, cancellationToken).ConfigureAwait(false);
             LogLockAddRejected(_logger, fileId, lockId, winner?.LockId);
             return null;
@@ -158,8 +155,8 @@ public sealed partial class WopiRedisLockProvider(
     /// </summary>
     /// <remarks>
     /// The transaction's <c>AddCondition(StringEqual(key, raw))</c> compares the
-    /// <em>byte-exact</em> resident value against the snapshot we read. If anything mutated
-    /// the value between our read and the EXEC (a sibling refresh, swap, remove, or expiry),
+    /// <em>byte-exact</em> resident value against the snapshot just read. If anything mutated
+    /// the value between the read and the EXEC (a sibling refresh, swap, remove, or expiry),
     /// the condition fails and the transaction aborts. The .NET-side <see cref="IWopiLockComparer"/>
     /// is consulted only for the caller's <paramref name="expectedExistingLockId"/> against the
     /// snapshot's <c>LockId</c>, so tolerant comparers (e.g. <see cref="JsonShapedWopiLockComparer"/>)
@@ -171,8 +168,8 @@ public sealed partial class WopiRedisLockProvider(
         Func<WopiLockInfo, WopiLockInfo> mutate,
         CancellationToken cancellationToken)
     {
-        // StackExchange.Redis APIs don't accept a CancellationToken; honour the caller's
-        // token at the entrance and trust the in-flight Redis round-trips to be short.
+        // StackExchange.Redis APIs don't accept a CancellationToken; the caller's token is
+        // honoured at the entrance and the in-flight Redis round-trips are assumed short.
         cancellationToken.ThrowIfCancellationRequested();
         var key = Key(fileId);
         var raw = await Db.StringGetAsync(key).ConfigureAwait(false);
@@ -185,11 +182,10 @@ public sealed partial class WopiRedisLockProvider(
         {
             // Proactively evict the stale record rather than waiting for Redis's TTL to reap it,
             // so this CAS path cleans up on read like GetLockAsync and the Azure/Memory providers.
-            // (Under the fake-clock conformance tests the Redis server clock never moves, so the
-            // server-side EX would not evict at all.) The delete is guarded by the same
-            // value-equality condition the mutation path uses, so a sibling that refreshed or
-            // recreated the lock between our GET and here is never clobbered: the condition fails
-            // and the delete is skipped.
+            // (Under a fake clock the Redis server clock never moves, so the server-side EX would
+            // not evict at all.) The delete is guarded by the same value-equality condition the
+            // mutation path uses, so a sibling that refreshed or recreated the lock in between is
+            // never clobbered: the condition fails and the delete is skipped.
             var evict = Db.CreateTransaction();
             evict.AddCondition(Condition.StringEqual(key, raw));
             _ = evict.KeyDeleteAsync(key);

--- a/src/WopiHost.Url/WopiUrlBuilder.cs
+++ b/src/WopiHost.Url/WopiUrlBuilder.cs
@@ -52,14 +52,14 @@ public partial class WopiUrlBuilder(
         }
         if (urlSettings is not null)
         {
-            foreach (var kvp in urlSettings) combinedUrlSettings[kvp.Key] = kvp.Value; // overrides
+            foreach (var kvp in urlSettings) combinedUrlSettings[kvp.Key] = kvp.Value;
         }
 
         // Single source of truth for the WopiSrc value: the wopiFileUrl parameter. The
         // WOPI_SOURCE placeholder, when present in a template, gets substituted with this
         // value (URL-escaped by ResolveOptionalParameter). Any caller-provided WOPI_SOURCE
-        // value in urlSettings is overwritten so we never produce two different WopiSrc
-        // values in the same URL.
+        // value in urlSettings is overwritten so a URL never carries two different WopiSrc
+        // values.
         combinedUrlSettings[WopiUrlSettings.Placeholders.WopiSource] = wopiFileUrl.ToString();
 
         var template = await _wopiDiscoverer.GetUrlTemplateAsync(extension, action).ConfigureAwait(false);
@@ -71,7 +71,6 @@ public partial class WopiUrlBuilder(
 
         var templateHasWopiSourcePlaceholder = template.Contains(WopiUrlSettings.Placeholders.WopiSource, StringComparison.Ordinal);
 
-        // Resolve optional parameters
         var url = UrlParamRegex().Replace(template, m => ResolveOptionalParameter(m.Groups["name"].Value, m.Groups["value"].Value, combinedUrlSettings) ?? string.Empty);
         url = url.TrimEnd('&');
 

--- a/src/WopiHost.Url/WopiUrlSettings.cs
+++ b/src/WopiHost.Url/WopiUrlSettings.cs
@@ -163,8 +163,7 @@ public class WopiUrlSettings : Dictionary<string, string>
     }
 
     /// <summary>
-    /// Makes a purple, clickable box appear if you set it to 1.
-    /// Sorry, this documentation hasn't been written yet. https://github.com/Microsoft/Office-Online-Test-Tools-and-Documentation/issues/52
+    /// Makes a purple, clickable box appear when set to 1. Microsoft has not documented this value.
     /// </summary>
     public int Perfstats
     {

--- a/test/WopiHost.Abstractions.Testing/LockProviderConformanceTests.cs
+++ b/test/WopiHost.Abstractions.Testing/LockProviderConformanceTests.cs
@@ -142,10 +142,8 @@ public abstract class LockProviderConformanceTests
     public async Task RefreshLockAsync_MismatchedExpectedLock_ReturnsFalseAndDoesNotMutate()
     {
         // Spec: RefreshLock honours the caller's lock id only when it matches the stored id.
-        // Pre-#1.6 the abstraction couldn't enforce this — the controller had to compare ids
-        // separately, racing against any concurrent UnlockAndRelock. Now the provider performs
-        // an atomic compare-and-refresh; a stale caller observes false here and the stored id
-        // / timestamp are untouched.
+        // The provider performs an atomic compare-and-refresh; a stale caller observes false
+        // here and the stored id / timestamp are untouched.
         var clock = new ControllableTimeProvider(DateTimeOffset.UtcNow);
         var sut = await CreateSutAsync(clock);
         var fileId = $"refresh-mismatch-{Guid.NewGuid()}";

--- a/test/WopiHost.AzureLockProvider.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/WopiHost.AzureLockProvider.Tests/ServiceCollectionExtensionsTests.cs
@@ -114,7 +114,7 @@ public class ServiceCollectionExtensionsTests
     public void AddAzureLockProvider_WhenLockProviderAlreadyRegistered_Throws()
     {
         // A host that wires two IWopiLockProviders would have the second registration silently
-        // win the resolve — pre-#456 there was no guard, post-#456 we fail fast at composition.
+        // win the resolve — the guard fails fast at composition instead.
         var services = new ServiceCollection();
         AddNullLogging(services);
         services.AddSingleton<IWopiLockProvider>(new FakeLockProvider());

--- a/test/WopiHost.AzureLockProvider.Tests/WopiAzureLockProviderEdgeCaseTests.cs
+++ b/test/WopiHost.AzureLockProvider.Tests/WopiAzureLockProviderEdgeCaseTests.cs
@@ -184,13 +184,12 @@ public class WopiAzureLockProviderEdgeCaseTests(AzuriteFixture azurite)
     [Fact]
     public async Task AddLockAsync_BlobExistsButNoMetadata_ReturnsNull_ToProtectInFlightAcquires()
     {
-        // After the #353 race fix the "no readable metadata" branch yields rather than cleaning
-        // up — that aggressive cleanup was the bug it was clobbering healthy peers mid-acquire.
-        // A bare metadata-less blob can mean either (a) a sibling acquire happening right now,
-        // whose UploadAsync has landed but whose AcquireAsync hasn't returned yet, or (b) an
-        // unlikely operator-created stub or a pre-fix crashed acquire. Either way, the safe
-        // answer is to return null; case (b) requires manual cleanup, which is documented and
-        // very rare since the new flow uploads metadata atomically.
+        // The "no readable metadata" branch yields rather than cleaning up, so it can't clobber
+        // healthy peers mid-acquire. A bare metadata-less blob can mean either (a) a sibling
+        // acquire happening right now, whose UploadAsync has landed but whose AcquireAsync hasn't
+        // returned yet, or (b) an operator-created stub or a crashed acquire. Either way, the safe
+        // answer is to return null; case (b) requires manual cleanup but is very rare since the
+        // flow uploads metadata atomically.
         var (provider, _) = await CreateProviderAsync();
         var lockBlob = GetLockBlob(provider, "file-stale-blob");
         using (var empty = new MemoryStream([]))
@@ -207,15 +206,13 @@ public class WopiAzureLockProviderEdgeCaseTests(AzuriteFixture azurite)
     [Fact]
     public async Task AddLockAsync_ConcurrentRace_OneWinsOthersReturnNull()
     {
-        // Regression test for the race that prompted #331 item 4b. With the atomic upload-with-
-        // metadata fix in place, six concurrent AddLockAsync calls converge on:
+        // With the atomic upload-with-metadata path, six concurrent AddLockAsync calls converge on:
         //   - exactly one winner (whose UploadAsync IfNoneMatch=* succeeds first)
         //   - five losers that see either 412/409 from UploadAsync or, if their TryGetProperties
         //     fired after the winner's upload, a fully-formed metadata blob → return null.
-        // Prior to the fix, peers' TryGetProperties hitting the brief Upload→SetMetadata window
-        // would observe an empty-metadata blob, enter the cleanup path, break the winner's
-        // lease, and clobber the acquire — surfacing as LeaseNotPresentWithBlobOperation on the
-        // winner's pending SetMetadata.
+        // A non-atomic upload would let peers observe an empty-metadata blob during the brief
+        // Upload→SetMetadata window, enter the cleanup path, break the winner's lease, and clobber
+        // the acquire — surfacing as LeaseNotPresentWithBlobOperation on the winner's SetMetadata.
         var (provider, _) = await CreateProviderAsync();
         var fileId = $"file-race-{Guid.NewGuid():N}";
 

--- a/test/WopiHost.AzureStorageProvider.Tests/BlobIdMapTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/BlobIdMapTests.cs
@@ -28,9 +28,9 @@ public class BlobIdMapTests
     [Fact]
     public void ScanAll_BlobsDifferingOnlyByCase_RegistersBoth()
     {
-        // Regression test: previously BlobIdMap case-folded the path before hashing, which
-        // collapsed Foo/file.txt and foo/file.txt onto the same id and silently dropped one
-        // from the map. Azure stores them as distinct blobs — the provider must too.
+        // BlobIdMap must not case-fold the path before hashing: that would collapse Foo/file.txt
+        // and foo/file.txt onto the same id and silently drop one. Azure stores them as distinct
+        // blobs — the provider must too.
         var map = NewMap();
         map.ScanAll(["Foo/file.txt", "foo/file.txt"]);
 
@@ -86,7 +86,7 @@ public class BlobIdMapTests
 
         Assert.True(map.Remove(id));
         Assert.False(map.TryGetPath(id, out _));
-        Assert.False(map.Remove(id)); // second call returns false
+        Assert.False(map.Remove(id));
     }
 
     [Fact]
@@ -130,9 +130,8 @@ public class BlobIdMapTests
         var map = NewMap();
         map.ScanAll(["a/b/c/leaf.txt"]);
 
-        // Leaf
         Assert.True(map.TryGetFileId("a/b/c/leaf.txt", out _));
-        // Each intermediate folder is registered
+        // Each intermediate folder is registered, not just the leaf.
         Assert.True(map.TryGetFileId("a/b/c", out _));
         Assert.True(map.TryGetFileId("a/b", out _));
         Assert.True(map.TryGetFileId("a", out _));

--- a/test/WopiHost.AzureStorageProvider.Tests/HashingBlobWriteStreamTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/HashingBlobWriteStreamTests.cs
@@ -173,10 +173,10 @@ public class HashingBlobWriteStreamTests(AzuriteFixture azurite)
     [Fact]
     public async Task Dispose_AfterDisposeAsync_IsNoOp()
     {
-        // #409 item 2.12: a caller that does `await using` followed by an explicit sync Dispose
-        // (or any other cross-method redispose) must not retrigger the inner-stream close, the
-        // hasher finalization, or the metadata write. The `_disposed` flag at the top of both
-        // paths is what guarantees that — pin it cross-method.
+        // A caller that does `await using` followed by an explicit sync Dispose (or any other
+        // cross-method redispose) must not retrigger the inner-stream close, the hasher
+        // finalization, or the metadata write. The `_disposed` flag at the top of both paths
+        // guarantees that — pinned cross-method here.
         var (blob, _) = await CreateBlobAsync();
         const string payload = "cross-method-async-first";
         var bytes = Encoding.UTF8.GetBytes(payload);

--- a/test/WopiHost.AzureStorageProvider.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/ServiceCollectionExtensionsTests.cs
@@ -66,8 +66,7 @@ public class ServiceCollectionExtensionsTests
     public void AddAzureStorageProvider_WithServiceUriAndNoCredential_FallsBackToDefaultCredential()
     {
         // No TokenCredential registered → ServiceCollectionExtensions must build a DefaultAzureCredential.
-        // We can't easily assert "is DefaultAzureCredential" since it's encapsulated in the BlobServiceClient,
-        // but resolution must not throw.
+        // It's encapsulated in the BlobServiceClient and not directly assertable, but resolution must not throw.
         var services = new ServiceCollection();
         AddNullLogging(services);
         var config = BuildConfig(new()

--- a/test/WopiHost.AzureStorageProvider.Tests/WopiAzureStorageProviderEdgeCaseTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/WopiAzureStorageProviderEdgeCaseTests.cs
@@ -66,8 +66,7 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
     [Fact]
     public async Task GetWopiResourceByName_UnknownContainer_ReturnsNull()
     {
-        // #380 item 4.2 — missing parent returns null, consistent with WopiFileSystemProvider.
-        // Was previously the only impl that returned null here; this pins the contract for both.
+        // Missing parent returns null, consistent with WopiFileSystemProvider — pins the contract for both.
         var (provider, _) = await CreateProviderAsync();
         var result = await provider.GetWopiFileByName("does-not-exist", "anything.txt");
 
@@ -167,9 +166,8 @@ public class WopiAzureStorageProviderEdgeCaseTests(AzuriteFixture azurite)
     {
         // WOPI spec forbids wildcards in the filter list. The provider treats any glob-looking
         // character as a literal — passing "*.docx" matches only a file named literally "*.docx"
-        // (which Azure won't let us upload anyway), so the result is empty. This pin guards
-        // against anyone reintroducing a regex/glob translator on the assumption that the old
-        // semantic is still in effect.
+        // (which Azure won't accept as a blob name anyway), so the result is empty. Guards
+        // against reintroducing a regex/glob translator.
         var (provider, container) = await CreateProviderAsync();
         await UploadAsync(container, "doc.docx");
 

--- a/test/WopiHost.AzureStorageProvider.Tests/WopiBlobContainerTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/WopiBlobContainerTests.cs
@@ -58,10 +58,10 @@ public class WopiBlobContainerTests(AzuriteFixture azurite)
     [Fact]
     public async Task Size_CachedAfterFirstAccess()
     {
-        // Successive reads should return the same value without re-enumerating. We can't
-        // observe the round-trip count directly, but if the value changes after a mutation
-        // we know the property re-read. This pin is for the cache invariant: once read,
-        // the value is stable for the lifetime of the WopiBlobContainer instance.
+        // Successive reads should return the same value without re-enumerating. The round-trip
+        // count isn't directly observable, but a value that changes after a mutation would prove
+        // the property re-read. Pins the cache invariant: once read, the value is stable for
+        // the lifetime of the WopiBlobContainer instance.
         var container = await CreateContainerAsync();
         await UploadAsync(container, "folder/a.bin", new byte[4]);
 

--- a/test/WopiHost.Cobalt.Tests/CoauthoringSessionTrackerTests.cs
+++ b/test/WopiHost.Cobalt.Tests/CoauthoringSessionTrackerTests.cs
@@ -48,8 +48,8 @@ public class CoauthoringSessionTrackerTests
     [Fact]
     public void AddOrRefreshSession_SameUserTwice_DeduplicatesByUserId()
     {
-        // Multiple browser tabs from the same user must collapse into a single editor —
-        // the bug #139 was reporting duplicate user names in OOS.
+        // Multiple browser tabs from the same user must collapse into a single editor,
+        // otherwise OOS shows duplicate user names.
         var fileId = NewFileId();
         _tracker.AddOrRefreshSession(fileId, "user-1", "Alice");
         _tracker.AddOrRefreshSession(fileId, "user-1", "Alice");
@@ -154,8 +154,7 @@ public class CoauthoringSessionTrackerTests
     public void GetEditorsTable_UsesStableClientIdPerUser()
     {
         // Same user across two refreshes (same fileId) must hash to the same ArrayGuid
-        // so the editors-table key collapses — this is what enforces the dedup-by-user
-        // behavior that the older string-keyed table provided.
+        // so the editors-table key collapses — this is what enforces dedup-by-user.
         var fileId = NewFileId();
         _tracker.AddOrRefreshSession(fileId, "user-1", "Alice");
         var firstKey = _tracker.GetEditorsTable(fileId).Keys.Single();

--- a/test/WopiHost.Cobalt.Tests/CobaltHostLockingStoreTests.cs
+++ b/test/WopiHost.Cobalt.Tests/CobaltHostLockingStoreTests.cs
@@ -7,9 +7,9 @@ namespace WopiHost.Cobalt.Tests;
 
 /// <summary>
 /// Behavior tests for <see cref="CobaltHostLockingStore"/>'s coauth/editing-session handlers
-/// — the bridge between Cobalt's HostLockingStore contract and our
+/// — the bridge between Cobalt's HostLockingStore contract and
 /// <see cref="CoauthoringSessionTracker"/>. The stub handlers (e.g. <c>HandleGetSchemaLock</c>)
-/// that just return a default output have no behavior worth verifying; we focus on the ones
+/// that just return a default output have no behavior worth verifying; the tests cover the ones
 /// that actually delegate to the tracker or read principal claims.
 /// </summary>
 public class CobaltHostLockingStoreTests
@@ -263,8 +263,8 @@ public class CobaltHostLockingStoreTests
     // The handlers below are intentional pass-throughs that return a default OutputType.
     // They cover protocol features WopiHost doesn't implement (exclusive locks, version
     // history, editor metadata, rename/delete via Cobalt instead of WOPI). The contract
-    // is just "don't throw" — which is what these tests verify. Keeping them as
-    // separate facts so a regression on any one handler is precise in the test report.
+    // is just "don't throw" — which is what these tests verify. They are kept as separate
+    // facts so a regression on any one handler is precise in the test report.
 
     [Fact]
     public void HandleGetExclusiveLock_DoesNotThrow()

--- a/test/WopiHost.Cobalt.Tests/CobaltProcessorTests.cs
+++ b/test/WopiHost.Cobalt.Tests/CobaltProcessorTests.cs
@@ -9,9 +9,9 @@ namespace WopiHost.Cobalt.Tests;
 /// <summary>
 /// Lifecycle tests for <see cref="CobaltProcessor"/> — construction, disposal, and
 /// the cancellation/argument-validation contract on <see cref="CobaltProcessor.ProcessCobalt"/>.
-/// We deliberately don't drive a full Cobalt request batch through ProcessCobalt here:
-/// the protocol is binary and exercised end-to-end by the validator + sample apps. Unit
-/// tests cover the seams around it.
+/// A full Cobalt request batch is not driven through ProcessCobalt here: the protocol is
+/// binary and exercised end-to-end by the validator + sample apps. Unit tests cover the
+/// seams around it.
 /// </summary>
 public class CobaltProcessorTests
 {

--- a/test/WopiHost.Core.Tests/Abstractions/WopiLockComparerTests.cs
+++ b/test/WopiHost.Core.Tests/Abstractions/WopiLockComparerTests.cs
@@ -47,7 +47,7 @@ public class WopiLockComparerTests
         [Fact]
         public void SameSField_DifferentExtraProperties_AreEqual()
         {
-            // The OOS quirk we're absorbing: stored lock has the original payload, the client
+            // The OOS quirk being absorbed: stored lock has the original payload, the client
             // sends back the same logical lock with an extra property added.
             var stored = """{"S":"abc-123","F":4}""";
             var fromClient = """{"S":"abc-123","F":4,"V":1}""";

--- a/test/WopiHost.Core.Tests/Endpoints/EndpointHelpersTests.cs
+++ b/test/WopiHost.Core.Tests/Endpoints/EndpointHelpersTests.cs
@@ -5,11 +5,9 @@ using WopiHost.Core.Endpoints;
 namespace WopiHost.Core.Tests.Endpoints;
 
 /// <summary>
-/// Unit tests for <see cref="EndpointHelpers.TryParseWopiSrc"/>. Relocated from the deleted
-/// WopiBootstrapperControllerTests.TryParseWopiSrc_* tests as part of the #430 phase 4 / 5
-/// migration — the parser implementation moved from the controller to EndpointHelpers in
-/// phase 3 and the tests follow it here. IssueEcosystemPointerAsync is covered by the
-/// EndpointSmokeTests integration suite (FileEcosystemPointer / ContainerEcosystemPointer).
+/// Unit tests for <see cref="EndpointHelpers.TryParseWopiSrc"/>. IssueEcosystemPointerAsync is
+/// covered by the EndpointSmokeTests integration suite (FileEcosystemPointer /
+/// ContainerEcosystemPointer).
 /// </summary>
 public class EndpointHelpersTests
 {
@@ -23,9 +21,7 @@ public class EndpointHelpersTests
     [InlineData("https://wopi.example.com/some/wopi/Files/CASE_INSENSITIVE", WopiResourceType.File, "CASE_INSENSITIVE")]
     [InlineData("https://wopi.example.com/wopi/CONTAINERS/abc", WopiResourceType.Container, "abc")]
     // Trailing-anchor wins: the path contains both an earlier "files" segment and a later
-    // "containers" segment. The current regex-based parser correctly resolves to the resource
-    // at the URL tail (containers/abc); the previous segment-scan implementation would have
-    // mis-parsed this as files/archive.
+    // "containers" segment. The parser resolves to the resource at the URL tail (containers/abc).
     [InlineData("https://wopi.example.com/files/archive/containers/abc", WopiResourceType.Container, "abc")]
     [InlineData("https://wopi.example.com/containers/parent/files/child", WopiResourceType.File, "child")]
     public void TryParseWopiSrc_ValidUrls(string url, WopiResourceType expectedType, string expectedId)
@@ -51,10 +47,10 @@ public class EndpointHelpersTests
         Assert.False(ok);
     }
 
-    // EnsureExactlyOneOf — replaces the hand-rolled mutex check used in name-negotiation
-    // endpoints (PutRelativeFile, CreateChildFile, CreateChildContainer). The spec mandates
-    // 501 — not 400 — when both targets are present OR both are absent; whitespace-only values
-    // count as absent so a header sent with an empty token doesn't sneak past the gate.
+    // EnsureExactlyOneOf is used by the name-negotiation endpoints (PutRelativeFile,
+    // CreateChildFile, CreateChildContainer). The spec mandates 501 — not 400 — when both
+    // targets are present OR both are absent; whitespace-only values count as absent so a
+    // header sent with an empty token doesn't sneak past the gate.
     [Theory]
     [InlineData(null, null)]
     [InlineData("", "")]

--- a/test/WopiHost.Core.Tests/Endpoints/MapWopiEndpointsTests.cs
+++ b/test/WopiHost.Core.Tests/Endpoints/MapWopiEndpointsTests.cs
@@ -15,8 +15,7 @@ namespace WopiHost.Core.Tests.Endpoints;
 
 /// <summary>
 /// Verifies that <see cref="WopiEndpointRouteBuilderExtensions.MapWopiEndpoints"/> registers
-/// the expected route table — names, templates, and resource-kind metadata. Full HTTP parity
-/// tests against the controller behaviour land in Phase 5 of the #430 migration.
+/// the expected route table — names, templates, and resource-kind metadata.
 /// </summary>
 public sealed class MapWopiEndpointsTests : IAsyncLifetime
 {
@@ -46,7 +45,7 @@ public sealed class MapWopiEndpointsTests : IAsyncLifetime
         builder.Services.AddSingleton(Mock.Of<IWopiWritableStorageProvider>());
         builder.Services.AddSingleton(Mock.Of<ICobaltProcessor>());
         // Override the default WOPI auth scheme so RequireAuthorization() resolves; the no-op
-        // handler short-circuits to NoResult since we never hit endpoints in this test. The
+        // handler short-circuits to NoResult since endpoints are never hit in this test. The
         // Bootstrap group requires WopiAuthenticationSchemes.Bootstrap to be registered for
         // its policy to construct at endpoint-registration time.
         builder.Services.AddAuthentication("test")
@@ -130,7 +129,7 @@ public sealed class MapWopiEndpointsTests : IAsyncLifetime
             "/wopi/folders/{id}/children",
             "/wopi/ecosystem",
             "/wopi/ecosystem/root_container_pointer",
-            // Phase 3: bootstrap GET — different auth scheme, but still a GET route.
+            // Bootstrap GET — different auth scheme, but still a GET route.
             "/wopibootstrapper",
         ];
         foreach (var template in expected)
@@ -163,14 +162,14 @@ public sealed class MapWopiEndpointsTests : IAsyncLifetime
     [Fact]
     public void PutFile_Maps_To_PUT_And_POST_On_Contents()
     {
-        // Phase 3a: PutFile uses MapMethods(["PUT", "POST"], ...) on /{id}/contents.
+        // PutFile uses MapMethods(["PUT", "POST"], ...) on /{id}/contents.
         var verbs = _endpoints
             .Where(e => e.RoutePattern.RawText == "/wopi/files/{id}/contents")
             .SelectMany(e => e.Metadata.GetMetadata<Microsoft.AspNetCore.Routing.HttpMethodMetadata>()?.HttpMethods ?? [])
             .ToHashSet();
-        Assert.Contains("GET", verbs);  // Phase 2: GetFile
-        Assert.Contains("PUT", verbs);  // Phase 3: PutFile
-        Assert.Contains("POST", verbs); // Phase 3: PutFile (alternate verb per spec)
+        Assert.Contains("GET", verbs);
+        Assert.Contains("PUT", verbs);
+        Assert.Contains("POST", verbs); // alternate verb per spec
     }
 
     [Theory]

--- a/test/WopiHost.Core.Tests/Infrastructure/DefaultCheckInfoBuilderTests.cs
+++ b/test/WopiHost.Core.Tests/Infrastructure/DefaultCheckInfoBuilderTests.cs
@@ -10,9 +10,7 @@ namespace WopiHost.Core.Tests.Infrastructure;
 
 /// <summary>
 /// Tests for the default <see cref="ICheckFileInfoBuilder"/>, <see cref="ICheckContainerInfoBuilder"/>,
-/// and <see cref="ICheckFolderInfoBuilder"/> implementations. Ported from the now-deleted
-/// <c>WopiExtensionsTests</c> when the <c>GetWopiCheckFileInfo</c> / <c>GetWopiCheckContainerInfo</c> /
-/// <c>BuildCheckFolderInfo</c> extension methods were replaced by these builders.
+/// and <see cref="ICheckFolderInfoBuilder"/> implementations.
 /// </summary>
 public class DefaultCheckInfoBuilderTests
 {
@@ -363,9 +361,9 @@ public class DefaultCheckInfoBuilderTests
         Assert.False(result.IsAnonymousUser);
     }
 
-    // Note: OnCheckFolderInfo callback firing is no longer the builder's responsibility — it
-    // moved to FoldersController.CheckFolderInfo as part of #363's resolution. The callback
-    // round-trip is covered by FoldersControllerTests.CheckFolderInfo_CallsOnCheckFolderInfoEvent.
+    // OnCheckFolderInfo callback firing is not the builder's responsibility — it lives in
+    // FoldersController.CheckFolderInfo. The callback round-trip is covered by
+    // FoldersControllerTests.CheckFolderInfo_CallsOnCheckFolderInfoEvent.
 
     [Fact]
     public async Task GetWopiCheckContainerInfo_CallsOnCheckContainerInfoEvent()
@@ -420,9 +418,8 @@ public class DefaultCheckInfoBuilderTests
     public async Task GetWopiCheckContainerInfo_AnonymousUser_ReportsIsAnonymousUserTrue()
     {
         // Spec: IsAnonymousUser "should match the IsAnonymousUser value returned in
-        // CheckFileInfo." The file + folder builders both set it from auth state; the
-        // container builder previously omitted it, so anonymous users were reported as
-        // authenticated in the container response.
+        // CheckFileInfo." All three builders (file, folder, container) must set it from auth
+        // state, otherwise anonymous users get reported as authenticated.
         var mockFolder = new Mock<IWopiContainer>();
         mockFolder.Setup(f => f.Name).Returns("AnonContainer");
         var mockSecurityHandler = new Mock<IWopiPermissionProvider>();

--- a/test/WopiHost.Core.Tests/Infrastructure/DefaultWopiNewChildFileNegotiatorTests.cs
+++ b/test/WopiHost.Core.Tests/Infrastructure/DefaultWopiNewChildFileNegotiatorTests.cs
@@ -74,7 +74,7 @@ public class DefaultWopiNewChildFileNegotiatorTests
     public async Task RelativeTarget_InvalidName_OmitsSuggestionWhenSanitiseStillFails()
     {
         // Sanitised candidate also fails (e.g. provider rejects reserved names like CON);
-        // omit X-WOPI-ValidRelativeTarget rather than emit a name we know is invalid.
+        // omit X-WOPI-ValidRelativeTarget rather than emit a known-invalid name.
         _writable.Setup(w => w.CheckValidFileName(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
@@ -132,9 +132,9 @@ public class DefaultWopiNewChildFileNegotiatorTests
     [Fact]
     public async Task RelativeTarget_Collision_Overwrite_PermissionProviderDenies_ReturnsNotImplemented()
     {
-        // Spec (#455): "If the user is not authorized to overwrite the target file, the host must
-        // respond with a 501 Not Implemented." The endpoint-level Permission.Create gate already
-        // passed (we're inside the negotiator), but the per-target permission provider rules out
+        // Spec: "If the user is not authorized to overwrite the target file, the host must
+        // respond with a 501 Not Implemented." The endpoint-level Permission.Create gate has
+        // already passed at the negotiator, but the per-target permission provider rules out
         // overwriting THIS specific file. The lock probe must NOT run — denying overwrite is a
         // strictly stronger signal than "the existing file is locked," so 501 wins.
         var existing = Mock.Of<IWopiFile>(f => f.Identifier == "existing-id");
@@ -193,7 +193,7 @@ public class DefaultWopiNewChildFileNegotiatorTests
     public async Task RelativeTarget_Collision_Overwrite_Unlocked_GetWritableFileReturnsNull_ReturnsInternalError()
     {
         // The writable provider's contract says GetWritableFile returns non-null for a file the
-        // read-side already resolved by name. A null here is defensive — covers line 86.
+        // read-side already resolved by name. A null here exercises the defensive path.
         var existing = Mock.Of<IWopiFile>(f => f.Identifier == "existing-id");
         _writable.Setup(w => w.CheckValidFileName("doc.docx", It.IsAny<CancellationToken>())).ReturnsAsync(true);
         _storage.Setup(s => s.GetWopiFileByName(Container, "doc.docx", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
@@ -209,8 +209,7 @@ public class DefaultWopiNewChildFileNegotiatorTests
     public async Task RelativeTarget_Collision_Overwrite_NoLockProvider_SkipsLockProbe()
     {
         // Hosts without a lock provider registered still need to honor overwrite — the lock probe
-        // is conditional on lockProvider being non-null. Covers the "lockProvider is null" branch
-        // (we exercise both halves: this test for the null case, the previous two for non-null).
+        // is conditional on lockProvider being non-null. Covers the "lockProvider is null" branch.
         var existing = Mock.Of<IWopiFile>(f => f.Identifier == "existing-id");
         var writableExisting = Mock.Of<IWopiWritableFile>();
         _writable.Setup(w => w.CheckValidFileName("doc.docx", It.IsAny<CancellationToken>())).ReturnsAsync(true);

--- a/test/WopiHost.Core.Tests/Infrastructure/WopiFileNameSanitiserTests.cs
+++ b/test/WopiHost.Core.Tests/Infrastructure/WopiFileNameSanitiserTests.cs
@@ -45,10 +45,9 @@ public class WopiFileNameSanitiserTests
     public void ScrubOrNull_AllSpaces_ReturnsUnderscores_NotNull(string input)
     {
         // Pins the subtle ordering: Replace(' ', '_') runs before Trim(), so an all-spaces input
-        // becomes a non-empty run of underscores rather than null. If we wanted "all spaces → null"
-        // we'd need to either drop ' ' from ForbiddenChars and rely on Trim, or check empty BEFORE
-        // the Replace. The current behaviour is intentional — a stem of underscores is a usable
-        // (if ugly) filename; the caller's fallback path handles it via CheckValidFileName.
+        // becomes a non-empty run of underscores rather than null. The behaviour is intentional
+        // — a stem of underscores is a usable (if ugly) filename; the caller's fallback path
+        // handles it via CheckValidFileName.
         Assert.Equal(new string('_', input.Length), WopiFileNameSanitiser.ScrubOrNull(input));
     }
 
@@ -92,10 +91,9 @@ public class WopiFileNameSanitiserTests
     [Fact]
     public async Task TryBuildValidCandidateAsync_EmptyOrPathNavStem_SubstitutesFallback()
     {
-        // Input ".docx" → ExtractExtension yields ".docx" (no, wait — leading-dot-only means
-        // ext = "" by the helper contract). So stem = ".docx", scrubbed = ".docx" (no forbidden
-        // chars), not in {".", ".."} → returns ".docx" as candidate. To actually exercise the
-        // fallback substitution we need a stem that scrubs to null. Use ".." which IS path-nav.
+        // Exercising the fallback substitution requires a stem that scrubs to null. ".." is
+        // path-nav and scrubs to null, whereas a leading-dot-only input like ".docx" yields
+        // ext = "" by the helper contract and would survive as its own candidate.
         var writable = new Mock<IWopiWritableStorageProvider>();
         writable.Setup(w => w.CheckValidFileName("fallback.docx", It.IsAny<CancellationToken>())).ReturnsAsync(true);
 

--- a/test/WopiHost.Core.Tests/Infrastructure/WopiLockAwareWritableStorageProviderTests.cs
+++ b/test/WopiHost.Core.Tests/Infrastructure/WopiLockAwareWritableStorageProviderTests.cs
@@ -69,8 +69,8 @@ public class WopiLockAwareWritableStorageProviderTests
     [Fact]
     public async Task CreateWopiChildResource_BypassesLockCheck()
     {
-        // The new resource doesn't have a prior lock; lock check is unnecessary and we should
-        // pass straight through. (Verifies the decorator doesn't accidentally guard creation.)
+        // The new resource doesn't have a prior lock, so the decorator passes straight through
+        // rather than accidentally guarding creation.
         var newFile = new Mock<IWopiWritableFile>().Object;
         _innerMock.Setup(x => x.CreateWopiChildFile("parent", "newfile.txt", It.IsAny<CancellationToken>()))
             .ReturnsAsync(newFile);
@@ -201,8 +201,8 @@ public class WopiLockAwareWritableStorageProviderTests
         services.AddSingleton(_lockProviderMock.Object);
         services.AddWopiLockAwareWritableStorage();
 
-        // Existing test rig: when the resource is locked the resolved (decorated) writable
-        // provider must throw rather than silently delegate to the inner.
+        // When the resource is locked the resolved (decorated) writable provider must throw
+        // rather than silently delegate to the inner.
         _lockProviderMock.Setup(x => x.GetLockAsync("file-x", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new WopiLockInfo { FileId = "file-x", LockId = "L" });
 

--- a/test/WopiHost.Core.Tests/Infrastructure/WopiNewChildFileResultExtensionsTests.cs
+++ b/test/WopiHost.Core.Tests/Infrastructure/WopiNewChildFileResultExtensionsTests.cs
@@ -46,7 +46,7 @@ public class WopiNewChildFileResultExtensionsTests
         Assert.IsType<Conflict>(actionResult);
         Assert.True(_response.Headers.ContainsKey(WopiHeaders.VALID_RELATIVE_TARGET));
         // Header value is UTF-7 encoded per the WOPI spec — the round-trip is asserted in
-        // UtfStringTests; here we only check the header was set with non-empty content.
+        // UtfStringTests; this only checks the header was set with non-empty content.
         Assert.NotEmpty(_response.Headers[WopiHeaders.VALID_RELATIVE_TARGET].ToString());
     }
 

--- a/test/WopiHost.Core.Tests/Infrastructure/WopiOverrideMatcherPolicyTests.cs
+++ b/test/WopiHost.Core.Tests/Infrastructure/WopiOverrideMatcherPolicyTests.cs
@@ -18,9 +18,8 @@ namespace WopiHost.Core.Tests.Infrastructure;
 /// End-to-end exercise of <see cref="WopiOverrideMatcherPolicy"/> against an in-memory
 /// <see cref="TestServer"/>. Maps synthetic POST endpoints sharing the same route template and
 /// HTTP verb, each tagged with a distinct <see cref="WopiOverrideMetadata"/>, and asserts the
-/// behaviours the Minimal-API migration depends on (issue #430):
-/// dispatch by header, per-endpoint authorization, pass-through for metadata-less endpoints,
-/// fallback to 404/405 when no candidate matches.
+/// override-dispatch behaviours: dispatch by header, per-endpoint authorization, pass-through
+/// for metadata-less endpoints, fallback to 404/405 when no candidate matches.
 /// </summary>
 public sealed class WopiOverrideMatcherPolicyTests : IAsyncLifetime
 {

--- a/test/WopiHost.Core.Tests/Infrastructure/WopiTelemetryCollection.cs
+++ b/test/WopiHost.Core.Tests/Infrastructure/WopiTelemetryCollection.cs
@@ -7,8 +7,7 @@ namespace WopiHost.Core.Tests.Infrastructure;
 /// </summary>
 /// <remarks>
 /// Without this, xUnit runs the telemetry test classes in parallel and one class's listener
-/// leaks into another's assertions about &quot;no listener&quot; (CI flake — see PR #356 / run
-/// 25456873777).
+/// leaks into another's assertions about &quot;no listener&quot;.
 /// </remarks>
 [CollectionDefinition(Name)]
 public sealed class WopiTelemetryCollection

--- a/test/WopiHost.Core.Tests/Infrastructure/WopiTelemetryEndpointFilterTests.cs
+++ b/test/WopiHost.Core.Tests/Infrastructure/WopiTelemetryEndpointFilterTests.cs
@@ -204,9 +204,9 @@ public class WopiTelemetryEndpointFilterTests
 
         // Override / lock id flow into the activity tags via StartActivity.
         Assert.Equal("LOCK", captured.Activity?.GetTagItem(WopiTelemetry.Tags.Override));
-        // Lock id and user id only land on the log scope, not the activity tag. The fact that the
-        // call returned successfully without throwing (e.g., a null-reference reading the claim)
-        // is the assertion we care about — exercises the `lockId/userId is not null` branches.
+        // Lock id and user id only land on the log scope, not the activity tag. The call
+        // returning successfully without throwing (e.g., a null-reference reading the claim)
+        // is the assertion — exercises the `lockId/userId is not null` branches.
         Assert.Equal("abc", captured.Activity?.GetTagItem(WopiTelemetry.Tags.FileId));
     }
 

--- a/test/WopiHost.Core.Tests/Infrastructure/WopiTelemetryTests.cs
+++ b/test/WopiHost.Core.Tests/Infrastructure/WopiTelemetryTests.cs
@@ -37,7 +37,7 @@ public sealed class WopiTelemetryTests : IDisposable
     [Fact]
     public void StartActivity_NoListener_ReturnsNull()
     {
-        // Use a private listener that ignores our source so StartActivity has no listener for it.
+        // Use a private listener that ignores the source so StartActivity has no listener for it.
         _listener.Dispose();
 
         using var activity = WopiTelemetry.StartActivity("Lock");

--- a/test/WopiHost.Core.Tests/Security/Authentication/JwtAccessTokenServiceTests.cs
+++ b/test/WopiHost.Core.Tests/Security/Authentication/JwtAccessTokenServiceTests.cs
@@ -69,8 +69,8 @@ public class JwtAccessTokenServiceTests
     [Fact]
     public async Task Validation_Rejects_Expired_Token()
     {
-        // JwtSecurityTokenHandler's lifetime check uses wall-clock time, not our TimeProvider,
-        // so we issue a very short-lived token with zero skew and wait past it.
+        // JwtSecurityTokenHandler's lifetime check uses wall-clock time, not the TimeProvider,
+        // so the token is issued very short-lived with zero skew and the test waits past it.
         var svc = BuildService(new WopiSecurityOptions
         {
             SigningKey = JwtAccessTokenService.DeriveHmacKey("k"),
@@ -315,12 +315,12 @@ public class JwtAccessTokenServiceTests
     [Fact]
     public async Task EphemeralKey_ConcurrentFirstRequests_AllTokensValidate()
     {
-        // #420 item 2.4: the singleton-scoped service used to lazily materialize _ephemeralDevKey
-        // via a non-atomic null-check + assignment in GetSigningKey. Concurrent first callers each
-        // minted a *different* random key; whichever assignment lost the publish race signed
-        // tokens with a key the service then discarded — those tokens would fail ValidateAsync
-        // because the service holds the winning key. Lazy<T> in ExecutionAndPublication mode
-        // (the default) makes the factory run exactly once. Pin the invariant.
+        // The singleton-scoped service materializes the ephemeral dev key exactly once via
+        // Lazy<T> in ExecutionAndPublication mode (the default). A non-atomic null-check +
+        // assignment would let concurrent first callers each mint a *different* random key;
+        // whichever assignment lost the publish race would sign tokens with a key the service
+        // then discarded, and those tokens would fail ValidateAsync because the service holds
+        // the winning key.
         var svc = BuildService(new WopiSecurityOptions()); // no SigningKey/SecurityKey → ephemeral path
 
         const int concurrency = 32;

--- a/test/WopiHost.Core.Tests/Security/Authorization/WopiAuthorizationHandlerTests.cs
+++ b/test/WopiHost.Core.Tests/Security/Authorization/WopiAuthorizationHandlerTests.cs
@@ -68,15 +68,13 @@ public class WopiAuthorizationHandlerTests
     [Fact]
     public async Task Concurrent_Requests_Sharing_Attribute_Do_Not_Race_On_Audit_Log()
     {
-        // Regression test for #380 items 2.5 / 5.3: [Authorize] attribute instances are cached
-        // on the action descriptor and shared by every concurrent request hitting the endpoint.
-        // The previous handler wrote requirement.ResourceId = routeId, then read it back into
-        // an audit log — two interleaved requests would cross-contaminate, logging the wrong
-        // file id (and inviting any custom handler that read the property to make wrong
-        // authorization decisions). After the fix the route id stays in a local; this test
-        // hammers the same shared requirement from many concurrent tasks with distinct route
-        // ids and asserts every captured log line pairs the right route id with the right
-        // claim id.
+        // [Authorize] attribute instances are cached on the action descriptor and shared by
+        // every concurrent request hitting the endpoint. The handler must keep the route id in
+        // a local rather than on the shared requirement, otherwise two interleaved requests
+        // cross-contaminate, logging the wrong file id (and inviting any custom handler that
+        // read the property to make wrong authorization decisions). This test hammers the same
+        // shared requirement from many concurrent tasks with distinct route ids and asserts
+        // every captured log line pairs the right route id with the right claim id.
         var requirement = new WopiAuthorizeAttribute(WopiResourceType.File, Permission.Read);
         var captures = new ConcurrentBag<(string TokenRid, string? RouteId)>();
         var handler = new WopiAuthorizationHandler(new CapturingLogger(captures));
@@ -96,8 +94,8 @@ public class WopiAuthorizationHandlerTests
         foreach (var (tokenRid, routeId) in captures)
         {
             // The {tokenRid} log argument is "token-rid-N" and the {routeId} argument is
-            // "file-N" — they must agree on N. Pre-fix this would fail because both fields
-            // could be plucked from any in-flight request.
+            // "file-N" — they must agree on N. If the fields were plucked from any in-flight
+            // request they could be crossed.
             var tokenIndex = tokenRid["token-rid-".Length..];
             var routeIndex = routeId!["file-".Length..];
             Assert.Equal(tokenIndex, routeIndex);
@@ -386,8 +384,8 @@ public class WopiAuthorizationHandlerTests
     public async Task Unknown_Permission_On_File_Falls_Through_To_False_Arm()
     {
         // Same guard, one level deeper — HasFilePermission's switch also has a `_ => false`
-        // arm. Exercise it with an out-of-range Permission value. Use UserCanWrite so we get
-        // past the early Read-implies-true and ReadOnly checks.
+        // arm. Exercise it with an out-of-range Permission value. UserCanWrite gets past the
+        // early Read-implies-true and ReadOnly checks.
         var requirement = new WopiAuthorizeAttribute(WopiResourceType.File, (Permission)999);
         var ctx = BuildContext(requirement, "fileId",
             Authenticated(

--- a/test/WopiHost.Discovery.Tests/AsyncExpiringLazyTests.cs
+++ b/test/WopiHost.Discovery.Tests/AsyncExpiringLazyTests.cs
@@ -103,9 +103,8 @@ public class AsyncExpiringLazyTests
     [Fact]
     public async Task Value_ConcurrentFirstTimeCallers_InvokeProviderExactlyOnce()
     {
-        // Regression test for #303: previously Value() released the lock between
-        // the cache-miss check and the fetch, so N concurrent first-time callers
-        // each fanned out and ran the (network-bound) provider.
+        // Value() must hold the lock across the cache-miss check and the fetch; otherwise
+        // N concurrent first-time callers each fan out and run the (network-bound) provider.
         var calls = 0;
         var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -140,9 +139,9 @@ public class AsyncExpiringLazyTests
     [Fact]
     public async Task Value_TwoInstances_DoNotShareLock()
     {
-        // Regression test: previously the lock was static, so two instances
-        // of AsyncExpiringLazy<string> serialized through one semaphore even
-        // though they cache independent values.
+        // The lock must be instance-scoped: a static lock would serialize two instances
+        // of AsyncExpiringLazy<string> through one semaphore even though they cache
+        // independent values.
         var gateA = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var gateB = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -205,7 +204,7 @@ public class AsyncExpiringLazyTests
     {
         // Double-Dispose must short-circuit on the second call — the inner SemaphoreSlim is
         // disposed exactly once. Hits the `_disposed = true` early-return branch on the second
-        // invocation; previously uncovered because nothing in the discovery flow disposes twice.
+        // invocation.
         var sut = CreateSut(_ => Task.FromResult(new TemporaryValue<string>
         {
             Result = "x",

--- a/test/WopiHost.Discovery.Tests/HttpDiscoveryFileProviderTests.cs
+++ b/test/WopiHost.Discovery.Tests/HttpDiscoveryFileProviderTests.cs
@@ -110,7 +110,7 @@ public class HttpDiscoveryFileProviderTests
     public async Task GetDiscoveryXmlAsync_OnMalformedXml_ThrowsDiscoveryException()
     {
         // A WOPI client that returns 200 with a non-XML body (HTML error pages, JSON, raw text)
-        // used to leak System.Xml.XmlException all the way out. The provider now wraps that into
+        // would otherwise leak System.Xml.XmlException. The provider wraps it into
         // DiscoveryException so callers see a single failure type for "discovery didn't work."
         const string nonXmlBody = "<html><body>This is not the discovery XML you're looking for.</body><unclosed>";
         var handler = new FakeHttpMessageHandler(_ =>

--- a/test/WopiHost.Discovery.Tests/WopiDiscovererTests.cs
+++ b/test/WopiHost.Discovery.Tests/WopiDiscovererTests.cs
@@ -249,8 +249,7 @@ public class WopiDiscovererTests
     {
         // Two AsyncExpiringLazy instances and one IDisposable proof-key cache live inside the
         // discoverer. Double-Dispose must short-circuit on the second call so the inner
-        // resources aren't double-disposed; previously the early-return branch was never hit
-        // because nothing in the discovery flow disposes twice.
+        // resources aren't double-disposed.
         InitDiscoverer(XmlOo2019, NetZoneEnum.ExternalHttps);
 
         _wopiDiscoverer.Dispose();

--- a/test/WopiHost.E2ETests.Collabora/CollaboraEditDocxTests.cs
+++ b/test/WopiHost.E2ETests.Collabora/CollaboraEditDocxTests.cs
@@ -4,9 +4,7 @@ using WopiHost.E2ETests.Collabora.Fixtures;
 namespace WopiHost.E2ETests.Collabora;
 
 /// <summary>
-/// End-to-end happy-path tests for the WopiHost ↔ Collabora editing loop. Tracked under
-/// <see href="https://github.com/petrsvihlik/WopiHost/issues/357">issue #357</see>
-/// "Approach B". Two tests:
+/// End-to-end happy-path tests for the WopiHost ↔ Collabora editing loop. Two tests:
 /// </summary>
 /// <list type="bullet">
 ///   <item>
@@ -38,7 +36,7 @@ namespace WopiHost.E2ETests.Collabora;
 /// </para>
 /// <para>
 /// <b>Selector strategy</b>: Collabora's editor UI iterates rapidly and DOM selectors drift
-/// between releases. We pin only the markers that have stayed stable across at least three
+/// between releases. The tests pin only the markers that have stayed stable across at least three
 /// CODE versions: <c>iframe[name='office_frame']</c> (the WopiHost.Web sample's own iframe),
 /// <c>#document-container</c> / <c>#document-canvas</c> (Collabora's main canvas area), and
 /// the <c>postMessage</c> API surface (Collabora's documented host-protocol channel, much
@@ -52,7 +50,7 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
 {
     private const string SampleDocxName = "test.docx";
 
-    /// <summary>How long we'll wait for Collabora's iframe to render the document area. Generous
+    /// <summary>How long to wait for Collabora's iframe to render the document area. Generous
     /// because CODE's startup + WebSocket handshake commonly takes 8–15 s on a cold cache.</summary>
     private static readonly TimeSpan s_iframeReadyTimeout = TimeSpan.FromSeconds(60);
 
@@ -70,7 +68,7 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
         _context = await playwright.Browser.NewContextAsync(new BrowserNewContextOptions
         {
             // The frontend ships HTTPS only with a dev cert; Aspire's per-run cert isn't in
-            // Chromium's trust store, so we accept the test-only cert explicitly.
+            // Chromium's trust store, so the test-only cert is accepted explicitly.
             IgnoreHTTPSErrors = true,
         });
 
@@ -88,8 +86,8 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
         }
 
         // Restore the original docx so the next run starts from the same fixture state, even
-        // if the save test mutated it. Skip the rewrite when the file is byte-identical so we
-        // don't churn the working tree's modified-time for diagnostics.
+        // if the save test mutated it. Skip the rewrite when the file is byte-identical to avoid
+        // churning the working tree's modified-time for diagnostics.
         if (_originalDocxBytes is not null)
         {
             var docxPath = Path.Combine(app.WopiDocsPath, SampleDocxName);
@@ -114,7 +112,7 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
 
     /// <summary>
     /// Init script installed on every test page to capture Collabora's postMessage stream.
-    /// We unwrap <c>e.data</c> (always a JSON string from Collabora) into structured fields
+    /// Unwraps <c>e.data</c> (always a JSON string from Collabora) into structured fields
     /// so the subsequent C# searches don't have to deal with JSON-in-JSON escaping.
     /// Without the unwrap, <c>JSON.stringify(window.__collaboraMessages)</c> turns
     /// <c>{"MessageId":"Action_Load_Resp"}</c> into <c>"{\"MessageId\":\"Action_Load_Resp\"}"</c>
@@ -174,9 +172,9 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
         }
         catch (PlaywrightException)
         {
-            // Surface the actual page so we can tell whether the table is missing, empty, or
-            // we landed on an error / auth-redirect page. Without this the failure message is
-            // just "selector not found" which is useless for triage.
+            // Surface the actual page to disambiguate a missing/empty table from an error /
+            // auth-redirect page. Without this the failure message is just "selector not found",
+            // which is useless for triage.
             var body = await page.ContentAsync();
             throw new Xunit.Sdk.XunitException(
                 $"Edit link for {SampleDocxName} not visible at {app.WebFrontendUrl.AbsoluteUri}. Page content was:\n{body}");
@@ -209,14 +207,14 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
             }), '*');
         }");
 
-        // Step 5: poll the captured postMessages until we see proof the document actually
-        // loaded. Action_Load_Resp{success:false} is the failure-mode signal we explicitly
-        // look for to fast-fail with a useful message instead of timing out blind.
+        // Step 5: poll the captured postMessages until there's proof the document actually
+        // loaded. Action_Load_Resp{success:false} is the failure-mode signal checked explicitly
+        // to fast-fail with a useful message instead of timing out blind.
         //
         // The capture script unwraps Collabora's JSON-in-JSON envelope into top-level
         // `messageId`/`status`/`success` fields on each entry, so the JS-side filtering uses
-        // straight property comparisons (no string-escape gymnastics). We do the find on the
-        // JS side and pass back a single boolean per loop iteration to keep the round-trip
+        // straight property comparisons (no string-escape gymnastics). The find runs on the
+        // JS side and passes back a single boolean per loop iteration to keep the round-trip
         // tiny and the C# code obvious.
         var loadDeadline = DateTime.UtcNow + s_iframeReadyTimeout;
         while (DateTime.UtcNow < loadDeadline)
@@ -262,7 +260,7 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
         var page = await _context.NewPageAsync();
 
         // Install a postMessage capture on EVERY page (host page + iframe contentWindow) before
-        // any navigation, so we see Collabora's host-integration events (App_LoadingStatus,
+        // any navigation, to capture Collabora's host-integration events (App_LoadingStatus,
         // Document_LoadedSuccessfully, Action_Save_Resp, etc.) from their first emission. The
         // events are JSON-encoded; the shared capture script parses them into structured fields
         // so subsequent C# searches don't have to deal with JSON-in-JSON escaping.
@@ -280,9 +278,8 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
         // Step 0: send Host_PostmessageReady to opt the host page into Collabora's postMessage
         // protocol. Without this, CODE 25.04 sends nothing back to the parent window — including
         // App_LoadingStatus, Document_LoadedSuccessfully, and (critically) Action_Save_Resp.
-        // The previous run captured zero postMessages from Collabora, which is what tipped me off
-        // that the host integration was untriggered. This is documented at
-        // https://sdk.collaboraonline.com/docs/postmessage_api.html (the host MUST initiate).
+        // The host MUST initiate, per
+        // https://sdk.collaboraonline.com/docs/postmessage_api.html.
         await page.EvaluateAsync(@"() => {
             var frame = document.querySelector('iframe[name=""office_frame""]');
             frame.contentWindow.postMessage(JSON.stringify({
@@ -306,10 +303,10 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
         // "subtree intercepts pointer events" — Playwright then times out at 5 s.
         //
         // The dialog's close affordance has varied across CODE versions: 25.04 ships an
-        // <button class="iframe-welcome-close">, older versions had a "Close" link. We try
-        // each in turn, fall back to pressing Escape on the iframe contentWindow (Collabora's
-        // dialog manager closes on Esc), and finally just remove the wrapper from the DOM if
-        // we're confident it's a welcome overlay (defensive against further selector drift).
+        // <button class="iframe-welcome-close">, older versions had a "Close" link. Each is
+        // tried in turn, falling back to pressing Escape on the iframe contentWindow (Collabora's
+        // dialog manager closes on Esc), and finally just removing the wrapper from the DOM
+        // (defensive against further selector drift).
         await TryDismissAsync(officeFrame.Locator(".iframe-welcome-close"), timeoutMs: 3_000);
         await TryDismissAsync(officeFrame.Locator(".iframe-welcome-wrap button:has-text('Close')"), timeoutMs: 1_500);
         await page.EvaluateAsync(@"() => {
@@ -326,8 +323,8 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
         // "Editing" entry switches the doc into edit mode so subsequent typing actually
         // mutates content. Wrapped to swallow any failure (selector drift, leftover overlay,
         // timeout) because the save assertion below is the real test — if Collabora kept the
-        // doc read-only, the write won't happen and we'll get a useful diagnostic dump.
-        // We catch the broad Exception bucket here because Playwright's timeout surfaces as
+        // doc read-only, the write won't happen and the diagnostic dump explains it.
+        // Catches the broad Exception bucket because Playwright's timeout surfaces as
         // System.TimeoutException (from WrapApiCallAsync), NOT as a PlaywrightException.
         try
         {
@@ -336,7 +333,7 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
         }
         catch (Exception ex) when (ex is PlaywrightException or TimeoutException)
         {
-            // View-mode dropdown not where we expect, or the click was intercepted. Fall
+            // View-mode dropdown not where expected, or the click was intercepted. Fall
             // through — the save assertion below will catch any resulting no-op write.
         }
 
@@ -346,8 +343,8 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
         // event and routes it through loolwsd's tile pipeline).
         // Force=true skips the visible/enabled/stable check so a *second* modal popping up
         // mid-click (e.g. the "Welcome" dialog on a fresh session) doesn't make the click
-        // retry-loop and time out. We don't need pointer-event semantics for this test — we
-        // only need focus + subsequent keyboard input, both of which work under Force.
+        // retry-loop and time out. Pointer-event semantics aren't needed here — only focus +
+        // subsequent keyboard input, both of which work under Force.
         await officeFrame.Locator("#document-container").ClickAsync(new() { Force = true });
 
         // Step 2: type a marker into the document. The actual text doesn't matter — what
@@ -356,7 +353,7 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
         await page.Keyboard.TypeAsync("wopihost-e2e-marker", new KeyboardTypeOptions { Delay = 30 });
 
         // Give Collabora's WebSocket pipeline a moment to settle so the document model is
-        // marked dirty before we ask it to save. Without this, Action_Save can race the typing
+        // marked dirty before the save request. Without this, Action_Save can race the typing
         // and be a no-op (loolwsd hasn't yet processed the keystrokes into a model change).
         await Task.Delay(TimeSpan.FromSeconds(2));
 
@@ -365,7 +362,7 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
         // so it's much more stable than poking the toolbar Save icon — that icon's DOM id
         // has changed at least once between CODE majors. Action_Save with default options
         // does a synchronous save back to the host via PutFile.
-        // We dispatch from the parent page because that's what a real WOPI host frontend does
+        // Dispatched from the parent page because that's what a real WOPI host frontend does
         // and what's authorised on Collabora's side (the iframe's window.parent).
         await page.EvaluateAsync(@"() => {
             const frame = document.querySelector(""iframe[name='office_frame']"");
@@ -378,8 +375,8 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
 
         // Step 4: poll for the on-disk write. The PutFile request travels Collabora → host
         // backend → file-system provider; even after Action_Save returns, the writeback can
-        // take a few seconds. We give it up to 60 s with a 250 ms poll cadence — the previous
-        // 30 s budget was sometimes too tight given Collabora's autosave debouncing on CI.
+        // take a few seconds. Allow up to 60 s with a 250 ms poll cadence — a shorter budget can
+        // be too tight given Collabora's autosave debouncing on CI.
         var saveDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(60);
         var changed = false;
         while (DateTime.UtcNow < saveDeadline)
@@ -394,8 +391,6 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
             await Task.Delay(250);
         }
 
-        // (helper) — `static` would be nicer but the class is sealed and the locator is an
-        // instance arg, so a private instance method keeps the call sites clean.
         static async Task TryDismissAsync(ILocator locator, int timeoutMs)
         {
             try
@@ -412,11 +407,10 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
         if (!changed)
         {
             // Pull the postMessage trail + the editor's read-only state to disambiguate WHY the
-            // save was a no-op. Three classes of failure mode we expect to be able to read off
-            // the captured events:
+            // save was a no-op. Three classes of failure mode readable off the captured events:
             //   - Document_LoadedSuccessfully with permissions != edit  → CheckFileInfo wire content not granting UserCanWrite.
             //   - Action_Save_Resp with success: false                  → host-side save handler failed (lock conflict, IO error).
-            //   - No Action_Save_Resp at all                            → Collabora ignored our save trigger (doc in view mode).
+            //   - No Action_Save_Resp at all                            → Collabora ignored the save trigger (doc in view mode).
             // Stringify on the JS side. `EvaluateAsync<object>` over an array returns a boxed
             // JS array whose .ToString() is "System.Object[]" — useless. JSON.stringify with
             // indentation gives a readable, copy-pasteable diagnostic.

--- a/test/WopiHost.E2ETests.Collabora/Fixtures/CollaboraAppFixture.cs
+++ b/test/WopiHost.E2ETests.Collabora/Fixtures/CollaboraAppFixture.cs
@@ -21,13 +21,13 @@ namespace WopiHost.E2ETests.Collabora.Fixtures;
 /// <para>
 /// Docker is required. The fixture probes <c>docker info</c> at construction time and stores
 /// the result in <see cref="IsDockerAvailable"/>; tests check this and skip when the engine is
-/// unreachable. We do NOT throw from <see cref="InitializeAsync"/> on missing Docker — that
+/// unreachable. <see cref="InitializeAsync"/> does NOT throw on missing Docker — that
 /// would surface as a hard failure rather than a skip on contributor machines.
 /// </para>
 /// <para>
 /// Redis is explicitly disabled (<c>AppHost:UseRedisLocks=false</c>) so the e2e test cycle
 /// only depends on a single container (Collabora) rather than two. The memory lock provider
-/// is sufficient for the single-process happy-path scenarios we test here.
+/// is sufficient for the single-process happy-path scenarios covered here.
 /// </para>
 /// </remarks>
 public sealed class CollaboraAppFixture : IAsyncLifetime
@@ -54,8 +54,8 @@ public sealed class CollaboraAppFixture : IAsyncLifetime
     {
         if (!IsDockerAvailable)
         {
-            // Don't start anything — tests will inspect IsDockerAvailable and skip. Throwing
-            // here would surface as a fixture init failure (red) rather than a clean skip.
+            // Start nothing — tests inspect IsDockerAvailable and skip. Throwing here would
+            // surface as a fixture init failure (red) rather than a clean skip.
             return;
         }
 
@@ -64,8 +64,8 @@ public sealed class CollaboraAppFixture : IAsyncLifetime
         // (resource-graph discovery) BEFORE returning, so post-CreateAsync configuration
         // mutations on the returned builder are too late to flip the resource graph. The
         // configureBuilder overload is the documented seam — its callback fires before the
-        // AppHost reads `builder.Configuration.GetValue<bool>(...)`. Command-line --args were
-        // tried first and silently no-op'd (the resource graph kept Redis on, Collabora off).
+        // AppHost reads `builder.Configuration.GetValue<bool>(...)`. Command-line --args silently
+        // no-op here (the resource graph keeps Redis on, Collabora off).
         var appBuilder = await DistributedApplicationTestingBuilder
             .CreateAsync<Projects.WopiHost_AppHost>([], (_, settings) =>
             {
@@ -78,12 +78,11 @@ public sealed class CollaboraAppFixture : IAsyncLifetime
             })
             .ConfigureAwait(false);
 
-        // Sanity check: if the AppHost:UseCollabora flag didn't propagate (it's been a recurring
-        // gotcha — args and `appBuilder.Configuration[..]="true"` *after* CreateAsync silently
-        // no-op because the AppHost has already read the value during entry-point invocation;
-        // the configureBuilder callback is the only seam that runs *before* that read), the
-        // Collabora container won't be in the resource graph. Fail fast here with a clear
-        // message rather than wait through the timeouts below.
+        // Sanity check: if the AppHost:UseCollabora flag didn't propagate (args and
+        // `appBuilder.Configuration[..]="true"` *after* CreateAsync silently no-op because the
+        // AppHost has already read the value during entry-point invocation; the configureBuilder
+        // callback is the only seam that runs *before* that read), the Collabora container won't
+        // be in the resource graph. Fail fast here rather than wait through the timeouts below.
         var resourceNames = appBuilder.Resources.Select(r => r.Name).ToList();
         if (!resourceNames.Contains("collabora"))
         {
@@ -99,14 +98,14 @@ public sealed class CollaboraAppFixture : IAsyncLifetime
         // Wait for the resources whose readiness gates the test. Collabora has an HTTP health
         // check (/hosting/discovery) wired in the AppHost, so WaitForResourceHealthyAsync is
         // the right blocker. The frontend's readiness already implies the backend is up (it
-        // WaitFors the backend internally), so we wait on the chain end.
+        // WaitFors the backend internally), so the wait targets the chain end.
         var notifications = _app.Services.GetRequiredService<ResourceNotificationService>();
         using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3)); // generous for first-run image pull
 
         // Wait for each resource to be reported in a Running state by Aspire's resource
         // notification service. Note that Running != accepting traffic — Aspire's Running
-        // signal only means the orchestrator has issued the start command. We backstop with
-        // an explicit HTTP poll against Collabora's /hosting/discovery below to confirm the
+        // signal only means the orchestrator has issued the start command. The explicit HTTP
+        // poll against Collabora's /hosting/discovery below backstops this to confirm the
         // container is actually serving.
         await notifications.WaitForResourceAsync("collabora", KnownResourceStates.Running, cts.Token).ConfigureAwait(false);
         await notifications.WaitForResourceAsync("wopihost", KnownResourceStates.Running, cts.Token).ConfigureAwait(false);
@@ -146,7 +145,7 @@ public sealed class CollaboraAppFixture : IAsyncLifetime
             catch (TaskCanceledException) when (!cts.Token.IsCancellationRequested)
             {
                 // Per-request HttpClient.Timeout elapsed (Collabora not yet bound). Distinct
-                // from cts.Token cancellation — that one means we hit the overall deadline.
+                // from cts.Token cancellation — that one means the overall deadline was hit.
             }
             await Task.Delay(TimeSpan.FromSeconds(1), cts.Token).ConfigureAwait(false);
         }
@@ -213,8 +212,8 @@ public sealed class CollaboraAppFixture : IAsyncLifetime
         try
         {
             // First find the container name. Aspire names containers after the resource with a
-            // hash suffix; match any "collabora*" we have running. Defensive fallback: if name
-            // discovery fails, dump *all* running containers' logs (only one in our setup).
+            // hash suffix; match any running "collabora*". Defensive fallback: if name discovery
+            // fails, dump *all* running containers' logs (only one in this setup).
             using var psProcess = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
             {
                 FileName = "docker",
@@ -256,7 +255,7 @@ public sealed class CollaboraAppFixture : IAsyncLifetime
             var stdout = await stdoutTask.ConfigureAwait(false);
             var stderr = await stderrTask.ConfigureAwait(false);
 
-            // Lines we care about for diagnosing websocket / WOPI-host rejection:
+            // Lines relevant to diagnosing websocket / WOPI-host rejection:
             //   - "WOPI" / "wopi" — matches host strings, allowed-host checks, WopiSrc parsing
             //   - "WebSocket" / "websocket" — handshake + upgrade
             //   - "Unauthorized" / "unauthoriz" — coolwsd's literal denial message
@@ -265,7 +264,7 @@ public sealed class CollaboraAppFixture : IAsyncLifetime
             //   - "ERR" / "WRN" — coolwsd's own severity tags
             //   - "Reject" / "reject" — generic denial
             //   - "isWopiHostAllowed" / "FrameAncestors" — specific check names from coolwsd
-            // Keep narrow on purpose; the full tail below catches anything we missed.
+            // Kept narrow on purpose; the full tail below catches anything missed.
             var filterKeywords = new[]
             {
                 "WOPI", "wopi", "WebSocket", "websocket", "Unauthorized", "unauthoriz",
@@ -324,9 +323,9 @@ public sealed class CollaboraAppFixture : IAsyncLifetime
     {
         // sample/WopiHost/appsettings.json sets WopiHost.FileSystemProvider:RootPath="../wopi-docs".
         // The path is relative to the *sample's* directory at runtime, so absolute = repo-root/sample/wopi-docs.
-        // We walk up from the test binary location until we hit the repo root (the directory
-        // containing WOPI.slnx) and then point at sample/wopi-docs from there. Robust to the
-        // artifacts/ layout (UseArtifactsOutput) which puts test dlls several levels below.
+        // Walks up from the test binary location until the repo root (the directory containing
+        // WOPI.slnx), then points at sample/wopi-docs from there. Robust to the artifacts/ layout
+        // (UseArtifactsOutput) which puts test dlls several levels below.
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
         while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "WOPI.slnx")))
         {

--- a/test/WopiHost.E2ETests.Collabora/Fixtures/DockerCheck.cs
+++ b/test/WopiHost.E2ETests.Collabora/Fixtures/DockerCheck.cs
@@ -15,10 +15,10 @@ internal static class DockerCheck
     /// without a running engine, or a context pointing at an offline daemon all surface here.
     /// </summary>
     /// <remarks>
-    /// The check is intentionally minimal — it only tells us "can Aspire start containers right
+    /// The check is intentionally minimal — it only answers "can Aspire start containers right
     /// now". It does <em>not</em> verify Linux-container mode, Docker Compose, image pull
-    /// permissions, or any other capability. If the more specific path fails downstream, we'd
-    /// rather see the real error than mask it with a coarser preflight.
+    /// permissions, or any other capability. A more specific path failing downstream should
+    /// surface the real error rather than be masked by a coarser preflight.
     /// </remarks>
     public static bool IsDockerAvailable()
     {

--- a/test/WopiHost.FileSystemProvider.Tests/InMemoryFileIdsTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/InMemoryFileIdsTests.cs
@@ -135,8 +135,8 @@ public class InMemoryFileIdsTests : IDisposable
     [Fact]
     public void UpdateFile_OldPath_NoLongerResolvesViaReverseLookup()
     {
-        // #409 item 2.2: the path→id reverse map must drop the old binding when an id is
-        // rebound to a new path, otherwise stale entries pile up unboundedly.
+        // The path→id reverse map must drop the old binding when an id is rebound to a new
+        // path, otherwise stale entries pile up unboundedly.
         var oldPath = Path.Combine(_tempDir.FullName, "old.docx");
         var newPath = Path.Combine(_tempDir.FullName, "new.docx");
         var id = _sut.AddFile(oldPath);
@@ -162,8 +162,8 @@ public class InMemoryFileIdsTests : IDisposable
     [Fact]
     public void ScanAll_Rescan_DropsBindingsForRemovedFiles()
     {
-        // Confirm both maps are reset on rescan — pre-#409-item-2.2 the forward map was cleared
-        // but a parallel reverse map could have lingered if one was added in isolation.
+        // Confirm both maps are reset on rescan — clearing only the forward map would let a
+        // parallel reverse-map entry linger.
         var stalePath = Path.Combine(_tempDir.FullName, "stale.docx");
         File.WriteAllText(stalePath, string.Empty);
         _sut.ScanAll(_tempDir.FullName);
@@ -178,9 +178,9 @@ public class InMemoryFileIdsTests : IDisposable
     [Fact]
     public async Task AddFile_ConcurrentDistinctPaths_AllEntriesObservable()
     {
-        // #409 item 2.2: pre-fix used a non-concurrent Dictionary, so parallel writers could
-        // corrupt the bucket array or lose entries silently. Verify each parallel add survives
-        // and is reachable in both directions.
+        // A non-concurrent Dictionary would let parallel writers corrupt the bucket array or
+        // lose entries silently. Verify each parallel add survives and is reachable in both
+        // directions.
         const int writers = 64;
         var paths = Enumerable.Range(0, writers)
             .Select(i => Path.Combine(_tempDir.FullName, $"f{i}.docx"))

--- a/test/WopiHost.FileSystemProvider.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/ServiceCollectionExtensionsTests.cs
@@ -41,8 +41,8 @@ public class ServiceCollectionExtensionsTests : IDisposable
     [Fact]
     public void AddFileSystemStorageProvider_RegistersProviderAndInterfacesAsSingleton()
     {
-        // The whole point of this test: the FS provider must be a singleton, matching
-        // AddAzureStorageProvider. Guards against re-introducing the scoped/singleton drift.
+        // The FS provider must be a singleton, matching AddAzureStorageProvider.
+        // Guards against scoped/singleton drift between the two providers.
         var services = BuildServices(out var config);
 
         services.AddFileSystemStorageProvider(config);

--- a/test/WopiHost.FileSystemProvider.Tests/WopiFileSystemProviderTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/WopiFileSystemProviderTests.cs
@@ -117,7 +117,7 @@ public class WopiFileSystemProviderTests : IDisposable
     public void Ctor_AlreadyScanned_SkipsRescan()
     {
         // Pre-populate the ids so WasScanned is true; ctor should skip ScanAll
-        // but still find the root because we add it manually.
+        // but still find the manually-added root.
         var ids = new InMemoryFileIds(NullLogger<InMemoryFileIds>.Instance);
         ids.AddFile(_root.FullName);
 
@@ -373,8 +373,8 @@ public class WopiFileSystemProviderTests : IDisposable
     [Fact]
     public async Task GetWopiResourceByName_MissingContainer_ReturnsNull()
     {
-        // Aligned with WopiAzureStorageProvider's behaviour (#380 item 4.2). Was previously
-        // a FileSystem-only throw — the interface now mandates null on missing parent.
+        // Aligned with WopiAzureStorageProvider's behaviour: the interface mandates null on a
+        // missing parent.
         var result = await _sut.GetWopiFileByName("missing-id", "root.txt");
 
         Assert.Null(result);
@@ -411,9 +411,8 @@ public class WopiFileSystemProviderTests : IDisposable
     [Fact]
     public async Task CheckValidName_FileNameAtMaxLength_ReturnsTrue()
     {
-        // Documented contract is "length up to FileNameMaxLength" — inclusive. Pre-fix the
-        // implementation used `<` so a name of exactly 250 chars was rejected; the unified
-        // single-segment validator now matches the contract (and the Azure provider).
+        // Documented contract is "length up to FileNameMaxLength" — inclusive. A name of exactly
+        // FileNameMaxLength chars must be accepted, matching the Azure provider.
         var atLimit = new string('a', _sut.FileNameMaxLength);
         Assert.True(await _sut.CheckValidFileName(atLimit));
     }
@@ -442,19 +441,19 @@ public class WopiFileSystemProviderTests : IDisposable
     [InlineData("..")]
     public async Task CheckValidName_FolderNameWithPathSeparatorOrNav_ReturnsFalse(string name)
     {
-        // Pre-fix CheckValidContainerName used Path.GetInvalidPathChars(), which omits the
-        // separators GetInvalidFileNameChars forbids — so a "container name" containing a path
-        // separator passed validation and silently broke the storage layer. We deliberately
-        // don't assert on `"foo\\bar"` here: on Linux, `\` is a legal filename character (not
-        // a separator) and the FS provider correctly follows the OS — the OS-agnostic
-        // backslash rejection lives in the Azure provider instead.
+        // CheckValidContainerName must reject path separators: Path.GetInvalidPathChars() omits
+        // the separators GetInvalidFileNameChars forbids, so a container name containing a path
+        // separator would otherwise pass validation and silently break the storage layer. This
+        // does not assert on `"foo\\bar"`: on Linux, `\` is a legal filename character (not a
+        // separator) and the FS provider correctly follows the OS — the OS-agnostic backslash
+        // rejection lives in the Azure provider instead.
         Assert.False(await _sut.CheckValidContainerName(name));
     }
 
     [Fact]
     public async Task CheckValidName_FolderNameTooLong_ReturnsFalse()
     {
-        // Pre-fix CheckValidContainerName had no length cap, so a 10K-char container name passed.
+        // CheckValidContainerName must cap length; without a cap a 10K-char container name passes.
         var longName = new string('a', _sut.FileNameMaxLength + 1);
         Assert.False(await _sut.CheckValidContainerName(longName));
     }
@@ -598,8 +597,8 @@ public class WopiFileSystemProviderTests : IDisposable
     [Fact]
     public async Task DeleteWopiResource_FileMissingId_ReturnsFalse()
     {
-        // #380 item 4.2 — return false for missing identifier (was throw FileNotFoundException),
-        // matching WopiAzureStorageProvider and letting the controller map cleanly to 404.
+        // Return false for a missing identifier, matching WopiAzureStorageProvider and letting
+        // the controller map cleanly to 404.
         var ok = await _sut.DeleteWopiFile("missing");
 
         Assert.False(ok);
@@ -641,7 +640,7 @@ public class WopiFileSystemProviderTests : IDisposable
     [Fact]
     public async Task DeleteWopiResource_FolderMissingId_ReturnsFalse()
     {
-        // #380 item 4.2 — missing identifier returns false, matching WopiAzureStorageProvider.
+        // Missing identifier returns false, matching WopiAzureStorageProvider.
         var ok = await _sut.DeleteWopiContainer("missing");
 
         Assert.False(ok);
@@ -685,7 +684,6 @@ public class WopiFileSystemProviderTests : IDisposable
     [Fact]
     public async Task RenameWopiResource_FileMissingId_ReturnsFalse()
     {
-        // #380 item 4.2.
         var ok = await _sut.RenameWopiFile("missing", "x.txt");
 
         Assert.False(ok);
@@ -715,7 +713,6 @@ public class WopiFileSystemProviderTests : IDisposable
     [Fact]
     public async Task RenameWopiResource_FolderMissingId_ReturnsFalse()
     {
-        // #380 item 4.2.
         var ok = await _sut.RenameWopiContainer("missing", "x");
 
         Assert.False(ok);
@@ -733,9 +730,8 @@ public class WopiFileSystemProviderTests : IDisposable
     [Fact]
     public async Task RenameWopiContainer_InvalidName_Throws()
     {
-        // Mirror of RenameWopiResource_InvalidName_Throws but for the container variant —
-        // the existing test only exercises the file path, so the container's invalid-name
-        // guard (ArgumentException) was previously uncovered.
+        // Container variant of RenameWopiResource_InvalidName_Throws — exercises the container's
+        // invalid-name guard (ArgumentException), which the file-path test doesn't cover.
         Assert.True(_fileIds.TryGetFileId(_empty.FullName, out var folderId));
 
         await Assert.ThrowsAsync<ArgumentException>(() =>
@@ -746,7 +742,7 @@ public class WopiFileSystemProviderTests : IDisposable
     public async Task GetSuggestedContainerName_InvalidName_Throws()
     {
         // The file-name variant is tested via GetSuggestedName_InvalidName_Throws; the
-        // container path uses CheckValidContainerName instead and was missed.
+        // container path uses CheckValidContainerName instead.
         Assert.True(_fileIds.TryGetFileId(_root.FullName, out var rootId));
 
         await Assert.ThrowsAsync<ArgumentException>(() =>
@@ -767,7 +763,7 @@ public class WopiFileSystemProviderTests : IDisposable
     public async Task GetWopiContainerByName_UnknownContainer_ReturnsNull()
     {
         // Mirrors GetWopiFileByName's missing-container behavior — the parent-container miss
-        // returns null per the #380 item 4.2 null-on-missing contract.
+        // returns null per the null-on-missing contract.
         var result = await _sut.GetWopiContainerByName("missing-container-id", "anything");
 
         Assert.Null(result);

--- a/test/WopiHost.FileSystemProvider.Tests/WopiFileTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/WopiFileTests.cs
@@ -96,7 +96,7 @@ public class WopiFileTests : IDisposable
 
         // Files created by the test process are owned by the current user;
         // stat/statx + getpwuid_r should resolve back to that name (or numeric uid
-        // if the user has been deleted from the passwd db, which we don't expect
+        // if the user has been deleted from the passwd db, which is not expected
         // in a CI environment).
         Assert.Equal(Environment.UserName, _sut.Owner);
     }

--- a/test/WopiHost.IntegrationTests/BootstrapEndpointTests.cs
+++ b/test/WopiHost.IntegrationTests/BootstrapEndpointTests.cs
@@ -20,8 +20,8 @@ public sealed class BootstrapEndpointTests(BootstrapEndpointTests.Fixture fixtur
     private const string SharedSigningSecret = "bootstrap-tests-shared-key-32bytes!";
     // The proof-validation filter that's attached to every WOPI endpoint (including bootstrap)
     // rejects requests without an access_token in query string — production hosts would either
-    // disable proof validation or have a custom proof validator that exempts bootstrap. For
-    // these tests we pass any value and let AlwaysValidProofValidator accept it.
+    // disable proof validation or have a custom proof validator that exempts bootstrap. These
+    // tests pass any value and let AlwaysValidProofValidator accept it.
     private const string BootstrapDummyToken = "dummy-token-for-proof-filter";
     private readonly Fixture _fixture = fixture;
 

--- a/test/WopiHost.IntegrationTests/ContainerEndpointTests.cs
+++ b/test/WopiHost.IntegrationTests/ContainerEndpointTests.cs
@@ -95,7 +95,7 @@ public sealed class ContainerEndpointTests(ReadOnlyEndpointsFixture fixture)
     {
         // Spec: each ChildFile and ChildContainer URL embeds an access token. Per "preventing
         // token trading", that token MUST be freshly minted per-child rather than the inbound
-        // parent-container token reused verbatim. We verify (a) each child URL's token differs
+        // parent-container token reused verbatim. This checks (a) each child URL's token differs
         // from the inbound one, and (b) the child tokens carry the resource type the URL
         // implies (File vs Container). Per-id binding is verified by the file-side ancestry
         // test — duplicating the casing-sensitive path-extraction assertion here adds noise
@@ -121,9 +121,9 @@ public sealed class ContainerEndpointTests(ReadOnlyEndpointsFixture fixture)
 
             var jwt = handler.ReadJwtToken(childToken);
             // Per-resource binding: URL path id must equal the JWT resource-id claim verbatim.
-            // The previous LowercaseUrls=true routing-option default was case-folding the URL
-            // path while leaving the JWT claim intact (minted from raw file.Identifier) —
-            // GetWopiSrc now passes LinkOptions { LowercaseUrls = false } to keep them aligned.
+            // GetWopiSrc passes LinkOptions { LowercaseUrls = false } so the URL path keeps its
+            // case and stays aligned with the JWT claim (minted from raw file.Identifier); the
+            // default LowercaseUrls=true would case-fold the path while leaving the claim intact.
             var childId = uri.AbsolutePath.Split('/').Last();
             Assert.Equal(childId, jwt.Claims.First(c => c.Type == WopiClaimTypes.ResourceId).Value);
             Assert.Equal("File", jwt.Claims.First(c => c.Type == WopiClaimTypes.ResourceType).Value);

--- a/test/WopiHost.IntegrationTests/ContainerMutatingEndpointTests.cs
+++ b/test/WopiHost.IntegrationTests/ContainerMutatingEndpointTests.cs
@@ -80,7 +80,7 @@ public sealed class ContainerMutatingEndpointTests(MutatingEndpointsFixture fixt
     {
         // Spec: suggested-mode "must never result in a 400 Bad Request or 409 Conflict. Rather,
         // the host must modify the proposed name as needed to create a new container that is
-        // legally named." Previously we returned 400 on invalid input regardless of mode.
+        // legally named."
         var token = await _fixture.MintContainerTokenAsync(_fixture.RootContainerId);
         using var client = _fixture.WopiBackend.CreateClient();
 
@@ -96,8 +96,7 @@ public sealed class ContainerMutatingEndpointTests(MutatingEndpointsFixture fixt
     public async Task CreateChildContainer_Relative_InvalidName_Returns_400_WithInvalidContainerNameError()
     {
         // Spec: specific-mode 400 "must include an X-WOPI-InvalidContainerNameError header that
-        // describes why the file name was invalid." Pre-fix returned bare BadRequest with no
-        // diagnostic header.
+        // describes why the file name was invalid."
         var token = await _fixture.MintContainerTokenAsync(_fixture.RootContainerId);
         using var client = _fixture.WopiBackend.CreateClient();
 
@@ -235,9 +234,9 @@ public sealed class ContainerMutatingEndpointTests(MutatingEndpointsFixture fixt
     [Fact]
     public async Task RenameContainer_Returns_200_WithNewName()
     {
-        // Spec: response JSON has a single required Name property that MUST be the new name.
-        // The pre-fix impl returned the OLD container snapshot's Name (out-of-sync with what
-        // the storage provider actually persisted).
+        // Spec: response JSON has a single required Name property that MUST be the new name,
+        // not the OLD container snapshot's Name (which would be out-of-sync with what the
+        // storage provider actually persisted).
         var childId = await _fixture.CreateTempContainerAsync();
         var token = await _fixture.MintContainerTokenAsync(childId);
         using var client = _fixture.WopiBackend.CreateClient();

--- a/test/WopiHost.IntegrationTests/FileMutatingEndpointTests.cs
+++ b/test/WopiHost.IntegrationTests/FileMutatingEndpointTests.cs
@@ -59,8 +59,8 @@ public sealed class FileMutatingEndpointTests(MutatingEndpointsFixture fixture)
     public async Task PutFile_OnLockedFile_MissingLockHeader_NonEmpty_Returns_409_WithCurrentLock()
     {
         // Spec: file is locked + X-WOPI-Lock missing → lock mismatch → 409 with the CURRENT
-        // lock id in X-WOPI-Lock. Previous impl returned 409 with an EMPTY X-WOPI-Lock because
-        // it branched on the request header's absence, not the file's lock state.
+        // lock id in X-WOPI-Lock. The mismatch is driven by the file's lock state, not the
+        // request header's absence.
         var fileId = await _fixture.CreateTempFileAsync("locked-non-empty"u8.ToArray());
         var token = await _fixture.MintFileTokenAsync(fileId);
         using var client = _fixture.WopiBackend.CreateClient();
@@ -86,9 +86,9 @@ public sealed class FileMutatingEndpointTests(MutatingEndpointsFixture fixture)
     public async Task PutFile_OnLockedFile_MissingLockHeader_ZeroByte_Returns_409_WithCurrentLock()
     {
         // Spec: file is locked → ANY PutFile without a matching X-WOPI-Lock is a mismatch,
-        // INCLUDING the 0-byte create-new fast path. The previous impl skipped the lock-state
-        // check on the no-header path and silently overwrote locked 0-byte files — a real
-        // security smell against malicious / buggy clients.
+        // INCLUDING the 0-byte create-new fast path. Skipping the lock-state check on the
+        // no-header path would silently overwrite locked 0-byte files — a security smell
+        // against malicious / buggy clients.
         var fileId = await _fixture.CreateTempFileAsync([]);  // 0-byte file
         var token = await _fixture.MintFileTokenAsync(fileId);
         using var client = _fixture.WopiBackend.CreateClient();
@@ -114,9 +114,8 @@ public sealed class FileMutatingEndpointTests(MutatingEndpointsFixture fixture)
     public async Task PutFile_OnUnlockedFile_WithLockHeader_NonEmpty_Returns_409_WithEmptyLock()
     {
         // Spec: file is unlocked → size decides; non-zero → 409 with the empty-lock placeholder
-        // in X-WOPI-Lock. The previous impl, when X-WOPI-Lock was sent against an unlocked file,
-        // would invoke ProcessLockCore → AddLockAsync and ACQUIRE the lock as a side effect,
-        // then write. PutFile is supposed to validate against an existing lock, not establish one.
+        // in X-WOPI-Lock. PutFile must validate against an existing lock, not establish one — an
+        // X-WOPI-Lock sent against an unlocked file must NOT acquire the lock as a side effect.
         var fileId = await _fixture.CreateTempFileAsync("existing-content"u8.ToArray());
         var token = await _fixture.MintFileTokenAsync(fileId);
         using var client = _fixture.WopiBackend.CreateClient();
@@ -209,8 +208,8 @@ public sealed class FileMutatingEndpointTests(MutatingEndpointsFixture fixture)
     {
         // Spec: "If the host can't rename the file because the name requested is invalid or
         // conflicts with an existing file, the host should try to generate a different name
-        // based on the requested name that meets the file name requirements." Previously we
-        // returned 400 immediately on invalid name. Now we sanitise '/' → '_' and proceed.
+        // based on the requested name that meets the file name requirements." An invalid name
+        // is sanitised ('/' → '_') and the rename proceeds rather than 400ing immediately.
         var fileId = await _fixture.CreateTempFileAsync("rename-me"u8.ToArray(), extension: ".txt");
         var token = await _fixture.MintFileTokenAsync(fileId);
         using var client = _fixture.WopiBackend.CreateClient();
@@ -291,7 +290,7 @@ public sealed class FileMutatingEndpointTests(MutatingEndpointsFixture fixture)
     {
         // Spec: suggested-mode MUST NOT return 400 — the host modifies the name to be valid.
         // "bad/name.txt" contains a forbidden '/' char; the negotiator sanitises it to a valid
-        // candidate, the file gets created, and we get 200.
+        // candidate, the file gets created, and the response is 200.
         var parentFileId = await _fixture.CreateTempFileAsync("anchor"u8.ToArray(), extension: ".txt");
         var token = await _fixture.MintFileTokenAsync(parentFileId, WopiFilePermissions.UserCanWrite);
         using var client = _fixture.WopiBackend.CreateClient();
@@ -522,8 +521,7 @@ public sealed class FileMutatingEndpointTests(MutatingEndpointsFixture fixture)
     [Fact]
     public async Task ProcessCobalt_OnMissingFile_Returns_404()
     {
-        // ProcessCobalt previously threw InvalidOperationException when the file was missing,
-        // surfacing as 500. Now returns 404 — matches the rest of the surface.
+        // ProcessCobalt returns 404 when the file is missing — matches the rest of the surface.
         var missing = new string('1', 64);
         var token = await _fixture.MintFileTokenAsync(missing);
         using var client = _fixture.WopiBackend.CreateClient();
@@ -557,8 +555,7 @@ public sealed class FileMutatingEndpointTests(MutatingEndpointsFixture fixture)
     [Fact]
     public async Task ProcessLock_OnMissingFile_Returns_404()
     {
-        // Spec: Lock/Unlock/RefreshLock all list 404 for "Resource not found". Previous impl
-        // threw InvalidOperationException → surfaced as 500.
+        // Spec: Lock/Unlock/RefreshLock all list 404 for "Resource not found".
         var missing = new string('0', 64);
         var token = await _fixture.MintFileTokenAsync(missing);
         using var client = _fixture.WopiBackend.CreateClient();
@@ -601,7 +598,7 @@ public sealed class FileMutatingEndpointTests(MutatingEndpointsFixture fixture)
     public async Task Lock_MissingNewLockIdentifier_Returns_400()
     {
         // Spec: Lock lists 400 Bad Request — "X-WOPI-Lock was not provided or was empty" — as
-        // a distinct status from 409 (lock mismatch). Previous impl returned 409.
+        // a distinct status from 409 (lock mismatch).
         var fileId = await _fixture.CreateTempFileAsync("x"u8.ToArray());
         var token = await _fixture.MintFileTokenAsync(fileId);
         using var client = _fixture.WopiBackend.CreateClient();

--- a/test/WopiHost.IntegrationTests/Fixtures/OidcWebAppFactory.cs
+++ b/test/WopiHost.IntegrationTests/Fixtures/OidcWebAppFactory.cs
@@ -61,7 +61,7 @@ public sealed class OidcWebAppFactory(Uri authority, string wopiSigningSecret, s
     /// the Secure flag.
     /// </para>
     /// <para>
-    /// <strong>Why we can't keep the defaults in tests.</strong> <see cref="HttpClient"/>
+    /// <strong>Why the defaults can't stay in tests.</strong> <see cref="HttpClient"/>
     /// silently drops Secure cookies on plaintext <c>http://localhost</c>, and TestServer's
     /// transport is in-memory HTTP only (no TLS). The alternative would be to switch the test
     /// host to Kestrel with a dev cert — a meaningful architecture change for a single test

--- a/test/WopiHost.IntegrationTests/Fixtures/TestAuthOidcWebAppFactory.cs
+++ b/test/WopiHost.IntegrationTests/Fixtures/TestAuthOidcWebAppFactory.cs
@@ -30,7 +30,7 @@ public sealed class TestAuthOidcWebAppFactory(string wopiSigningSecret, string w
 
         builder.ConfigureServices(services =>
         {
-            // Replace the default cookie scheme with our test handler so [Authorize] passes when
+            // Replace the default cookie scheme with the test handler so [Authorize] passes when
             // a request includes the test-user headers (see TestAuthClientExtensions.AsUser).
             var defaultScheme = TestAuthHandler.SchemeName;
             services.AddAuthentication(options =>

--- a/test/WopiHost.IntegrationTests/Fixtures/WopiBackendFactory.cs
+++ b/test/WopiHost.IntegrationTests/Fixtures/WopiBackendFactory.cs
@@ -24,8 +24,8 @@ namespace WopiHost.IntegrationTests.Fixtures;
 /// and swaps the <see cref="IDiscoverer"/> for a test-only stub that exposes the in-process
 /// RSA key pair (<see cref="FakeDiscovererWithProofKeys"/>). Lets a dedicated suite exercise
 /// the proof-validation pipeline end-to-end with real signatures — see <see cref="ProofKeys"/>.
-/// Pre-#456 every integration test ran through <see cref="AlwaysValidProofValidator"/>, so the
-/// proof-validation surface had no integration coverage at all.
+/// The default <see cref="AlwaysValidProofValidator"/> mode leaves the proof-validation surface
+/// without integration coverage, so this flag exists to drive it.
 /// </param>
 public sealed class WopiBackendFactory(
     string wopiSigningSecret,

--- a/test/WopiHost.IntegrationTests/OidcSignInTests.cs
+++ b/test/WopiHost.IntegrationTests/OidcSignInTests.cs
@@ -14,11 +14,11 @@ namespace WopiHost.IntegrationTests;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <strong>Why this exists.</strong> The PR #479 migration moved <c>AccountController</c> to a
-/// minimal-API <c>AccountEndpoints</c> (<c>Results.Challenge</c> / <c>Results.SignOut</c>).
+/// <strong>Why this exists.</strong> Sign-in/out is served by minimal-API
+/// <c>AccountEndpoints</c> (<c>Results.Challenge</c> / <c>Results.SignOut</c>).
 /// <see cref="WopiTokenRoundTripTests"/> only exercises <c>[Authorize]</c> enforcement via
-/// <c>TestAuthHandler</c>, which short-circuits the real OIDC handshake. Issue #480 closed the
-/// coverage gap by driving the actual sign-in/out endpoints.
+/// <c>TestAuthHandler</c>, which short-circuits the real OIDC handshake. This suite drives the
+/// actual sign-in/out endpoints to close that coverage gap.
 /// </para>
 /// <para>
 /// <strong>Why two HttpClients.</strong> The TestServer in-memory handler routes every request
@@ -81,8 +81,8 @@ public partial class OidcSignInTests : IClassFixture<OidcSignInTests.AppFactory>
         //      is enough, since the form action is the same URL.
         //  (b) The OIDC handler requested response_mode=form_post, so the mock IdP answers
         //      with 200 + HTML containing an auto-submitting <form action="/signin-oidc"
-        //      method="post"> carrying hidden inputs `code` and `state`. We scrape those and
-        //      replay them as a POST to the callback in Phase 3.
+        //      method="post"> carrying hidden inputs `code` and `state`. The test scrapes those
+        //      and replays them as a POST to the callback in Phase 3.
         using var idpClient = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false });
         using var loginForm = new FormUrlEncodedContent(new Dictionary<string, string>
         {
@@ -105,7 +105,7 @@ public partial class OidcSignInTests : IClassFixture<OidcSignInTests.AppFactory>
         Assert.Equal(HttpStatusCode.Redirect, callbackResp.StatusCode);
         Assert.Equal("/", callbackResp.Headers.Location?.OriginalString);
 
-        // Phase 4 — The auth cookie now resolves [Authorize] and we get the Browse page.
+        // Phase 4 — The auth cookie now resolves [Authorize] and returns the Browse page.
         var homeResp = await testClient.GetAsync("/");
         Assert.Equal(HttpStatusCode.OK, homeResp.StatusCode);
     }

--- a/test/WopiHost.IntegrationTests/PermissionClaimRoundTripTests.cs
+++ b/test/WopiHost.IntegrationTests/PermissionClaimRoundTripTests.cs
@@ -20,9 +20,6 @@ namespace WopiHost.IntegrationTests;
 /// response, downgrading access, or evaluate to <see langword="true"/>, leaking edit rights
 /// to a view-only token). This integration test pins both directions.
 /// </para>
-/// <para>
-/// Source: audit item #456 — "No integration test for permission claim round-trip."
-/// </para>
 /// </remarks>
 [Collection("ReadOnlyEndpoints")]
 public sealed class PermissionClaimRoundTripTests(ReadOnlyEndpointsFixture fixture)
@@ -65,11 +62,10 @@ public sealed class PermissionClaimRoundTripTests(ReadOnlyEndpointsFixture fixtu
         // DefaultWopiPermissionProvider + CheckFileInfo builder pipeline).
         //
         // Why NOT use WopiFilePermissions.None for the negative case: JwtAccessTokenService
-        // intentionally skips emitting the wopi:fperms claim when permissions equal None
-        // (line 72 in JwtAccessTokenService), and the provider then falls back to
-        // WopiHostOptions.DefaultFilePermissions — which is non-empty by default. The
-        // None-suppression is a separate design decision; this test pins the round-trip
-        // for non-None values where the claim IS emitted.
+        // intentionally skips emitting the wopi:fperms claim when permissions equal None, and
+        // the provider then falls back to WopiHostOptions.DefaultFilePermissions — which is
+        // non-empty by default. The None-suppression is a separate design decision; this test
+        // pins the round-trip for non-None values where the claim IS emitted.
         var token = await _fixture.MintFileTokenAsync(_fixture.FirstFileId, WopiFilePermissions.UserCanRename);
         using var client = _fixture.WopiBackend.CreateClient();
 

--- a/test/WopiHost.IntegrationTests/ProofValidationIntegrationTests.cs
+++ b/test/WopiHost.IntegrationTests/ProofValidationIntegrationTests.cs
@@ -12,8 +12,8 @@ namespace WopiHost.IntegrationTests;
 
 /// <summary>
 /// End-to-end coverage of <c>WopiProofValidator</c> against the production filter pipeline.
-/// Every other integration test class swaps the validator for <see cref="AlwaysValidProofValidator"/>;
-/// pre-#456 that meant the proof-validation surface had no integration coverage at all. This
+/// Every other integration test class swaps the validator for <see cref="AlwaysValidProofValidator"/>,
+/// leaving the proof-validation surface without integration coverage. This
 /// suite wires the real validator (via <see cref="WopiBackendFactory"/>'s
 /// <c>useRealProofValidator</c> flag) and a discoverer that publishes a known RSA key pair
 /// (<see cref="FakeDiscovererWithProofKeys"/>), so each test exercises the same code path
@@ -133,8 +133,8 @@ public sealed class ProofValidationIntegrationTests : IAsyncLifetime, IDisposabl
     public async Task ProofValidator_Rejects_RequestMissingProofHeader()
     {
         // No X-WOPI-Proof / X-WOPI-TimeStamp headers — the validator's first guard fails and the
-        // request 500s. Pre-#456 this path was untested at the integration level; the unit test
-        // covered ValidateProofAsync directly but never asserted the filter wired it correctly.
+        // request 500s. The unit tests cover ValidateProofAsync directly; this asserts the
+        // filter wires it correctly at the integration level.
         using var client = CreateClient();
         using var request = new HttpRequestMessage(HttpMethod.Get, BuildRequestUrl());
 

--- a/test/WopiHost.IntegrationTests/PutRelativeFileOverwrite501Tests.cs
+++ b/test/WopiHost.IntegrationTests/PutRelativeFileOverwrite501Tests.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace WopiHost.IntegrationTests;
 
 /// <summary>
-/// Spec-correctness test for the PutRelativeFile 501 path described in #455.
+/// Spec-correctness test for the PutRelativeFile 501 path.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -79,7 +79,7 @@ public sealed class PutRelativeFileOverwrite501Tests : IClassFixture<PutRelative
         var token = await _fixture.MintFileTokenAsync(parentFileId, WopiFilePermissions.UserCanWrite);
         using var client = _fixture.WopiBackend.CreateClient();
 
-        // Use a name we know doesn't exist — GUID-stemmed so it can't collide.
+        // Use a non-existent name — GUID-stemmed so it can't collide.
         var freshName = $"fresh-{Guid.NewGuid():N}.txt";
         var req = new HttpRequestMessage(HttpMethod.Post, $"/wopi/files/{parentFileId}?access_token={Uri.EscapeDataString(token)}")
         {

--- a/test/WopiHost.IntegrationTests/WopiTokenRoundTripTests.cs
+++ b/test/WopiHost.IntegrationTests/WopiTokenRoundTripTests.cs
@@ -78,7 +78,7 @@ public sealed partial class WopiTokenRoundTripTests(WopiTokenRoundTripTests.Fixt
         hostpage.EnsureSuccessStatusCode();
         var token = ExtractAccessToken(await hostpage.Content.ReadAsStringAsync());
 
-        // 2. Backend validates the token and answers CheckFileInfo with our user identity.
+        // 2. Backend validates the token and answers CheckFileInfo with the user identity.
         using var backend = _fixture.WopiBackend.CreateClient();
         var checkInfoResponse = await backend.GetAsync($"/wopi/files/{fileId}?access_token={Uri.EscapeDataString(token)}");
 

--- a/test/WopiHost.MemoryLockProvider.Tests/MemoryLockProviderTests.cs
+++ b/test/WopiHost.MemoryLockProvider.Tests/MemoryLockProviderTests.cs
@@ -18,8 +18,8 @@ public class MemoryLockProviderTests
     {
         // Seeds a stale record directly into the provider's per-instance state. The
         // TimeProvider-based expiry path is covered by the conformance suite; this case
-        // additionally exercises the "I observed an entry whose DateCreated predates my clock"
-        // eviction branch with a system clock (no fake), which the conformance suite can't model
+        // additionally exercises the "entry whose DateCreated predates the clock" eviction
+        // branch with a system clock (no fake), which the conformance suite can't model
         // without reaching into impl-specific state.
         var provider = new MemoryLockProvider(NullLogger<MemoryLockProvider>.Instance);
         var fileId = $"expired-direct-{Guid.NewGuid()}";
@@ -39,9 +39,8 @@ public class MemoryLockProviderTests
     [Fact]
     public void TwoInstances_OwnIndependentLockState()
     {
-        // Pins #380 item 2.3 — pre-fix the provider used a static dictionary, so two instances
-        // shared a single lock store. Now state is per-instance; a lock seeded into one provider
-        // must not appear on a sibling.
+        // State must be per-instance: a static dictionary would make two instances share a single
+        // lock store. A lock seeded into one provider must not appear on a sibling.
         var providerA = new MemoryLockProvider(NullLogger<MemoryLockProvider>.Instance);
         var providerB = new MemoryLockProvider(NullLogger<MemoryLockProvider>.Instance);
 

--- a/test/WopiHost.MemoryLockProvider.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/WopiHost.MemoryLockProvider.Tests/ServiceCollectionExtensionsTests.cs
@@ -10,7 +10,7 @@ namespace WopiHost.MemoryLockProvider.Tests;
 /// Unit tests for <see cref="ServiceCollectionExtensions.AddMemoryLockProvider"/>. The
 /// conformance suite bypasses DI (it constructs the provider directly), so the registration
 /// extension's behaviour — null-arg guards, lifetime, and the duplicate-registration check
-/// added in #456 — needs its own coverage.
+/// — needs its own coverage.
 /// </summary>
 public class ServiceCollectionExtensionsTests
 {
@@ -37,7 +37,7 @@ public class ServiceCollectionExtensionsTests
     public void AddMemoryLockProvider_WhenLockProviderAlreadyRegistered_Throws()
     {
         // A host that wires two IWopiLockProviders would have the second registration silently
-        // win the resolve — pre-#456 there was no guard, post-#456 we fail fast at composition.
+        // win the resolve — the guard fails fast at composition instead.
         var services = NewServicesWithLogging();
         services.AddSingleton<IWopiLockProvider>(new FakeLockProvider());
 

--- a/test/WopiHost.RedisLockProvider.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/WopiHost.RedisLockProvider.Tests/ServiceCollectionExtensionsTests.cs
@@ -73,7 +73,7 @@ public class ServiceCollectionExtensionsTests
     public void AddRedisLockProvider_WhenLockProviderAlreadyRegistered_Throws()
     {
         // A host that wires two IWopiLockProviders would have the second registration silently
-        // win the resolve — pre-#456 there was no guard, post-#456 we fail fast at composition.
+        // win the resolve — the guard fails fast at composition instead.
         var services = NewServicesWith();
         services.AddSingleton<IWopiLockProvider>(A.Fake<IWopiLockProvider>());
 

--- a/test/WopiHost.SmokeTests/Fixtures/PlaywrightFixture.cs
+++ b/test/WopiHost.SmokeTests/Fixtures/PlaywrightFixture.cs
@@ -9,8 +9,8 @@ namespace WopiHost.SmokeTests.Fixtures;
 /// (cheap; sub-second) for isolation, so tests don't share cookies / storage.
 /// </summary>
 /// <remarks>
-/// On first construction we shell out to <c>Playwright.Program.Main(["install", "chromium"])</c>,
-/// which is idempotent — it is fast when browsers are already cached, and downloads them once
+/// On first construction this shells out to <c>Playwright.Program.Main(["install", "chromium"])</c>,
+/// which is idempotent — fast when browsers are already cached, and downloads them once
 /// otherwise. CI workflows can install upfront via <c>pwsh playwright.ps1 install --with-deps chromium</c>
 /// to avoid the per-test-run check.
 /// </remarks>

--- a/test/WopiHost.SmokeTests/Fixtures/WebSampleFactory.cs
+++ b/test/WopiHost.SmokeTests/Fixtures/WebSampleFactory.cs
@@ -15,10 +15,10 @@ namespace WopiHost.SmokeTests.Fixtures;
 /// Playwright (which drives a browser) can reach it.
 /// </summary>
 /// <remarks>
-/// We don't use <c>WebApplicationFactory&lt;T&gt;</c> here because its <c>StartServer</c>
-/// hard-casts <c>IServer</c> to <c>TestServer</c>, which crashes the moment we swap in Kestrel.
-/// Instead we replicate the relevant pieces of <c>sample/WopiHost.Web/Program.cs</c>
-/// (Razor Components, discovery, storage provider) and bind Kestrel ourselves. The DI wiring is
+/// <c>WebApplicationFactory&lt;T&gt;</c> is avoided here because its <c>StartServer</c>
+/// hard-casts <c>IServer</c> to <c>TestServer</c>, which crashes once Kestrel is swapped in.
+/// Instead this replicates the relevant pieces of <c>sample/WopiHost.Web/Program.cs</c>
+/// (Razor Components, discovery, storage provider) and binds Kestrel directly. The DI wiring is
 /// intentionally minimal — just enough to make the Browse page render — and the
 /// <see cref="IDiscoverer"/> registration is replaced with a <see cref="FakeDiscoverer"/> so
 /// the page doesn't try to fetch discovery XML from an unreachable test hostname.

--- a/test/WopiHost.SmokeTests/WebSampleSmokeTests.cs
+++ b/test/WopiHost.SmokeTests/WebSampleSmokeTests.cs
@@ -98,7 +98,7 @@ public sealed class WebSampleSmokeTests(PlaywrightFixture playwright) : IAsyncLi
     [Fact]
     public async Task Index_loads_with_no_javascript_errors()
     {
-        // We only assert on JS errors (PageError) — resource load failures (favicon, fake-discoverer
+        // Asserts only on JS errors (PageError) — resource load failures (favicon, fake-discoverer
         // icon URIs, the ~/css/site.css that StaticWebAssets disablement skips) come through as
         // Console errors and are noise from the test setup, not bugs in the sample.
         var page = await _context.NewPageAsync();

--- a/test/WopiHost.Url.Tests/WopiUrlGeneratorTests.cs
+++ b/test/WopiHost.Url.Tests/WopiUrlGeneratorTests.cs
@@ -61,10 +61,10 @@ public partial class WopiUrlGeneratorTests
     [Fact]
     public async Task GetFileUrlAsync_TemplateContainsWopiSourcePlaceholder_SubstitutesAndDoesNotAppendDuplicate()
     {
-        // Modern OOS / M365 templates carry `<wopisrc=WOPI_SOURCE&>`. Prior to the WOPI_SOURCE fix
-        // the builder would unconditionally append `&WOPISrc=...`, producing two WopiSrc params
-        // (lowercase from the substitution + uppercase from the append). The placeholder must now
-        // be auto-populated from the wopiFileUrl parameter and the unconditional append skipped.
+        // Modern OOS / M365 templates carry `<wopisrc=WOPI_SOURCE&>`. Unconditionally appending
+        // `&WOPISrc=...` would produce two WopiSrc params (lowercase from the substitution +
+        // uppercase from the append). The placeholder must be auto-populated from the wopiFileUrl
+        // parameter and the unconditional append skipped.
         const string template = "https://office.example.com/x/_vti_bin/excelserviceinternal.asmx?<ui=UI_LLCC&><wopisrc=WOPI_SOURCE&>";
         A.CallTo(() => _discoverer.GetUrlTemplateAsync("xlsm", WopiActionEnum.LegacyWebService)).ReturnsLazily(() => template);
 


### PR DESCRIPTION
## What

A full sweep of code comments across `src/`, `test/`, `sample/`, `infra/`, and the two CI workflows, plus a codified comment-style policy in `CLAUDE.md`.

The bar applied to every `//` comment and the prose inside `///` XML docs:

- **Third person** — no "we"/"our"/"let's"; describe what the code does, not what the author did.
- **Only the non-obvious** — keep genuine gotchas (e.g. the macOS `stat`/`stat$INODE64` ABI split, the `passwd` struct-sizing crash, Redis/Azure atomicity, spec quirks); delete comments that just restate the code.
- **No meta-commentary** — no "matching X", no "previously/pre-fix" history, no reviewer justifications.
- **No issue/PR numbers** (`#123`) — where the number carried meaning, the substance is inlined instead.
- **Concise** — prefer deleting over padding.

## Guardrails / verification

- **Comment-only.** No code, identifiers, logic, string literals, attributes, or `#pragma`/`#region` directives changed. XML doc tags on public APIs are all preserved (only wording trimmed). Verified by diffing every non-comment changed line — the only ones are three trailing-comment removals where the code is byte-identical.
- **Builds clean** under warnings-as-errors (0 warnings) — confirms no XML doc was dropped.
- **Tests pass** — `WopiHost.Core.Tests` (362) and `WopiHost.IntegrationTests` (120, 5 OIDC skipped).
- Residual scan: **zero** issue-number refs and **zero** first-person left in comments.

## Going forward

`CLAUDE.md` now has a "Comment style" subsection under Code Style & Build Rules, so these conventions are enforced for future changes rather than relying on review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)