### PR TITLE
Provider config/options consistency + documented provider pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,13 @@ Abstractions ← Abstractions.Testing (test-helper library; depends on xunit)
 
 Each storage / lock provider package exposes a typed `services.Add{Provider}{StorageOrLock}Provider(...)` extension. The composition root references the provider package(s) it wants and calls the extension directly — no reflection, no assembly-name strings. Available extensions: `AddFileSystemStorageProvider(cfg)`, `AddAzureStorageProvider(cfg)`, `AddMemoryLockProvider()`, `AddAzureLockProvider(cfg)`, `AddRedisLockProvider(cfg)`. The sample retains a small sample-local discriminator (`Sample:StorageProvider`, `Sample:LockProvider`) so the AppHost flag flow can flip providers at runtime — see [sample/WopiHost/ServiceCollectionExtensions.cs](sample/WopiHost/ServiceCollectionExtensions.cs).
 
+Conventions a new provider follows (keeps the set from drifting):
+
+- **Naming.** `Add{Name}StorageProvider` / `Add{Name}LockProvider`. Takes `IConfiguration` only when the provider has settings to bind.
+- **Options.** A provider with configurable settings has a `{Name}{Storage|Lock}ProviderOptions` class bound from a `Wopi:StorageProvider` / `Wopi:LockProvider` section via `AddOptions<T>().Bind(...).ValidateOnStart()`. A provider with **no** settings (e.g. `MemoryLockProvider` — purely in-memory, expiry fixed at the spec's 30 min) deliberately has **no** options class; don't add an empty one for symmetry.
+- **Consume options, not raw config.** Provider implementations inject `IOptions<T>`, not `IConfiguration` — binding/validation stays at the composition root.
+- **Registration.** Storage providers register with `TryAdd*` (a host pre-registering its own implementation wins; a repeat call no-ops). Lock providers throw if an `IWopiLockProvider` is already registered — exactly one lock backend per process, so a second registration is a configuration error, not a silent override.
+
 ### Infrastructure (infra/)
 
 - **WopiHost.AppHost** — .NET Aspire orchestrator for local development. The backend is pinned at `:5000` (the WOPI host URL is referenced by Collabora's `host.docker.internal:5000`); the frontend and validator use `WithHttpsEndpoint()` so Aspire allocates their ports from the OS's free pool — the dashboard shows whatever was bound.

--- a/sample/WopiHost.Validator/Infrastructure/ServiceCollectionExtensions.cs
+++ b/sample/WopiHost.Validator/Infrastructure/ServiceCollectionExtensions.cs
@@ -34,9 +34,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddWopiServer(this IServiceCollection services, IConfiguration configuration)
     {
         services.Configure<WopiHostOptions>(configuration.GetSection(WopiHostOptions.SectionName));
-        services.AddSingleton<InMemoryFileIds>();
-        services.AddSingleton<IWopiStorageProvider, WopiFileSystemProvider>();
-        services.AddSingleton<IWopiWritableStorageProvider, WopiFileSystemProvider>();
+        services.AddFileSystemStorageProvider(configuration);
         services.AddSingleton<IWopiLockProvider, MemoryLockProvider.MemoryLockProvider>();
         // The validator plugs in its own IWopiHostExtensions to populate the optional
         // CheckFileInfo URLs the Microsoft validator probes for.

--- a/sample/WopiHost.Web.Oidc/Program.cs
+++ b/sample/WopiHost.Web.Oidc/Program.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Logging;
-using WopiHost.Abstractions;
 using WopiHost.Discovery;
 using WopiHost.FileSystemProvider;
 using WopiHost.ServiceDefaults;
@@ -42,8 +41,7 @@ builder.Services
 builder.Services.AddWopiDiscovery<WopiOptions>(
     options => builder.Configuration.GetSection(DiscoveryOptions.SectionName).Bind(options));
 
-builder.Services.AddSingleton<InMemoryFileIds>();
-builder.Services.AddScoped<IWopiStorageProvider, WopiFileSystemProvider>();
+builder.Services.AddFileSystemStorageProvider(builder.Configuration);
 
 // WOPI access-token signer must use the same key as the WOPI backend. Bind a project-local
 // WopiSigningOptions pointed at the same configuration path (Wopi:Security) — pure frontends

--- a/sample/WopiHost.Web/Program.cs
+++ b/sample/WopiHost.Web/Program.cs
@@ -1,4 +1,3 @@
-using WopiHost.Abstractions;
 using WopiHost.Discovery;
 using WopiHost.FileSystemProvider;
 using WopiHost.ServiceDefaults;
@@ -31,8 +30,7 @@ builder.Services
 builder.Services.AddWopiDiscovery<WopiOptions>(
     options => builder.Configuration.GetSection(DiscoveryOptions.SectionName).Bind(options));
 
-builder.Services.AddSingleton<InMemoryFileIds>();
-builder.Services.AddScoped<IWopiStorageProvider, WopiFileSystemProvider>();
+builder.Services.AddFileSystemStorageProvider(builder.Configuration);
 
 var app = builder.Build();
 

--- a/src/WopiHost.FileSystemProvider/WopiFileSystemProvider.cs
+++ b/src/WopiHost.FileSystemProvider/WopiFileSystemProvider.cs
@@ -1,8 +1,8 @@
 using System.Collections.ObjectModel;
 using System.Runtime.CompilerServices;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using WopiHost.Abstractions;
 
 namespace WopiHost.FileSystemProvider;
@@ -24,21 +24,20 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
     /// </summary>
     /// <param name="fileIds">In-memory storage for file identifiers.</param>
     /// <param name="env">Provides information about the hosting environment an application is running in.</param>
-    /// <param name="configuration">Application configuration.</param>
+    /// <param name="options">Bound file-system provider options, supplying <c>RootPath</c>.</param>
     /// <param name="logger">Logger.</param>
     public WopiFileSystemProvider(
         InMemoryFileIds fileIds,
         IHostEnvironment env,
-        IConfiguration configuration,
+        IOptions<WopiFileSystemProviderOptions> options,
         ILogger<WopiFileSystemProvider> logger)
     {
-        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(env);
+        ArgumentNullException.ThrowIfNull(options);
         _fileIds = fileIds ?? throw new ArgumentNullException(nameof(fileIds));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        var fileSystemProviderOptions = configuration.GetSection(WopiFileSystemProviderOptions.SectionName)?
-            .Get<WopiFileSystemProviderOptions>() ?? throw new ArgumentNullException(nameof(configuration));
 
-        var wopiRootPath = fileSystemProviderOptions.RootPath;
+        var wopiRootPath = options.Value.RootPath;
         _wopiAbsolutePath = Path.IsPathRooted(wopiRootPath)
             ? wopiRootPath
             : new DirectoryInfo(Path.Combine(env.ContentRootPath, wopiRootPath)).FullName;

--- a/test/WopiHost.FileSystemProvider.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/ServiceCollectionExtensionsTests.cs
@@ -33,9 +33,6 @@ public class ServiceCollectionExtensionsTests : IDisposable
         {
             ["Wopi:StorageProvider:RootPath"] = _tempDir.FullName,
         });
-        // The provider constructor resolves IConfiguration from DI (separate from the options
-        // binding wired up inside AddFileSystemStorageProvider), so it must be registered too.
-        services.AddSingleton(config);
         return services;
     }
 

--- a/test/WopiHost.FileSystemProvider.Tests/WopiFileSystemProviderTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/WopiFileSystemProviderTests.cs
@@ -1,7 +1,7 @@
 using FakeItEasy;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using WopiHost.Abstractions;
 
 namespace WopiHost.FileSystemProvider.Tests;
@@ -55,43 +55,34 @@ public class WopiFileSystemProviderTests : IDisposable
         InMemoryFileIds? ids = null,
         IHostEnvironment? env = null)
     {
-        var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                [$"{WopiFileSystemProviderOptions.SectionName}:{nameof(WopiFileSystemProviderOptions.RootPath)}"] = rootPath,
-            })
-            .Build();
-        return new WopiFileSystemProvider(ids ?? _fileIds, env ?? _env, config, NullLogger<WopiFileSystemProvider>.Instance);
+        var options = Options.Create(new WopiFileSystemProviderOptions { RootPath = rootPath });
+        return new WopiFileSystemProvider(ids ?? _fileIds, env ?? _env, options, NullLogger<WopiFileSystemProvider>.Instance);
     }
 
     // ---------- Constructor ----------
 
     [Fact]
-    public void Ctor_NullConfiguration_Throws()
+    public void Ctor_NullOptions_Throws()
     {
         Assert.Throws<ArgumentNullException>(() =>
-            new WopiFileSystemProvider(_fileIds, _env, configuration: null!, NullLogger<WopiFileSystemProvider>.Instance));
+            new WopiFileSystemProvider(_fileIds, _env, options: null!, NullLogger<WopiFileSystemProvider>.Instance));
     }
 
     [Fact]
     public void Ctor_NullFileIds_Throws()
     {
-        var config = new ConfigurationBuilder().AddInMemoryCollection(
-            new Dictionary<string, string?>
-            {
-                [$"{WopiFileSystemProviderOptions.SectionName}:{nameof(WopiFileSystemProviderOptions.RootPath)}"] = _root.FullName,
-            }).Build();
+        var options = Options.Create(new WopiFileSystemProviderOptions { RootPath = _root.FullName });
 
         Assert.Throws<ArgumentNullException>(() =>
-            new WopiFileSystemProvider(fileIds: null!, _env, config, NullLogger<WopiFileSystemProvider>.Instance));
+            new WopiFileSystemProvider(fileIds: null!, _env, options, NullLogger<WopiFileSystemProvider>.Instance));
     }
 
     [Fact]
-    public void Ctor_MissingStorageOptionsSection_Throws()
+    public void Ctor_NullRootPath_Throws()
     {
-        var emptyConfig = new ConfigurationBuilder().Build();
+        var options = Options.Create(new WopiFileSystemProviderOptions { RootPath = null! });
         Assert.ThrowsAny<Exception>(() =>
-            new WopiFileSystemProvider(_fileIds, _env, emptyConfig, NullLogger<WopiFileSystemProvider>.Instance));
+            new WopiFileSystemProvider(_fileIds, _env, options, NullLogger<WopiFileSystemProvider>.Instance));
     }
 
     [Fact]

--- a/test/WopiHost.IntegrationTests/Fixtures/OidcWebAppFactory.cs
+++ b/test/WopiHost.IntegrationTests/Fixtures/OidcWebAppFactory.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Mvc.Testing;
+using WopiHost.Discovery;
 using WopiHost.Web.Oidc;
 
 namespace WopiHost.IntegrationTests.Fixtures;
@@ -39,6 +40,12 @@ public sealed class OidcWebAppFactory(Uri authority, string wopiSigningSecret, s
 
                 RelaxOidcCookiePolicyForInMemoryHttpTestServer(options);
             });
+
+            // Stub discovery so the authenticated Browse page renders from canned capabilities
+            // rather than fetching from the unreachable test ClientUrl — without this the
+            // discovery HttpClient hangs until the resilience handler's 30s timeout and the page 500s.
+            services.RemoveAll<IDiscoverer>();
+            services.AddSingleton<IDiscoverer, FakeDiscoverer>();
         });
 
         builder.UseEnvironment("Development");

--- a/test/WopiHost.SmokeTests/Fixtures/WebSampleFactory.cs
+++ b/test/WopiHost.SmokeTests/Fixtures/WebSampleFactory.cs
@@ -1,7 +1,6 @@
 using System.Net;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
-using WopiHost.Abstractions;
 using WopiHost.Discovery;
 using WopiHost.FileSystemProvider;
 using WopiHost.Web.Components;
@@ -57,8 +56,7 @@ public sealed class WebSampleFactory : IDisposable, IAsyncDisposable
         // Faked discoverer instead of AddWopiDiscovery — avoids HTTP fetch from ClientUrl.
         builder.Services.AddSingleton<IDiscoverer, FakeDiscoverer>();
 
-        builder.Services.AddSingleton<InMemoryFileIds>();
-        builder.Services.AddScoped<IWopiStorageProvider, WopiFileSystemProvider>();
+        builder.Services.AddFileSystemStorageProvider(builder.Configuration);
 
         var app = builder.Build();
         app.UseDeveloperExceptionPage();


### PR DESCRIPTION
Three architectural items from the #493 backlog. (The fourth, `StorageProviderConformanceTests`, is intentionally left for a focused follow-up — see below.)

## Lock-provider `ValidateOnStart` parity — verified, no change
The "Redis missing `ValidateOnStart`" flag is stale: `AddRedisLockProvider` already chains `.ValidateOnStart()`, as does `AddAzureLockProvider`. `MemoryLockProvider` has no options to validate. So parity already holds — confirmed and documented, no code change.

## Provider pattern documented (`CLAUDE.md`)
Added a conventions list under **Provider Model** so future providers don't drift:
- naming (`Add{Name}{Storage|Lock}Provider`),
- when a provider gets an options class — and that **`MemoryLockProvider` deliberately has none** (no settings; expiry is the spec-fixed 30 min). **Decided against** adding a vacuous marker options class purely for symmetry,
- implementations consume `IOptions<T>`, not `IConfiguration`,
- registration rules: storage uses `TryAdd*`; lock providers throw if one is already registered (exactly one backend per process).

## Mixed config access — migrated the one offender
`WopiFileSystemProvider` was the only `src/` type reading `IConfiguration` in its constructor. It now injects `IOptions<WopiFileSystemProviderOptions>`, keeping binding + validation at the composition root. Consumers updated:
- `WopiHost.Web` / `WopiHost.Web.Oidc` replaced bespoke `AddSingleton<InMemoryFileIds>() + AddScoped<IWopiStorageProvider, WopiFileSystemProvider>()` with `AddFileSystemStorageProvider(builder.Configuration)` (binds + validates options, and aligns them on the singleton lifetime).
- Provider unit tests construct via `Options.Create(...)`.

## Verification
- Full solution builds clean (0 warnings, warnings-as-errors).
- `WopiHost.FileSystemProvider.Tests`: 118 pass. `WopiHost.IntegrationTests`: 123 pass, 2 fail — the 2 are the Dockerized OIDC sign-in tests, which **fail identically on clean `master`** (pre-existing; a 500 in the mock-OIDC protected-page flow in this environment), so unrelated to this change.

## Deferred: `StorageProviderConformanceTests`
The remaining backlog item is net-new test infrastructure (a seeded-data factory abstraction + a shared conformance base + FS and Azure subclasses). It deserves its own focused review, and its Azure leg is Docker/Azurite-gated (CI-verified, not locally). Bundling it here would make this PR sprawling and half-unverifiable locally — I'll raise it as a dedicated PR.

Refs #493 (resolves the lock-provider validation-parity, DI/options-naming, and mixed-config-access items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)