### PR TITLE
Add codebase-audit skill

### DIFF
--- a/.claude/skills/codebase-audit/SKILL.md
+++ b/.claude/skills/codebase-audit/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: codebase-audit
+description: >-
+  Run a repeatable, multi-dimension code-quality / architecture / WOPI-spec-compliance audit of
+  the WopiHost codebase and produce a tracker-ready findings report. Use this whenever the user
+  wants to sweep the codebase for smells — code duplication, leaky abstractions, architectural
+  inconsistencies, non-idiomatic .NET / Minimal-API patterns, wrong patterns, refactoring
+  opportunities, security smells, performance issues, tech debt (TODOs, `#pragma` suppressions,
+  hardcoded constants), test-coverage gaps, or WOPI spec non-compliance. Trigger on phrasings like
+  "audit the codebase", "find code smells", "tech-debt sweep", "is the codebase in good shape",
+  "review the architecture", "find duplication / leaky abstractions / refactors", "check WOPI spec
+  compliance", or "keep the codebase in top shape" — even when the user doesn't say the word
+  "audit". This is the standing health-check for the repo; prefer it over an ad-hoc grep sweep.
+---
+
+# Codebase audit
+
+A standing, repeatable health-check for WopiHost. It reproduces the methodology behind this repo's
+past audit trackers (broad-sweep code-smell, leaky-abstraction, Minimal-API-idiom, and WOPI
+spec-correctness audits) so the codebase stays in top shape across many runs — without resurfacing
+decisions that were already verified as intentional.
+
+## What makes this repeatable (read first)
+
+The single thing that keeps a recurring audit useful instead of noisy is a **do-not-re-file
+ledger**: a list of findings that earlier audits investigated and deliberately rejected as
+false-positives or intentional design. Every run MUST load it and suppress anything on it.
+
+1. Read `references/do-not-refile.md` — the verified-intentional ledger. Treat each entry as
+   out-of-bounds unless the surrounding code has materially changed.
+2. Read the root `CLAUDE.md` — the repo's own conventions (comment style, provider model, DI
+   rules, nullable/warnings-as-errors, net10 targeting, centralized packages). Findings are
+   measured against these, and several "smells" are actually documented conventions.
+3. Check currently-open issues/PRs (`gh issue list`, `gh pr list`) so you cross-reference existing
+   trackers rather than re-filing them.
+
+Then run the scan, verify, and report.
+
+## The bar: only clear net wins (and never make it worse)
+
+The point of this audit is to make the codebase *better* — so a finding ships only if its
+remediation is a **clear improvement**. Apply this test to every candidate before filing it:
+
+> If a competent maintainer applied the suggested fix, would the codebase be unambiguously better —
+> more correct, safer, clearer, or meaningfully simpler — with **no** offsetting loss?
+
+If the honest answer is "it's a lateral move," "it trades clarity for theoretical purity," or "it's
+correct in principle but nobody would thank you for it," **drop it**. A short list of real wins is
+the goal; padding it with debatable nits trains the reader to ignore the whole report. When unsure
+whether a fix is a net improvement, leave it out rather than hedge.
+
+### Do NOT flag — "fixes" that would factually worsen the codebase
+
+These are anti-findings: recommending them makes the code *worse*. Each has been correctly rejected
+in this repo before — don't resurface them.
+
+- **Annotating instead of improving.** Adding `// reserved` to an interface-mandated unused
+  parameter, or any comment whose only job is to silence a non-warning. (The honest fix for an
+  unused `CancellationToken` on an async seam is to *honor* it, not comment it.)
+- **Micro-optimizing cold paths into contortions.** Avoiding a trivial allocation on a
+  cached / startup / 12h-refresh path via span gymnastics or a clever one-liner. Clarity wins where
+  performance doesn't matter.
+- **Premature abstraction / wrapper types with no safety gain.** A value type, factory, or
+  indirection that adds ceremony without preventing a real, plausible bug. (Typed ids here are a
+  deliberate, separately-tracked design decision — not a drive-by smell.)
+- **Code-moving extractions with no readability gain — and real risk.** Splitting a clear linear
+  pipeline just to shorten a method. Extractions can introduce subtle bugs (eagerly touching
+  `file.Length` before a write once primed a stale version cache and broke a validator test).
+  Extract only when it genuinely clarifies or removes duplication.
+- **Consistency for its own sake.** An empty options class "for symmetry," or forcing two
+  legitimately-different things to look identical. Symmetry isn't a goal; correctness and clarity are.
+- **Fighting intentional configuration.** Undoing a deliberate analyzer suppression, a documented
+  `Scoped` lifetime, a spec-mandated UTF-7 pragma, or a raised qlty threshold. If `CLAUDE.md` or an
+  inline rationale defends it, it is not a finding.
+- **Cleverness over clarity.** Replacing readable code with a denser expression that's harder to read.
+- **Churn for taste during stabilization.** A sweeping mechanical rewrite whose only benefit is
+  preference, with real regression surface and little payoff.
+
+When a candidate matches one of these, don't discard it silently — record it in the do-not-re-file
+section with the reason, so the next run doesn't re-propose it.
+
+## Method
+
+The audit fans out so breadth doesn't cost depth, then converges on verification. Don't try to hold
+the whole codebase in one pass.
+
+1. **Cheap mechanical pass.** Run `scripts/mechanical-scan.sh` (from the repo root). It greps the
+   stable, deterministic smells (TODOs, `#pragma warning disable`, `AddScoped`/`AddSingleton` drift,
+   `IConfiguration` constructor params, broad `catch (Exception)`, `postMessage(..., '*')`,
+   `Enum.Parse` on input, etc.) and prints `file:line` hits. These are **leads, not findings** —
+   every one still has to be read in context and verified.
+
+2. **Parallel area scans.** Fan out one reviewer per area; each covers *all* dimensions for its
+   slice. Areas: `src/WopiHost.Core` + `src/WopiHost.Abstractions`; the storage/lock providers
+   (`*Provider`); `src/WopiHost.Discovery` + `Url` + `Cobalt`; `sample/` frontends; `infra/`;
+   `test/`. Give each reviewer `references/dimensions.md` (the per-dimension checklist) and the
+   do-not-re-file ledger, and have it return candidate findings with `file:line` anchors.
+   - If subagents/Workflow are available, this is a natural fan-out (the past audits used "four
+     parallel scans"). If not, walk the areas sequentially.
+
+3. **Spot-verify in source AND pass the net-value bar.** Do NOT trust scan output. Open the file at
+   the cited line and confirm the smell is real. Then apply the bar above: would the fix make the
+   codebase unambiguously better? Past audits dropped items that "verification showed were false
+   positives or already correctly handled" — also drop the ones whose fix would be a lateral move or
+   a net loss. Mark survivors **[verified]**. A finding without a confirmed `file:line` anchor, or
+   whose remediation isn't a clear win, does not ship.
+
+4. **Classify + anchor + hint.** Every finding gets: a severity (High / Medium / Low), a dimension,
+   a `file:line` link, and a one-line remediation hint. No vague "this could be cleaner." Lead the
+   report with the highest-confidence clear wins — the slam-dunks a maintainer can apply without
+   debate — so the most valuable work is unmissable.
+
+See `references/dimensions.md` for the dimension checklist (WOPI spec compliance, leaky
+abstractions, architectural inconsistencies, duplication, refactoring, .NET/Minimal-API idiom,
+security, performance, tech debt, test-coverage gaps) — each with the concrete patterns earlier
+audits actually found, so a new run knows what "good" looks like here.
+
+## Severity
+
+- **High** — wire-level / security / correctness: a WOPI spec violation a real client would hit, a
+  data race or TOCTOU, a security leak (origin wildcard, stack traces, broad swallow of auth
+  failures), a contract that throws where callers don't expect it.
+- **Medium** — architectural drift, duplication, leaky abstractions, missing test coverage on a
+  security/contract path, non-idiomatic patterns that will propagate.
+- **Low** — quick wins: inconsistent defaults, stray allocations, unused params, untracked TODOs,
+  tidy-ups.
+
+When in doubt about whether something is a real problem, spend the verification time rather than
+inflating the count — a tight, true list beats a long, hedged one.
+
+## Output
+
+Produce a single markdown report, ready to paste into a tracker issue. Use this structure:
+
+```
+## Codebase audit (<YYYY-MM-DD>)
+
+<one-line scope: areas swept, how many findings.>
+
+### High severity
+- [ ] **<title>** **[verified]** — [`path:line`](path#Lline). <what's wrong + why it matters>. <remediation hint>.
+
+### Medium severity
+- [ ] ...
+
+### Low severity
+- [ ] ...
+
+---
+
+### Do not re-file (verified false positives / intentional design)
+<Carry forward every entry from references/do-not-refile.md, PLUS any new candidate this run
+investigated and rejected. This regenerated section is what you (or the next run) fold back into
+the ledger.>
+
+---
+
+### Tally
+| Dimension | High | Medium | Low |
+|---|---:|---:|---:|
+| ... | | | |
+| **Total** | | | |
+```
+
+Rules for the report:
+- Phrase each finding in third person, concrete, no meta-commentary (per CLAUDE.md comment style).
+- Reference `file:line` with a real anchor; never invent line numbers — confirm them.
+- If a candidate turns out intentional, don't silently drop it — move it to the do-not-re-file
+  section with the reason, so the next run doesn't re-investigate it.
+- Cross-reference existing issues/PRs by number when a finding is already tracked, instead of
+  duplicating it.
+
+## Closing the loop (so the ledger compounds)
+
+After the user triages the report, append any newly-confirmed-intentional items to
+`references/do-not-refile.md`. That file is the institutional memory; keeping it current is what
+makes the next run faster and quieter. If you fix findings in the same session, note the resolving
+PR next to the item (the past trackers used `→ #PR`).

--- a/.claude/skills/codebase-audit/references/dimensions.md
+++ b/.claude/skills/codebase-audit/references/dimensions.md
@@ -1,0 +1,123 @@
+# Audit dimensions
+
+The checklist each area reviewer works through. Patterns below are drawn from this repo's real past
+findings — they tell a new run what kinds of things have genuinely been wrong here, so it can spot
+the next instance instead of inventing generic advice. Every candidate still needs source
+verification and a `file:line` anchor.
+
+**Apply the net-value bar (see SKILL.md) to everything here:** only report a finding when its fix
+would make the codebase unambiguously better. A pattern matching a checklist item is necessary but
+not sufficient — if the "fix" would be a lateral move, add ceremony, fight an intentional decision,
+or trade clarity for purity, it is not a finding. When in doubt, leave it out.
+
+## 1. WOPI spec compliance (usually High)
+
+The protocol is exacting; a single wrong header or status code silently breaks real clients
+(Collabora, M365, the WOPI Validator suite). Check each against Microsoft Learn's WOPI REST docs.
+
+- **Exact response headers.** No stray spaces in header *names* or *values* (a past bug shipped
+  `"X-WOPI-InvalidFileNameError "` and `EMPTY_LOCK_VALUE = " "` instead of the empty string the spec
+  mandates). On a 409 lock-mismatch / GetLock / unlocked file, `X-WOPI-Lock` must be present and set
+  to the current lock id or the empty string per spec.
+- **Status-code branching.** PutRelativeFile uses 409 vs 501 for distinct failures; over-length lock
+  ids are 400; missing-vs-conflict is 404 vs 409. Confirm the handler returns the spec's code.
+- **Lock atomicity.** RefreshLock / UnlockAndRelock MUST be a true compare-and-swap inside the
+  provider (not a check-then-act in the endpoint). A past High was a non-atomic `Get`+`TryUpdate`.
+- **Required request headers honored.** PutFile should read `X-WOPI-Editors`; PutRelativeFile
+  `X-WOPI-FileConversion` / `X-WOPI-Size`; lock ops require `X-WOPI-Lock`.
+- **Token scoping.** A freshly-minted child/relative resource gets a token bound to the NEW resource
+  id (token-trading prevention), not the inbound token.
+- **Sample token scoping.** A "view" link must not mint a token with write flags — Collabora derives
+  view-vs-edit from `CheckFileInfo` permission flags, so an over-permissive token opens edit mode.
+
+## 2. Leaky abstractions & contracts (High/Medium)
+
+- **Framework types in `WopiHost.Abstractions`.** `HttpContext`, MVC/ASP.NET types leaking into the
+  abstraction layer (the adapter `WopiRequestInfo` exists precisely to keep HTTP out of it).
+- **Undefined / surprising contracts.** A property or method whose null/throw/empty behavior isn't
+  documented but whose callers assume one (e.g. an interface member that throws on some platforms).
+- **Read/write seam.** The read interface (`IWopiStorageProvider`) must not expose write affordances;
+  writes go through `IWopiWritableStorageProvider` / `IWopiWritableFile`.
+- **Sync-over-async at a boundary** that isn't a deliberate, documented `Dispose` case.
+
+## 3. Architectural inconsistencies (Medium)
+
+These are "two things that should match but don't." The providers are the usual offenders.
+
+- **DI lifetime drift.** Equivalent providers registered with different lifetimes (a past fix aligned
+  FileSystem `Scoped` → `Singleton` to match Azure). Singleton is safe only if the type is stateless
+  and captures no scoped dependency.
+- **Override semantics.** Storage providers register with `TryAdd*` so a host can pre-register its
+  own; lock providers throw if one is already registered (exactly one per process). A plain
+  `Add*` that should be `TryAdd*` is the smell.
+- **Options-validation parity.** Every options-bound provider chains `.ValidateOnStart()`.
+- **Config access pattern.** Implementations inject `IOptions<T>`, not `IConfiguration` — binding +
+  validation belong at the composition root. An `IConfiguration` constructor param in `src/` is the
+  smell (the FileSystem provider was migrated for exactly this).
+- **Conformance-test coverage.** Every `IWopiLockProvider` / `IWopiStorageProvider` runs the shared
+  `*ConformanceTests`. A provider without a conformance subclass is drift.
+- **Provider conventions** (per CLAUDE.md): `Add{Name}{Storage|Lock}Provider` naming; an options
+  class only when there are settings (Memory lock provider deliberately has none — see ledger).
+
+## 4. Code duplication (Medium)
+
+- **Repeated literals/logic.** The same forbidden-filename character set or sanitization in multiple
+  handlers; the same id↔path map logic; copy-pasted validation.
+- **Duplicated test fixtures.** Near-identical `AzuriteFixture` / `PlaywrightFixture` / token-minting
+  helpers across test projects (some are intentionally left — check the ledger).
+- **`csproj` / `Program.cs` drift.** Repeated `PropertyGroup` settings that belong in a
+  `Directory.Build.props`; sample frontends independently re-wiring the same boilerplate.
+
+## 5. Refactoring opportunities (Medium/Low)
+
+- **Long handlers.** Endpoint bodies that interleave validate / resolve / write — extract named
+  helpers (but watch for side effects: accessing `file.Length` before a write can prime a stale
+  version cache).
+- **Primitive obsession.** Bare `string` ids / lock tokens threaded everywhere (typed
+  `WopiResourceId` / `WopiLockToken` are tracked design tasks — don't re-file, link them).
+- **Many-parameter helpers.** A private helper taking 9–10 pass-through params → bundle into a
+  record (done for `ProcessLockCore` → `LockOperationRequest`).
+
+## 6. .NET 10 / Minimal-API idiom (Medium/Low)
+
+- `TypedResults.*` over `Results.*` in endpoints (typed unions); consistent in the samples too.
+- Redundant `[FromServices]` annotations (inferred in .NET 10); unnecessary `app.UseRouting()`.
+- `[AsParameters]` request records for large handlers; `IParsable` for typed route params.
+- File-scoped namespaces (IDE0161); no unused usings (IDE0005); source-generated `[LoggerMessage]`
+  over direct `ILogger.LogX` calls.
+- Endpoint filters / route groups over per-handler boilerplate.
+
+## 7. Security smells (High)
+
+- `postMessage(..., '*')` wildcard target origin in sample host pages — use the configured client
+  origin.
+- Stack-trace / exception-detail leakage not gated behind `IsDevelopment()`.
+- `Enum.Parse` / other throwing parses on untrusted route/header input → 500 instead of 400; use
+  `TryParse`.
+- Broad `catch (Exception)` that swallows without filtering async-rude exceptions
+  (OOM/SO/ThreadAbort) or without structured logging — especially in auth/proof validation.
+- A dev-only escape hatch (e.g. proof-validation disable) that isn't refused outside Development.
+
+## 8. Performance (Medium/Low)
+
+- O(n) scans on a hot path (a past fix added a reverse `_pathToId` dict to `BlobIdMap` to kill a
+  linear `TryGetFileId`). Mirror what the FS provider's `InMemoryFileIds` already does.
+- TOCTOU between an existence check and a mutating call — use conditional headers/ETags
+  (`IfNoneMatch`) instead of check-then-act.
+- Avoidable allocations on cached/hot paths (weigh against readability — a cold 12h-cached path is
+  not worth contorting).
+
+## 9. Tech debt (Low)
+
+- `//TODO` / `//HACK` comments with no tracking issue — convert or remove.
+- `#pragma warning disable` without an adjacent rationale comment (warnings-as-errors is on, so each
+  suppression should explain why it can't be honored — e.g. UTF-7 mandated by the spec).
+- Hardcoded constants that should be named/centralized; magic strings for headers.
+- Inconsistent option defaults (some `GetValue("X", defaultValue: ...)` explicit, some implicit).
+
+## 10. Test-coverage gaps (Medium)
+
+- Security/contract round-trips with unit tests on each side but none end-to-end (a past fix added a
+  permission-claim round-trip integration test; another added real-proof-key validation coverage).
+- A provider lacking the shared conformance subclass.
+- Docker-gated suites (Azurite/Redis/Collabora) — note when a path is CI-only-verifiable.

--- a/.claude/skills/codebase-audit/references/do-not-refile.md
+++ b/.claude/skills/codebase-audit/references/do-not-refile.md
@@ -1,0 +1,73 @@
+# Do not re-file — verified false-positives & intentional design
+
+Every entry here was investigated by a past audit (or a focused fix) and **deliberately rejected**
+as a finding: it's either a false positive or an intentional design decision with a documented
+reason. A new audit run must treat these as out-of-bounds and must not re-file them — unless the
+surrounding code has materially changed, in which case re-verify before resurfacing.
+
+Keep this file current: when a run investigates a new candidate and concludes it's intentional,
+add it here with the reason. This ledger is what keeps repeat audits quiet and fast.
+
+## Concurrency / async
+
+- **`CobaltSession.cs` `.Result` access is not a sync-over-async deadlock.** Both call sites guard
+  on `task.Status == TaskStatus.RanToCompletion` before touching `.Result` — correct sync-unwrap of
+  an already-completed task.
+- **`HashingBlobWriteStream` sync `SetMetadata` in `Dispose` is intentional.** `Stream.Dispose`
+  can't be async (documented inline); the `DisposeAsync` path uses `SetMetadataAsync`. This is the
+  one necessary sync-over-async boundary.
+
+## Spec / wire format
+
+- **`UtfString` keeps `#pragma warning disable SYSLIB0001` (UTF-7).** UTF-7 is mandated by the WOPI
+  spec for `X-WOPI-SuggestedTarget` / `X-WOPI-RelativeTarget`; the framework deprecation can't be
+  honored. The suppression carries a spec-linked rationale.
+
+## Abstractions / API surface
+
+- **`using Microsoft.AspNetCore.Mvc;` in `*Endpoints.cs` is required.** `[FromHeader]` /
+  `[FromRoute]` / `[FromBody]` / `[FromServices]` live there and bind the `[AsParameters]`
+  record-struct properties. Removing it breaks the build.
+- **`ICheckFolderInfoBuilder.Build` staying synchronous is intentional.** Documented on the
+  interface; making it async would regress an Infer# null-deref false positive.
+- **`WopiSecurityOptions.SigningKey` stays `byte[]?` (CA1819 suppressed).** The `IConfiguration`
+  `BinaryConverter` only targets `byte[]`, and `SymmetricSecurityKey(byte[])` consumes it directly.
+  The suppression has a documented rationale next to the field.
+- **`WopiResourceId` being a `static` helper (not a value type) is the current state, not a bug.**
+  Turning it into a typed id is a deliberate, API-breaking design task — tracked, not a quick win.
+  Don't file "primitive obsession: string ids" as a fresh smell; link the design issue instead.
+
+## DI / provider model
+
+- **`MemoryLockProvider` deliberately has no options class.** It has no configurable settings — the
+  lock expiry is the spec-fixed 30 minutes. Don't add an empty marker options class for symmetry.
+- **`DefaultCheckFileInfoBuilder` (and the other CheckInfo builders) are registered `Scoped` on
+  purpose.** They capture the writable storage provider, which may be scoped; promoting to singleton
+  would risk a captive dependency. The registration site documents this.
+
+## Validation framework
+
+- **`Microsoft.Extensions.Validation` (`AddValidation()`) was evaluated and rejected for the WOPI
+  surface.** Three structural mismatches (501-vs-400 status branching, override-conditional header
+  requirements, spec-mandated empty-body + failure headers). Header mutual-exclusivity is handled
+  the lightweight way via `EndpointHelpers.EnsureExactlyOneOf`.
+
+## Samples / frontends
+
+- **Server-rendered views in the `WopiHost.Web` frontends are appropriate.** It's a view-heavy
+  sample; Minimal APIs aren't designed to serve views, so "migrate to minimal-API-served views" is
+  not an improvement.
+- **`Wopi:Security:DisableProofValidation` is a dev-only flag, by design.** It swaps in a no-op
+  proof validator for clients (Collabora) that don't sign callbacks, and throws on startup outside
+  Development. Not a security hole.
+
+## Intentionally-kept duplication
+
+- **`AzuriteFixture` / `PlaywrightFixture` duplication across test projects is accepted.** Sharing
+  would force heavier test dependencies (`Aspire.Hosting.Testing`) onto lighter projects; the
+  duplication is small and the consumers pin versions in lockstep. (Revisit only if it starts
+  drifting.)
+- **Sample `Program.cs` initialization overlap is accepted.** The only genuinely shared middleware
+  (`MapDefaultEndpoints`) already lives in `ServiceDefaults`; folding logging setup into
+  `AddServiceDefaults` would change logging for every consumer, including the Serilog backend and
+  test hosts.

--- a/.claude/skills/codebase-audit/scripts/mechanical-scan.sh
+++ b/.claude/skills/codebase-audit/scripts/mechanical-scan.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Mechanical smell scan for the codebase-audit skill.
+#
+# Prints file:line LEADS for the stable, deterministic smells — not findings. Every hit still has to
+# be read in context and verified before it earns a place in the audit report (some are intentional;
+# cross-check references/do-not-refile.md). Run from the repo root.
+#
+# Prefers ripgrep (rg); falls back to grep. Excludes build output and generated files.
+
+set -u
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" || exit 1
+
+# --- search helper: scan(<regex>) over hand-written C# (+ a couple of other globs per call) -------
+if command -v rg >/dev/null 2>&1; then
+  GLOBS=(-g '!**/artifacts/**' -g '!**/bin/**' -g '!**/obj/**' -g '!**/*.g.cs')
+  scan() { rg -n --no-heading "${GLOBS[@]}" "$@" 2>/dev/null; }
+else
+  scan() { # last arg is the path(s); flags before it
+    grep -rnE --include='*.cs' --exclude-dir={artifacts,bin,obj} "$@" 2>/dev/null | grep -v '\.g\.cs:'; }
+fi
+
+section() { printf '\n========== %s ==========\n' "$1"; }
+
+section "TODO / HACK / FIXME (tech debt — should be tracked or removed)"
+scan -t cs 'TODO|HACK|FIXME|XXX' src sample infra test 2>/dev/null || scan 'TODO|HACK|FIXME|XXX' src sample infra test
+
+section "#pragma warning disable (each needs an adjacent rationale comment)"
+scan -t cs 'pragma warning disable' src sample infra 2>/dev/null || scan 'pragma warning disable' src sample infra
+
+section "Provider DI lifetime — plain AddScoped/AddSingleton (want TryAdd*; watch lifetime drift)"
+scan -t cs 'services\.Add(Scoped|Singleton|Transient)<' src 2>/dev/null || scan 'services\.Add(Scoped|Singleton|Transient)<' src
+
+section "IConfiguration as a constructor param in src/ (prefer IOptions<T>)"
+scan -t cs 'IConfiguration[[:space:]]+[a-z]' src 2>/dev/null || scan 'IConfiguration[[:space:]]+[a-z]' src
+
+section "Broad catch (Exception) (filter async-rude exceptions; log structured detail)"
+scan -t cs 'catch \(Exception' src sample 2>/dev/null || scan 'catch \(Exception' src sample
+
+section "Sync-over-async (.Result / .Wait() / GetAwaiter().GetResult())"
+scan -t cs '\.Result\b|\.Wait\(\)|GetAwaiter\(\)\.GetResult' src sample infra 2>/dev/null || scan '\.Result\b|\.Wait\(\)|GetAwaiter\(\)\.GetResult' src sample infra
+
+section "Throwing parse on input — Enum.Parse (prefer Enum.TryParse for untrusted input)"
+scan -t cs 'Enum\.Parse' src sample 2>/dev/null || scan 'Enum\.Parse' src sample
+
+section "Wildcard postMessage origin in sample host pages (security)"
+if command -v rg >/dev/null 2>&1; then
+  rg -n --no-heading -g '!**/bin/**' -g '!**/obj/**' "postMessage\([^)]*['\"]\*['\"]" sample 2>/dev/null
+else
+  grep -rnE "postMessage\([^)]*['\"]\*['\"]" sample --exclude-dir={bin,obj} 2>/dev/null
+fi
+
+section "Direct ILogger.LogX calls (prefer source-generated [LoggerMessage])"
+scan -t cs '\.(LogInformation|LogWarning|LogError|LogDebug|LogTrace|LogCritical)\(' src 2>/dev/null || scan '\.(LogInformation|LogWarning|LogError|LogDebug|LogTrace|LogCritical)\(' src
+
+section "Block-scoped namespaces (prefer file-scoped: 'namespace X;')"
+scan -t cs '^namespace [A-Za-z0-9_.]+$' src sample infra test 2>/dev/null || scan '^namespace [A-Za-z0-9_.]+$' src sample infra test
+
+section "Header constants with a trailing space before the closing quote (wire-format bug)"
+scan -t cs '"[A-Za-z-]+ "' src 2>/dev/null || scan '"[A-Za-z-]+ "' src
+
+printf '\n--- end of mechanical scan. These are LEADS; verify each in source. ---\n'

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell scripts must keep LF endings so they run on Linux / CI regardless of the
+# committer's core.autocrlf setting.
+*.sh text eol=lf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,16 @@ dotnet run --project sample/WopiHost
 - Package validation baseline is `8.0.0` — avoid breaking public API changes in NuGet-packaged libraries. Bump in lockstep with releases (auto-bumped by `.github/workflows/release.yml` after each stable release). Packages without a prior release on NuGet.org opt out via `EnablePackageValidation=false` in their `.csproj`.
 - `InternalsVisibleTo` is auto-configured for `*.Tests` assemblies.
 
+## Codebase audit skill
+
+`.claude/skills/codebase-audit/` is the repo's standing health-check — a repeatable, multi-dimension
+code-quality / architecture / WOPI-spec-compliance audit modeled on the prior audit trackers. Invoke
+it (or just ask to "audit the codebase" / "find code smells") to sweep for duplication, leaky
+abstractions, architectural drift, non-idiomatic patterns, security/performance smells, tech debt,
+and spec non-compliance. It only reports **clear net wins** and respects a `do-not-re-file` ledger of
+verified-intentional decisions so repeat runs stay quiet. After a run, fold any newly-confirmed
+intentional decisions back into that ledger.
+
 ## Architecture
 
 This is a modular **WOPI protocol host** implementation that integrates custom data sources with Office Online Server / Microsoft 365 for the Web.


### PR DESCRIPTION
Adds `.claude/skills/codebase-audit/` — a repeatable, multi-dimension code-quality / architecture / WOPI-spec-compliance audit, distilled from the repo's prior audit trackers (#456, #457, #458, #359, #331, #369, #493, #511) so the codebase stays in top shape across many runs.

## What it does

Run it (or just ask to "audit the codebase" / "find code smells" / "tech-debt sweep"). It:
1. loads the **do-not-re-file ledger** + `CLAUDE.md` conventions + open issues/PRs first;
2. runs a cheap mechanical scan for deterministic leads, then **fans out parallel area scans** (Core/Abstractions, providers, Discovery/Url/Cobalt, samples, infra, tests), each covering all dimensions;
3. **spot-verifies in source** before anything is reported;
4. emits a tracker-ready report: severity (High/Med/Low) × dimension, `file:line` anchors, one-line remediation hints, a regenerated do-not-re-file section, and a tally.

## Two design choices that make it work repeatedly

- **Net-value bar.** A finding ships only if its fix makes the codebase *unambiguously better*. An explicit "do NOT flag" anti-list keeps it from recommending changes that would *worsen* the code — annotating instead of fixing, micro-optimizing cold paths, premature abstraction, code-moving extractions with no readability gain, consistency-for-its-own-sake, fighting intentional suppressions, churn-for-taste. The report leads with the highest-confidence clear wins.
- **Do-not-re-file ledger** (`references/do-not-refile.md`). Seeded with every verified-intentional decision from past audits + this session (the `CobaltSession.Result` guard, the UTF-7 pragma, `MemoryLockProvider` having no options class, `DefaultCheckFileInfoBuilder` scoped-by-design, accepted fixture duplication, …). Each run loads it, suppresses those, and regenerates it — so repeat runs stay quiet and the institutional memory compounds.

## Files

- `SKILL.md` — methodology, the net-value bar + anti-list, severity, report template.
- `references/dimensions.md` — the 10-dimension checklist, grounded in real past findings (so a run knows what "good" looks like *here*).
- `references/do-not-refile.md` — the seeded ledger.
- `scripts/mechanical-scan.sh` — deterministic leads (TODOs, `#pragma`, DI lifetime drift, `IConfiguration` ctor params, broad `catch`, wildcard `postMessage`, …). Smoke-tested.
- `CLAUDE.md` gains a pointer; `.gitattributes` pins `*.sh` to LF so the scripts stay Linux/CI-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)