### PR TITLE
Fix stale WopiFileSystemProvider id-scheme comment (base64 → SHA-256)

### DIFF
--- a/src/WopiHost.FileSystemProvider/WopiFileSystemProvider.cs
+++ b/src/WopiHost.FileSystemProvider/WopiFileSystemProvider.cs
@@ -8,7 +8,8 @@ using WopiHost.Abstractions;
 namespace WopiHost.FileSystemProvider;
 
 /// <summary>
-/// Provides files and folders based on a base64-encoded paths.
+/// Provides files and folders from a local directory tree, addressing each resource by a
+/// deterministic SHA-256 hash of its canonical path (see <see cref="InMemoryFileIds"/>).
 /// </summary>
 public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritableStorageProvider
 {


### PR DESCRIPTION
The `WopiFileSystemProvider` class summary still described ids as "base64-encoded paths"; they've been deterministic SHA-256 hashes of the canonical path since the `WopiResourceId` switch. One-line XML-doc correction, no behavior change. (Surfaced by the `codebase-audit` doc pass — #519.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)