### PR TITLE
ci: fix Claude review auth (Claude GitHub App + id-token)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -21,6 +21,7 @@ permissions:
   pull-requests: write
   issues: write
   actions: read
+  id-token: write # required: the Claude GitHub App fetches a GitHub OIDC token to authenticate
 
 jobs:
   approve:
@@ -48,10 +49,9 @@ jobs:
           # billing. Swap for `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}`
           # to bill the API instead.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Use the workflow's own token for GitHub API ops (posting the review). This
-          # skips the action's default OIDC -> Claude-GitHub-App token exchange, which
-          # would otherwise require `id-token: write` plus the app installed on the repo.
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # GitHub API auth (posting the review) is handled by the Claude GitHub App via
+          # the OIDC token (id-token: write above). The app must be installed on the repo:
+          # https://github.com/apps/claude
           # Informational: posts review comments, never fails the check.
           prompt: |
             Review this pull request against the conventions in CLAUDE.md.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -40,12 +40,18 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
+      # continue-on-error keeps this informational: a reviewer hiccup never fails the PR's checks.
       - uses: anthropics/claude-code-action@v1
+        continue-on-error: true
         with:
           # Pro/Max subscription token from `claude setup-token` — no per-use API
           # billing. Swap for `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}`
           # to bill the API instead.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Use the workflow's own token for GitHub API ops (posting the review). This
+          # skips the action's default OIDC -> Claude-GitHub-App token exchange, which
+          # would otherwise require `id-token: write` plus the app installed on the repo.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           # Informational: posts review comments, never fails the check.
           prompt: |
             Review this pull request against the conventions in CLAUDE.md.


### PR DESCRIPTION
## Summary

The Claude reviewer added in #486 failed on its first real run (PR #523):

```
error: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
Could not fetch an OIDC token. Did you remember to add `id-token: write`?
```

`claude-code-action` authenticates to the GitHub API through the **Claude GitHub App** using an OIDC token, which the workflow didn't permit.

## Fix (Claude GitHub App path)

- Add **`id-token: write`** to the job permissions so the action can fetch the GitHub OIDC token the app exchange needs.
- **`continue-on-error: true`** on the action step — keeps the reviewer *informational*: a hiccup never turns the PR's `review` check red or blocks a merge.

Model auth is unchanged (`CLAUDE_CODE_OAUTH_TOKEN`, your subscription). No `github_token` is passed — the app handles GitHub auth directly, so reviews post as the Claude app.

## ⚠️ Required before this works: install the Claude GitHub App

Install it on the repo (one-time): **https://github.com/apps/claude** → *Install/Configure* → select `petrsvihlik/WopiHost`. Without the app installed, the OIDC exchange has nothing to authenticate against.

## Verifying

`pull_request_target` runs the workflow from the **base branch**, so this takes effect once merged to `master`. Order: **install the app → merge this PR** → the first green review is on the next PR/push. (PR #523's `review` check stays red until then; it's informational and doesn't block.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
