### PR TITLE
audit skill: add .NET design-guidelines, security & library-hygiene vectors

### DIFF
--- a/.claude/skills/codebase-audit/SKILL.md
+++ b/.claude/skills/codebase-audit/SKILL.md
@@ -134,10 +134,16 @@ the whole codebase in one pass.
 See `references/dimensions.md` for the dimension checklist (WOPI spec compliance, leaky
 abstractions, architectural inconsistencies, duplication, refactoring, .NET/Minimal-API idiom,
 security, performance, tech debt, test-coverage gaps, documentation accuracy, **over-engineering /
-simplification**) — each with the concrete patterns earlier audits actually found, so a new run
-knows what "good" looks like here. Dimension 12 (over-engineering) is the subtractive counterpart to
-the rest: its findings *remove* complexity rather than add it, and it's where the typed-id-style
-"introduce a wrapper" instinct gets inverted into "delete the wrapper that earns nothing."
+simplification**, **public API & .NET design guidelines**, **library hygiene & runtime
+correctness**) — each with the concrete patterns earlier audits actually found, so a new run knows
+what "good" looks like here. Two dimensions have a distinct lens worth calling out:
+- **Dimension 12 (over-engineering)** is the subtractive counterpart to the rest: its findings
+  *remove* complexity, and it's where the typed-id-style "introduce a wrapper" instinct gets inverted
+  into "delete the wrapper that earns nothing."
+- **Dimension 13 (public API / .NET design guidelines)** measures the *packaged* libraries' public
+  surface against the [.NET Framework Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/),
+  since those 10 NuGet contracts can only be broken at a major bump — suppressed `CAxxxx` rules are
+  its prime leads.
 
 ## Severity
 

--- a/.claude/skills/codebase-audit/references/dimensions.md
+++ b/.claude/skills/codebase-audit/references/dimensions.md
@@ -99,6 +99,21 @@ These are "two things that should match but don't." The providers are the usual 
 - Broad `catch (Exception)` that swallows without filtering async-rude exceptions
   (OOM/SO/ThreadAbort) or without structured logging — especially in auth/proof validation.
 - A dev-only escape hatch (e.g. proof-validation disable) that isn't refused outside Development.
+- **Path traversal in the file-system provider (highest-severity class here).** A resource id or
+  relative/suggested target that resolves outside the configured root (`..`, absolute paths, UNC,
+  alternate data streams). Confirm the provider canonicalizes and re-roots (`Path.GetFullPath` +
+  `StartsWith(root)`) before any `File.*`/`Directory.*` call — a WOPI host acts on client-supplied
+  targets, so an unrooted path is arbitrary file read/write.
+- **Non-constant-time comparison of secrets.** `==` / `string.Equals` / `SequenceEqual` on a proof
+  signature, HMAC, access token, or lock id is a timing side-channel; crypto/auth comparisons use
+  `CryptographicOperations.FixedTimeEquals`.
+- **Secrets in logs / exceptions.** Access tokens, signing/proof keys, `Authorization` or
+  `X-WOPI-Proof` header values, or file contents passed to `ILogger` or an exception message. Redact.
+- **Weak randomness for security values.** `System.Random` (or `Guid.NewGuid()`) minting a token,
+  nonce, or anything that must be unguessable → `RandomNumberGenerator`.
+- **Token/JWT validation that doesn't validate.** `TokenValidationParameters` with
+  `ValidateIssuer`/`ValidateAudience`/`ValidateLifetime`/signature checks disabled, outside the one
+  documented dev no-op proof validator.
 
 ## 8. Performance (Medium/Low)
 
@@ -201,3 +216,58 @@ libraries it is not. Note the constraint in the finding rather than blindly reco
 Report each as: the construct, its `file:line`, why it earns nothing, and the subtractive remediation
 (`inline` / `collapse` / `delete` / `replace with literal`) — plus the removal-cost note if it's
 public API.
+
+## 13. Public API & .NET design guidelines (Medium/High on packaged libraries)
+
+This repo ships ~10 NuGet packages with a package-validation baseline, so the **public surface** of
+the `src/*` libraries is a contract. Hold it to the
+[.NET Framework Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/) —
+the rules the framework holds itself to. Scope this dimension to **public/protected** members of
+packaged libraries (`Abstractions`, `Core`, `Discovery`, `Url`, the providers, `Cobalt`); internal,
+sample, infra, and test code are held to a looser bar. Most items map to a `CAxxxx` analyzer rule, so
+a *suppressed* one (`<NoWarn>` / `#pragma warning disable CAxxxx` / `.editorconfig severity = none`)
+is a prime lead — open it and confirm the suppression is justified (some are; see the ledger).
+
+- **Naming.** PascalCase types/members; `I`-prefixed interfaces; async methods end in `Async`; no
+  abbreviations / Hungarian; types are nouns, methods verbs; enum names singular (flags plural).
+- **Collections & arrays on the surface.** Return `IReadOnlyList<T>` / `IEnumerable<T>`, not `List<T>`
+  or `T[]` (CA1819); accept the narrowest interface that works. (Accepted exception:
+  `WopiSecurityOptions.SigningKey` stays `byte[]` — see ledger.)
+- **Type design.** `struct` only for small, immutable value types with value semantics; `sealed` by
+  default unless inheritance is designed-for; abstract base vs interface chosen deliberately; no
+  public mutable static state.
+- **Member design.** Properties are cheap and side-effect-free (else a method); avoid `ref`/`out`
+  where a return value or a record/tuple is clearer; `CancellationToken` is the last parameter and
+  defaulted; favour overloads over ambiguous optional args on the public surface.
+- **Exceptions.** Throw the most specific type (`ArgumentNullException.ThrowIfNull`, `ArgumentException`,
+  `InvalidOperationException`) — never bare `Exception`/`ApplicationException`/`SystemException`;
+  preserve the stack with `throw;` not `throw ex;`.
+- **Over-exposed surface.** A `public` type/member with no external consumer that could be `internal`
+  — every public symbol is a maintenance + package-validation liability. (Lens overlaps dimension 12;
+  here the question is "should this be in the contract at all," not "is the abstraction earning its
+  keep.")
+- **Nullability matches behavior.** A public member annotated non-null that can return null (or the
+  reverse), or `!` null-forgiving used to paper over a real nullable on the contract.
+
+Report each as `path:line | guideline → why it matters on the public API → fix`, and flag whether the
+fix is itself a breaking change (package-validation baseline) so it can be timed with a major bump.
+
+## 14. Library hygiene & runtime correctness (Medium)
+
+Cross-cutting correctness for code that ships as a library and runs inside someone else's host.
+
+- **`ConfigureAwait(false)` in library code.** Every `await` in a packaged `src/*` library that
+  doesn't need the original sync context should use `ConfigureAwait(false)`, so a consumer that blocks
+  on the call can't deadlock. `AsyncExpiringLazy` already does this — new awaits should match. (Don't
+  flag sample/ASP.NET request paths, where the context is benign.)
+- **Disposal & stream leaks.** Internally-created `IDisposable`/`IAsyncDisposable` is wrapped in
+  `using`/`await using`; a stream opened then not disposed on an error path is a leak; the
+  caller-owns-disposal contract on `OpenReadAsync`/`OpenWriteAsync` is documented.
+- **Globalization / ordinal correctness.** Protocol strings (header names, `X-WOPI-Override` values,
+  ids, lock tokens) compare and case-fold with `StringComparison.Ordinal[IgnoreCase]` and
+  `ToUpperInvariant()` — never the current culture (`ToUpper()`, default `string.Equals`). A
+  culture-sensitive compare on a wire value is a latent bug (Turkish-I etc.).
+- **`async void`.** Only valid on event handlers; elsewhere it swallows exceptions and can crash the
+  host — make it `async Task`.
+- **`DateTimeOffset` for protocol time.** Lock expiry / WOPI timestamps use `DateTimeOffset` (the lock
+  providers already do); a bare `DateTime.Now`/`UtcNow` on an expiry or wire path is a smell.

--- a/.claude/skills/codebase-audit/references/do-not-refile.md
+++ b/.claude/skills/codebase-audit/references/do-not-refile.md
@@ -33,6 +33,11 @@ add it here with the reason. This ledger is what keeps repeat audits quiet and f
 - **`WopiSecurityOptions.SigningKey` stays `byte[]?` (CA1819 suppressed).** The `IConfiguration`
   `BinaryConverter` only targets `byte[]`, and `SymmetricSecurityKey(byte[])` consumes it directly.
   The suppression has a documented rationale next to the field.
+- **The committed `<NoWarn>` suppressions are intentional (dimension 13 lead, but justified).**
+  `CS1591` in the root `Directory.Build.props` silences missing-XML-doc warnings on non-packable
+  projects (samples/infra/tests don't ship docs); `xUnit1051` in `test/Directory.Build.props` is a
+  test-only analyzer relaxation. Both are documented inline. Don't file them as suppressed-rule
+  findings unless a *packaged* library starts carrying a broad `<NoWarn>`.
 - **Typed id/token value types (`WopiResourceId`, `WopiLockToken`) were considered and decided
   against.** Bare `string` resource ids and lock tokens are the intended state. The two design
   issues (#514, #515) were closed as *not planned*: the payoff is purely preventive (no known

--- a/.claude/skills/codebase-audit/scripts/mechanical-scan.sh
+++ b/.claude/skills/codebase-audit/scripts/mechanical-scan.sh
@@ -58,4 +58,26 @@ scan -t cs '^namespace [A-Za-z0-9_.]+$' src sample infra test 2>/dev/null || sca
 section "Header constants with a trailing space before the closing quote (wire-format bug)"
 scan -t cs '"[A-Za-z-]+ "' src 2>/dev/null || scan '"[A-Za-z-]+ "' src
 
+section "Culture-sensitive ToUpper()/ToLower() (protocol strings want *Invariant / Ordinal)"
+scan -t cs '\.To(Upper|Lower)\(\)' src 2>/dev/null || scan '\.To(Upper|Lower)\(\)' src
+
+section "async void (valid only on event handlers; elsewhere it swallows exceptions)"
+scan -t cs 'async void ' src sample infra 2>/dev/null || scan 'async void ' src sample infra
+
+section "Non-specific throw (prefer ArgumentException/InvalidOperationException over Exception)"
+scan -t cs 'throw new (Exception|ApplicationException|SystemException)\(' src sample 2>/dev/null || scan 'throw new (Exception|ApplicationException|SystemException)\(' src sample
+
+section "Rethrow that may lose the stack trace ('throw ex;' — use bare 'throw;')"
+scan -t cs 'throw [a-z][A-Za-z0-9_]*;' src sample 2>/dev/null || scan 'throw [a-z][A-Za-z0-9_]*;' src sample
+
+section "Weak RNG for security values (new Random — use RandomNumberGenerator for tokens/nonces)"
+scan -t cs 'new Random\(' src 2>/dev/null || scan 'new Random\(' src
+
+section "Suppressed analyzer rules (NoWarn / editorconfig severity=none — verify each is justified; leads for dim 13)"
+if command -v rg >/dev/null 2>&1; then
+  rg -n --no-heading -g '!**/artifacts/**' -g '!**/bin/**' -g '!**/obj/**' '<NoWarn>|severity[[:space:]]*=[[:space:]]*(none|silent)' src sample infra test Directory.Build.props Directory.Packages.props .editorconfig 2>/dev/null
+else
+  grep -rnE --exclude-dir={artifacts,bin,obj} '<NoWarn>|severity[[:space:]]*=[[:space:]]*(none|silent)' src sample infra test Directory.Build.props Directory.Packages.props .editorconfig 2>/dev/null
+fi
+
 printf '\n--- end of mechanical scan. These are LEADS; verify each in source. ---\n'


### PR DESCRIPTION
## Summary

Enriches the `codebase-audit` skill with the vectors it was missing, including the **.NET design-guidelines** check requested. The skill was strong on WOPI-spec, architecture, idiom, and the (recently added) over-engineering dimension, but had real gaps in public-API discipline, several high-severity security classes specific to a file-serving auth-bearing host, and library/runtime hygiene.

## What's added

**Dimension 13 — Public API & .NET design guidelines** *(the requested one)*
Holds the **packaged** libraries' public surface to the [.NET Framework Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/), since those ~10 NuGet contracts can only be broken at a major bump. Covers naming, collections/arrays on the surface (CA1819), type/member design, exceptions, over-exposed surface, and nullability-matches-behavior. Scoped to public/protected members of `src/*`; suppressed `CAxxxx` rules are its prime leads.

**Dimension 14 — Library hygiene & runtime correctness**
`ConfigureAwait(false)` in library code, disposal/stream leaks, globalization/ordinal correctness on protocol strings (Turkish-I class bugs), `async void`, and `DateTimeOffset` for protocol time.

**Sharpened Dimension 7 (Security)** with the high-severity classes that were absent for a host like this:
- **Path traversal** in the file-system provider (`..`/absolute/UNC resolving outside the root) — the single highest-severity class here.
- **Non-constant-time comparison** of proofs/HMACs/tokens (`CryptographicOperations.FixedTimeEquals`).
- **Secrets in logs/exceptions**, **weak RNG** for security values, and **JWT/token validation that doesn't actually validate**.

**`mechanical-scan.sh`** — new deterministic leads: culture-sensitive `ToUpper()/ToLower()`, `async void`, bare `throw new Exception`, stack-losing `throw ex;`, `new Random(`, and suppressed analyzer rules (`<NoWarn>` / `.editorconfig severity=none`).

**Ledger** — pre-records the two intentional `<NoWarn>`s (CS1591 non-packable, xUnit1051 test-only) so dimension 13 doesn't re-file them.

## Verification

Ran `mechanical-scan.sh` — the new sections execute cleanly, and the codebase is already clean on most of them (no `ToUpper()`, `async void`, `new Random(`, or bare `throw new Exception`), which is the point: the skill now *checks* those vectors. The only suppressed-rule leads are the two known-justified `NoWarn`s (now in the ledger).

## Note

These are `.md`/script skill files; opening a PR per your explicit request (the usual convention is to commit skill docs straight to master). Kept the additions to **clear, high-value vectors** — applying the skill's own "no bloat / net-wins only" bar to its own growth rather than padding the dimension list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
