### PR TITLE
codeql: fix path-traversal gap in file create + cut scan noise

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,14 @@
+name: WopiHost CodeQL config
+
+# Scope the scan to first-party source. The default scan produced ~85% noise from:
+#   - artifacts/** — generated build output (source generators: Regex/OpenApi, Razor, xunit entry
+#     points). Never hand-written, never shipped as source.
+#   - test/** — test-only nits (resource disposal in short-lived test procs, useless upcasts,
+#     broad catches in fixtures). Low value and not shipped.
+# Excluding them leaves the real signal in src/, sample/, and infra/.
+paths-ignore:
+  - 'artifacts/**'
+  - 'test/**'
+
+queries:
+  - uses: security-and-quality

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: csharp
-          queries: security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Restore dependencies
         run: dotnet restore WOPI.slnx

--- a/src/WopiHost.FileSystemProvider/WopiFileSystemProvider.cs
+++ b/src/WopiHost.FileSystemProvider/WopiFileSystemProvider.cs
@@ -293,6 +293,12 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(containerId);
+        // Reject names that aren't a single path segment (separators, '.', '..') before combining —
+        // the name is client-controlled (relative/suggested target), so this is the path-traversal guard.
+        if (!await CheckValidFileName(name, cancellationToken).ConfigureAwait(false))
+        {
+            throw new ArgumentException(message: "Invalid characters in the name.", paramName: nameof(name));
+        }
         var fullPath = ResolveContainerPath(containerId);
         var newPath = Path.Combine(fullPath, name);
         if (File.Exists(newPath))
@@ -316,6 +322,12 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(containerId);
+        // Reject names that aren't a single path segment (separators, '.', '..') before combining —
+        // the name is client-controlled, so this is the path-traversal guard.
+        if (!await CheckValidContainerName(name, cancellationToken).ConfigureAwait(false))
+        {
+            throw new ArgumentException(message: "Invalid characters in the name.", paramName: nameof(name));
+        }
         var fullPath = ResolveContainerPath(containerId);
         var newPath = Path.Combine(fullPath, name);
         var dirInfo = new DirectoryInfo(newPath);

--- a/test/WopiHost.FileSystemProvider.Tests/WopiFileSystemProviderTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/WopiFileSystemProviderTests.cs
@@ -546,6 +546,18 @@ public class WopiFileSystemProviderTests : IDisposable
             _sut.CreateWopiChildFile("missing", "x.txt"));
     }
 
+    [Theory]
+    [InlineData("../escape.txt")]
+    [InlineData("sub/escape.txt")]
+    [InlineData("..")]
+    public async Task CreateWopiChildResource_FileWithTraversalName_Throws(string name)
+    {
+        // The name is client-controlled (relative/suggested target); a name that isn't a single
+        // path segment must be rejected before Path.Combine so it can't escape the root.
+        var rootId = _sut.RootContainer.Identifier;
+        await Assert.ThrowsAsync<ArgumentException>(() => _sut.CreateWopiChildFile(rootId, name));
+    }
+
     [Fact]
     public async Task CreateWopiChildResource_Folder_CreatesAndReturnsFolder()
     {
@@ -570,6 +582,16 @@ public class WopiFileSystemProviderTests : IDisposable
     {
         await Assert.ThrowsAsync<DirectoryNotFoundException>(() =>
             _sut.CreateWopiChildContainer("missing", "x"));
+    }
+
+    [Theory]
+    [InlineData("../escape")]
+    [InlineData("sub/escape")]
+    [InlineData("..")]
+    public async Task CreateWopiChildResource_FolderWithTraversalName_Throws(string name)
+    {
+        var rootId = _sut.RootContainer.Identifier;
+        await Assert.ThrowsAsync<ArgumentException>(() => _sut.CreateWopiChildContainer(rootId, name));
     }
 
     // ---------- DeleteWopiFile / DeleteWopiContainer ----------


### PR DESCRIPTION
## Summary

Triages the CodeQL code-scanning alerts on `master` (205 open). Most were noise; one was a real security gap.

## The real fix — path traversal in the file-system provider
`cs/path-combine` flagged 14 `Path.Combine` calls in `WopiFileSystemProvider`. Reading them: the rename and suggested-name paths already validate the client-supplied name with `IsValidSingleSegmentName` (blocks path separators via `Path.GetInvalidFileNameChars()` and `.`/`..`), but **`CreateWopiChildFile` and `CreateWopiChildContainer` combined the name into a path without that check** — a path-traversal defense-in-depth gap (the name is a client-controlled relative/suggested target).

Fixed by validating up front in both methods (throws `ArgumentException` → the WOPI invalid-name error), and added cross-platform traversal-rejection tests (`/` and `..`, which are blocked on both Windows and the Linux CI). The other 12 `path-combine` flags are false positives (already-validated names, or internal id→path map lookups not used for direct FS access).

## The noise — CodeQL config
~85% of the alerts were generated build output (`artifacts/**` — Regex/OpenApi source generators, Razor, xunit entry points) and test-only nits (resource disposal in short-lived test procs, useless upcasts). Added `.github/codeql/codeql-config.yml` with `paths-ignore` for `artifacts/**` and `test/**`, wired into the workflow. That collapses ~179 of the 205 alerts.

## Verification
- Full solution builds clean; `WopiHost.FileSystemProvider.Tests` **138** (incl. 6 new traversal cases) and `WopiHost.IntegrationTests` **125** pass.

## Follow-up (separate, on master)
The residual `src/` alerts after this are all **false positives or style**, handled by dismissal (not code changes), each with a reason:
- `cs/log-forging` ×1 — structured logging (`BeginScope` + `[LoggerMessage]`), not string concatenation.
- `cs/constant-condition` ×2 — the inner check of a double-checked lock; CodeQL doesn't model the concurrent write.
- `cs/linq/missed-*` ×4 — subjective loop-vs-LINQ style.
- `cs/path-combine` (the 12 validated/internal ones).

> Note on `test/**` exclusion: it removes ~148 test-code alerts (mostly low-value). Adjustable if you'd rather scan tests too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
