### PR TITLE
codeql: drop dead paths-ignore (no-op for C#)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,14 +1,11 @@
 name: WopiHost CodeQL config
 
-# Scope the scan to first-party source. The default scan produced ~85% noise from:
-#   - artifacts/** — generated build output (source generators: Regex/OpenApi, Razor, xunit entry
-#     points). Never hand-written, never shipped as source.
-#   - test/** — test-only nits (resource disposal in short-lived test procs, useless upcasts,
-#     broad catches in fixtures). Low value and not shipped.
-# Excluding them leaves the real signal in src/, sample/, and infra/.
-paths-ignore:
-  - 'artifacts/**'
-  - 'test/**'
-
+# Enables the broader security-and-quality query suite (the default is security only).
+#
+# Note on noise from artifacts/** (generated source: Regex/OpenApi generators) and test/**:
+# `paths-ignore` does NOT work for compiled languages — CodeQL analyzes whatever the build
+# compiles and ignores location filters for C#/Java/Go/C++ (only JS/TS, Python, Ruby honor it).
+# Those non-shipping alerts are therefore handled by dismissing them in the Security tab
+# (durable across rescans), not by a path filter here.
 queries:
   - uses: security-and-quality


### PR DESCRIPTION
## What

`paths-ignore` in the CodeQL config file is a **no-op for compiled languages**. It only filters interpreted languages (JS/TS, Python, Ruby); for C# (and Java/Go/C++) CodeQL analyzes whatever the build compiles and ignores the SARIF location filter.

The `artifacts/**` + `test/**` entries added in #530 therefore never excluded anything — the master scan on the #530 merge still produced 205 results, with all 179 non-`src` alerts left open.

## What changed

- Removed the dead `paths-ignore` block.
- Kept the `security-and-quality` query suite (which *does* take effect).
- Documented the compiled-language constraint so this isn't re-attempted.

## How the noise was actually cleared

The 179 non-shipping alerts (148 test-only, 31 generated source-generator output under `artifacts/obj/`) were **dismissed** in the Security tab — `used in tests` and `won't fix` respectively. Dismissals persist across rescans, so they stay closed. Open alerts on master are now **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)