### PR TITLE
skill: add prepare-release (house-style notes + draft release)

### DIFF
--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: prepare-release
+description: >-
+  Turn the merged-PR changelog since the last release into polished, consolidated GitHub release
+  notes (Highlights, ✨ New, 🐛 Fixes, 🧹 Refactors, 🔧 Maintenance/CI/deps, 💥 Breaking changes,
+  and a verified Migration guide) modeled on this repo's prior releases, then open a **draft**
+  GitHub release for review. Use whenever the user wants to cut, prep, draft, or write notes for a
+  release. Trigger on phrasings like "prep a release", "prepare the 9.0.0 release", "cut a
+  release", "draft a release", "release X.Y.Z", "write release notes", or "generate the changelog
+  for the next version" — even when the version number isn't given.
+---
+
+# Prepare release
+
+Produces a release description in the house style and creates a **draft** GitHub release. The draft
+is the safety boundary: publishing a release fires `.github/workflows/release.yml`
+(`release: types: [published]`) which pushes packages to NuGet.org — so this skill **never
+publishes**. The user reviews the draft in the GitHub UI and clicks Publish themselves.
+
+Repo: `petrsvihlik/WopiHost`. Tags are bare semver (`8.0.0`, not `v8.0.0`); the release target is
+`master`.
+
+## Inputs
+
+- **New version** (required) — e.g. `9.0.0`. If the user didn't say it, ask. Pick the bump per
+  semver from the actual change surface: any public-API break → major; new back-compatible API →
+  minor; fixes only → patch. The repo is in API-stabilization, so breaking changes are expected
+  and land as majors.
+- **Previous tag** (auto) — the latest published release (`gh release list -L 1` /
+  `gh release view --json tagName`). Override only if the user names a different base.
+
+## Step 1 — Gather the raw changelog
+
+Let GitHub assemble the merged-PR list rather than hand-collecting it:
+
+```bash
+bash .claude/skills/prepare-release/scripts/gather-changelog.sh <NEW_VERSION> <PREV_TAG>
+```
+
+It calls the `releases/generate-notes` API (the same engine behind GitHub's "Generate release
+notes" button) and prints the raw `## What's Changed` list plus the `Full Changelog` compare link.
+If the tag doesn't exist yet, generate-notes targets `master` HEAD — which is what you want when
+prepping ahead of tagging. Keep that raw list; it's the input you transform, and the
+`Full Changelog` line is pasted verbatim at the very end of the notes.
+
+## Step 2 — Study the house format
+
+Read the most recent prior release as the canonical template — match its section order, heading
+style, table shape, and migration-guide depth:
+
+```bash
+gh release view <PREV_TAG> --repo petrsvihlik/WopiHost --json body -q .body
+```
+
+`references/format.md` distills that format and the consolidation/labeling rules. Read it before
+writing.
+
+## Step 3 — Categorize and consolidate
+
+Map every raw PR into one section, collapsing noise (see `references/format.md` for the full
+rules). In short:
+
+- **Highlights** — a 2–3 paragraph lede naming the release's theme (the one architectural headline
+  + the secondary themes), plus an upfront ⚠️ requirements/breaking call-out.
+- **✨ New** — user-visible features and new packages/capabilities.
+- **🐛 Fixes** — bug fixes and spec-correctness.
+- **🧹 Refactors & internals** — internal cleanups worth noting (cross-link anything that's also a
+  breaking change).
+- **🔧 Maintenance, CI & dependencies** — **consolidate hard**: collapse every Dependabot bump of
+  the same package into one `pkg X → Y` line spanning the whole range; group the re-applied /
+  baseline / framework-targeting chores. Don't list 30 individual bump PRs.
+- Group **related PRs that share an issue tracker** (e.g. several PRs all closing items of one
+  audit issue) into a single bullet citing all of them.
+- Drop pure-noise PRs (a bump later reverted/superseded within the same range) — but never silently
+  drop a real change.
+
+## Step 4 — Breaking changes + migration guide (verify against code)
+
+This is the part that must not be hallucinated. For each PR that changes public API, **read the
+actual change** before writing the migration step:
+
+- `gh pr view <N> --repo petrsvihlik/WopiHost --json title,body`
+- `gh pr diff <N> --repo petrsvihlik/WopiHost` (or read the current source — the renamed symbol,
+  the new signature, the new registration call).
+
+Then:
+
+- Build a **💥 Breaking changes** table: `| | Before (Nx) | After (N+1.0) | PR |`.
+- Write a numbered **Migration guide** with copy-pasteable ` ```diff ` before/after blocks for each
+  break (target framework, registration/wiring, renamed symbols, changed signatures, DI lifetime,
+  data/runtime breaks). Show the real old and new names/signatures, not invented ones.
+- A rename with unchanged values → say "recompile, not a behavior change".
+
+If there are no public-API breaks, omit both sections (a minor/patch release).
+
+## Step 5 — Assemble the notes
+
+Follow the skeleton in `references/format.md`. End with the verbatim `Full Changelog` compare link
+from Step 1. Write the whole thing to a file so it can feed `--notes-file` and be shown to the user:
+
+```
+artifacts/release-notes-<NEW_VERSION>.md
+```
+
+(`artifacts/` is git-ignored, so the file isn't committed.)
+
+## Step 6 — Create the draft release
+
+```bash
+gh release create <NEW_VERSION> \
+  --repo petrsvihlik/WopiHost \
+  --draft \
+  --target master \
+  --title "<NEW_VERSION>" \
+  --notes-file artifacts/release-notes-<NEW_VERSION>.md
+```
+
+`--draft` is mandatory — it creates the tag-less draft without firing the NuGet publish workflow.
+Print the resulting draft URL. Then show the user the full notes as a copy-pasteable fenced block
+(wrap in a 4-backtick ```` ```` ```` fence so the inner ` ```diff ` blocks survive) and tell them:
+review in the UI, edit if needed, and click **Publish** to tag + ship to NuGet.
+
+## Guardrails
+
+- **Never** run `gh release create` without `--draft`, and never `gh release edit --draft=false` /
+  publish. Tagging + publish is the user's call because it triggers NuGet push.
+- Don't invent PRs, issue numbers, or API shapes — every cited `#N` comes from the raw changelog or
+  a real `gh pr` lookup; every migration diff reflects code you actually read.
+- Keep prose in the repo's comment/voice style: concrete, third-person, no meta-narration.

--- a/.claude/skills/prepare-release/references/format.md
+++ b/.claude/skills/prepare-release/references/format.md
@@ -1,0 +1,85 @@
+# Release-notes format
+
+The canonical exemplar is the most recent prior release (`gh release view <PREV_TAG> --json body`).
+This file distills its structure and the rules for turning a raw merged-PR list into it.
+
+## Section skeleton
+
+```
+# <VERSION>
+
+## Highlights
+<2–3 short paragraphs: the one headline theme, then secondary themes. Last paragraph is an
+ ⚠️ requirements/breaking call-out (target framework, "see Migration guide below").>
+
+## ✨ New
+- **<feature>** ([#NN](pr-link)[, closes #II]) — one-line what + why it matters.
+
+## 🐛 Fixes
+- **<fix>** ([#NN](pr-link)) — what was wrong / what's correct now.
+
+## 🧹 Refactors & internals
+- **<change>** ([#NN](pr-link)) — note; cross-reference if also breaking.
+
+## 🔧 Maintenance, CI & dependencies
+- **<grouped chore>** (...).
+- **Dependency bumps** (consolidated): pkgA `x → y`, pkgB `x → y`, ...
+
+---
+
+## 💥 Breaking changes
+| | Before (Nx) | After (N+1.0) | PR |
+|---|---|---|---|
+| **<area>** | <old> | <new> | [#NN](pr-link) |
+
+---
+
+## Migration guide
+
+### 1. <break>
+<prose> +
+```diff
+- old
++ new
+```
+
+---
+
+**Full Changelog**: https://github.com/petrsvihlik/WopiHost/compare/<PREV_TAG>...<VERSION>
+```
+
+Omit 💥 + Migration guide entirely for a release with no public-API breaks.
+
+## Voice
+
+- Bold the subject of each bullet; keep to one or two lines.
+- Every bullet cites its PR(s) as `[#NN](https://github.com/petrsvihlik/WopiHost/pull/NN)`; cite the
+  closed issue too when it frames the work (`closes #II`).
+- Concrete and third-person — describe what the release does, not the work that went into it.
+- Emoji headers exactly as above (they're part of the house style).
+
+## Consolidation rules (the part that makes notes readable)
+
+1. **Dependabot bumps → one line per package, full range.** If `pkg` went `1.0 → 1.1 → 1.2 → 1.3`
+   across four PRs, write `pkg 1.0 → 1.3` once under Maintenance. Never enumerate the intermediate
+   bump PRs. Aspire's family of packages (`Aspire.Hosting.*`) collapses to a single
+   `Aspire.Hosting.* X → Y` entry.
+2. **Re-applied / superseded chores fold in.** "re-apply bumps Dependabot wrongly closed",
+   baseline reverts/bumps, and test-package consolidation are one or two Maintenance bullets, not
+   one each.
+3. **PRs sharing an issue tracker group together.** Several PRs that each close items of one audit
+   issue → a single bullet listing all of them and the issue.
+4. **A feature delivered across multiple PRs is one bullet.** e.g. an action wired in one PR and
+   fixed/hardened in two follow-ups → one bullet citing all three.
+5. **Drop within-range churn.** A bump added then reverted inside the same release window doesn't
+   appear. But a genuine change never disappears silently — if coverage is bounded, say so.
+6. **Classify by user impact, not by commit type prefix.** A `refactor(...)` PR that removes
+   `HttpContext` from a public seam is a *breaking change*, not a refactor footnote — surface it in
+   both places.
+
+## Migration guide must be verified
+
+Each migration step mirrors code actually read in Step 4 (`gh pr diff` or the current source):
+the real renamed symbol, the real new signature, the real new registration call. A `diff` block
+that doesn't compile against the shipped API is worse than no block. When a symbol was renamed but
+its value/behavior is unchanged, say so explicitly so consumers know it's a mechanical recompile.

--- a/.claude/skills/prepare-release/scripts/gather-changelog.sh
+++ b/.claude/skills/prepare-release/scripts/gather-changelog.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Print the raw merged-PR changelog for an upcoming release, using GitHub's own
+# release-notes generator (the engine behind the "Generate release notes" button).
+#
+# Usage: gather-changelog.sh <NEW_VERSION> [PREV_TAG]
+#   NEW_VERSION  tag to generate for, e.g. 9.0.0 (need not exist yet — then master HEAD is the target)
+#   PREV_TAG     base of the comparison; defaults to the latest published release
+#
+# Output: the raw "## What's Changed" list + the "Full Changelog" compare link, ready to be
+# transformed into house-style notes. This does NOT create a tag or a release.
+set -euo pipefail
+
+REPO="petrsvihlik/WopiHost"
+NEW_VERSION="${1:?usage: gather-changelog.sh <NEW_VERSION> [PREV_TAG]}"
+PREV_TAG="${2:-}"
+
+if [[ -z "$PREV_TAG" ]]; then
+  PREV_TAG="$(gh release view --repo "$REPO" --json tagName -q .tagName 2>/dev/null || true)"
+  if [[ -z "$PREV_TAG" ]]; then
+    echo "Could not determine the previous release tag; pass it explicitly." >&2
+    exit 1
+  fi
+fi
+
+echo "# Generating changelog: ${PREV_TAG} -> ${NEW_VERSION}" >&2
+
+gh api -X POST "repos/${REPO}/releases/generate-notes" \
+  -f tag_name="${NEW_VERSION}" \
+  -f previous_tag_name="${PREV_TAG}" \
+  -f target_commitish="master" \
+  -q .body


### PR DESCRIPTION
## What

Adds a `prepare-release` skill so cutting a release is a one-liner: *"prep the 10.0.0 release"* → Claude generates consolidated, house-style notes and opens a **draft** GitHub release for review.

## How it works

1. **Gather** — `scripts/gather-changelog.sh` calls the `releases/generate-notes` API (the engine behind GitHub's "Generate release notes" button) to get the raw merged-PR list + `Full Changelog` link for the upcoming tag, using the latest published release as the base.
2. **Study the format** — reads the most recent prior release as the canonical template.
3. **Categorize & consolidate** — maps every PR into `Highlights / ✨ New / 🐛 Fixes / 🧹 Refactors / 🔧 Maintenance`, collapsing Dependabot bumps to one line per package across the full range and grouping PRs that share an issue tracker.
4. **Verify breaking changes against code** — reads the actual `gh pr diff` / current source for each public-API break so the 💥 table and Migration-guide `diff` blocks reflect real symbols/signatures, not invented ones.
5. **Draft only** — `gh release create <ver> --draft`. Publishing fires `release.yml` (NuGet push), so tagging/publishing stays the maintainer's manual click. This is a hard guardrail in the skill.

## Files

- `.claude/skills/prepare-release/SKILL.md` — the workflow + guardrails.
- `.claude/skills/prepare-release/references/format.md` — section skeleton, voice, consolidation rules.
- `.claude/skills/prepare-release/scripts/gather-changelog.sh` — raw-changelog fetcher (verified against `8.0.0...9.0.0`).

Modeled on the existing `codebase-audit` skill's structure (SKILL.md + references/ + scripts/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)