### PR TITLE
docs: add security policy + security issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: 🔒 Report a security vulnerability privately
+    url: https://github.com/petrsvihlik/WopiHost/security/advisories/new
+    about: For sensitive or exploitable issues, report privately so details stay confidential until a fix ships.
   - name: 💬 GitHub Community Support
     url: https://github.com/petrsvihlik/WopiHost/discussions
     about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/security_report.yml
+++ b/.github/ISSUE_TEMPLATE/security_report.yml
@@ -1,0 +1,121 @@
+name: 🔒 Security Vulnerability
+description: Report a security vulnerability in WopiHost
+title: "[Security]: "
+labels: ["security"]
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## ⚠️ Read this first
+
+        **This is a public issue — anything you write here is visible to everyone.**
+
+        If the vulnerability is sensitive or exploitable, **do not file it here.** Report it
+        privately instead so the details stay between you and the maintainers until a fix ships:
+
+        👉 **[Report a vulnerability privately](https://github.com/petrsvihlik/WopiHost/security/advisories/new)**
+
+        Use this public template **only** for low-sensitivity issues, and keep the description
+        high-level — no weaponizable proof-of-concept. When in doubt, use the private channel.
+
+        See the [Security Policy](https://github.com/petrsvihlik/WopiHost/blob/master/SECURITY.md)
+        for details and what to expect after reporting.
+
+  - type: checkboxes
+    id: disclosure-ack
+    attributes:
+      label: Responsible disclosure
+      description: Please confirm before continuing.
+      options:
+        - label: I have read the Security Policy and confirm this report contains no sensitive exploit details that warrant private reporting.
+          required: true
+        - label: I am not aware of this issue being publicly disclosed or exploited elsewhere.
+          required: false
+
+  - type: input
+    id: affected-package
+    attributes:
+      label: Affected package(s)
+      description: Which WopiHost NuGet package(s) and version are affected?
+      placeholder: "e.g., WopiHost.Core 9.0.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Estimated severity
+      description: Your rough assessment (the maintainers will re-evaluate).
+      options:
+        - Low
+        - Medium
+        - High
+        - Critical
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A high-level description of the vulnerability and the affected component.
+      placeholder: "What is the weakness, and where is it?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: What can an attacker achieve? (e.g. unauthorized file access, token forgery, path traversal, DoS)
+      placeholder: "Who is affected and what is the worst-case outcome?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: How to reproduce (high-level)
+      description: |
+        Outline the conditions to trigger it. Keep it high-level here — if a detailed
+        proof-of-concept is required, please switch to private reporting.
+      placeholder: |
+        1. Configure the host with '...'
+        2. Send a WOPI request with '...'
+        3. Observe '...'
+    validations:
+      required: true
+
+  - type: textarea
+    id: affected-config
+    attributes:
+      label: Affected configuration
+      description: Anything that scopes the issue — provider in use, auth setup, proof validation on/off, OS, .NET version.
+      placeholder: "e.g., FileSystemProvider on Linux, proof validation enabled, .NET 10"
+    validations:
+      required: false
+
+  - type: textarea
+    id: suggested-fix
+    attributes:
+      label: Suggested fix or mitigation
+      description: If you have a fix or workaround in mind, describe it here.
+      placeholder: "Optional"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: contribution-intent
+    attributes:
+      label: Contribution intent
+      description: How would you like to help resolve this?
+      options:
+        - I'd like to submit a PR with a fix (coordinate privately first)
+        - I can help test a fix once available
+        - I can provide more details privately if needed
+        - I'm just reporting it
+    validations:
+      required: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+# Security Policy
+
+## Supported Versions
+
+WopiHost ships from a single `master` line, and only the **latest published release** receives
+security fixes. There are no maintained back-port branches — older majors are superseded as soon as
+a new one ships on NuGet.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest release (currently `9.x`) | :white_check_mark: |
+| Any earlier version | :x: |
+
+If you're on an older version, the fix is to upgrade to the latest release. Because the project is
+in its API-stabilization phase, a security fix may land in a new major — see the release notes and
+[migration guide](https://github.com/petrsvihlik/WopiHost/releases) for upgrade steps.
+
+## Reporting a Vulnerability
+
+Please **do not** post exploit details, proof-of-concept code, or anything that could be weaponized
+in a public channel before a fix is available.
+
+There are two ways to report, depending on sensitivity:
+
+1. **Sensitive / exploitable issues — report privately (recommended).**
+   Use GitHub's private vulnerability reporting:
+   **[Report a vulnerability](https://github.com/petrsvihlik/WopiHost/security/advisories/new)**
+   (Security → Advisories → *Report a vulnerability*). This keeps the details between you and the
+   maintainers until a fix and advisory are published, and lets us credit you in the advisory.
+
+2. **Low-sensitivity issues — open a security issue.**
+   Use the **🔒 Security Vulnerability** template at
+   [New issue](https://github.com/petrsvihlik/WopiHost/issues/new/choose). Keep the public
+   description high-level; if a detailed proof-of-concept is needed, prefer the private channel above.
+
+When in doubt, choose the private channel.
+
+### What to expect
+
+WopiHost is a volunteer-maintained open-source project, so timelines are best-effort rather than a
+contractual SLA:
+
+- **Acknowledgement** within ~7 days that the report was received.
+- **Initial assessment** (accepted / needs-more-info / declined, with reasoning) once the report
+  has been triaged.
+- **If accepted** — the maintainers work on a fix, cut a new release, and publish a
+  [GitHub Security Advisory](https://github.com/petrsvihlik/WopiHost/security/advisories) crediting
+  the reporter (unless you ask to stay anonymous). Coordinated disclosure is preferred: please hold
+  public details until the fixed release is out.
+- **If declined** — you'll get an explanation (e.g. out of scope, by-design, not reproducible, or
+  belongs to an upstream dependency).
+
+There is no bug-bounty program. Reports about third-party dependencies are forwarded upstream where
+possible, but the upstream project owns the fix.


### PR DESCRIPTION
## What

Satisfies the GitHub community-standards **Security policy** check and gives reporters a clear, sensible path.

## Files

- **`SECURITY.md`** —
  - **Supported versions:** only the **latest release** (currently `9.x`) is supported; older versions are superseded on each release (no back-port branches). Phrased to stay true across releases.
  - **Reporting:** two channels — **private GitHub advisory reporting** (recommended for sensitive/exploitable issues) and a **public security issue template** for low-sensitivity reports kept high-level.
  - **Expectations:** best-effort volunteer timelines (~7-day ack), accept/decline flow, advisory + reporter credit, no bounty.
- **`.github/ISSUE_TEMPLATE/security_report.yml`** — 🔒 Forms-style template matching the existing bug/feature templates. Leads with a "this is public — use private reporting for sensitive issues" warning, a disclosure-ack checkbox, and high-level impact/repro fields. Labels issues `security`.
- **`.github/ISSUE_TEMPLATE/config.yml`** — adds a *"Report a security vulnerability privately"* link to the issue chooser, pointing at the advisory form.

## Notes

- **Private Vulnerability Reporting is already enabled** on the repo, so the private link/button is live.
- The **`security` label was created** (`#D93F0B`) so the template applies it.
- Honest call-out: routing security reports through public issues discloses them before a fix exists — hence private advisory reporting is positioned as the recommended primary channel, with the public template as a high-level fallback. Drop the private bits if you'd rather keep it issues-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)