### PR TITLE
ci: three read-only agentic workflows (triage, CI-diagnosis, docs-drift)

### DIFF
--- a/.github/workflows/ci-failure-diagnosis.yml
+++ b/.github/workflows/ci-failure-diagnosis.yml
@@ -1,0 +1,55 @@
+name: CI Failure Diagnosis
+
+# When the main CI workflows fail, read the failed logs and post ONE concise root-cause comment on
+# the associated PR (the "why did CI go red" dig, done for you). Read-only; comments only.
+#
+# Uses workflow_run rather than a step inside each CI workflow: workflow_run runs in the base-repo
+# context with access to secrets even when the failing run came from a fork PR, so it can comment on
+# fork PRs safely — the one trigger where that works (unlike pull_request).
+
+on:
+  workflow_run:
+    workflows: ["Build & Test", "E2E (Collabora)"]
+    types: [completed]
+
+jobs:
+  diagnose:
+    if: github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read         # read the failed run's logs
+      pull-requests: write  # comment on the associated PR
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Diagnose the failure
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          claude_args: '--allowed-tools "Bash,Read,Grep,Glob"'
+          prompt: |
+            The CI run "${{ github.event.workflow_run.name }}" failed on ${{ github.repository }}
+            (run id ${{ github.event.workflow_run.id }}, head sha
+            ${{ github.event.workflow_run.head_sha }}, branch
+            ${{ github.event.workflow_run.head_branch }}).
+
+            1. Fetch the failed logs: `gh run view ${{ github.event.workflow_run.id }} --log-failed`.
+            2. Identify the single most likely root cause — the specific failing step / test / error.
+            3. Find where to report: locate a PR for head sha ${{ github.event.workflow_run.head_sha }}
+               (`gh pr list --search "${{ github.event.workflow_run.head_sha }}" --state open`, or by
+               head branch). If one exists, comment on it. If none (e.g. a direct push to master),
+               do NOTHING — do not open an issue.
+            4. Post ONE concise comment: the failing step/test, the key error line(s), and the first
+               thing to check or the likely fix.
+
+            Hard constraints: read-only on code; at most ONE PR comment; no code changes, branches, or
+            issues. If it looks flaky/transient, say so in one line. If you can't pin a cause, say what
+            you ruled out rather than guessing.

--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -1,0 +1,53 @@
+name: Docs Drift Check
+
+# On PRs that touch the public API or READMEs, run a focused documentation-accuracy pass (dimension
+# 11 of the codebase-audit skill, single-dimension mode) and comment if any doc/wiki reference went
+# stale — catching the class of bug where a rename or a changed port leaves the docs lying. Read-only.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'src/**/*.cs'
+      - '**/README.md'
+
+jobs:
+  docs-drift:
+    # Internal PRs only — the OIDC token exchange doesn't work in the secret-less fork context
+    # (same constraint as claude-code-review.yml).
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0   # need the merge-base to diff the PR
+
+      - name: Check for documentation drift
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--allowed-tools "Bash,Read,Grep,Glob"'
+          prompt: |
+            Run a focused DOCUMENTATION-DRIFT check on PR #${{ github.event.pull_request.number }}
+            in ${{ github.repository }} — dimension 11 of the codebase-audit skill, single-dimension
+            mode.
+
+            Read .claude/skills/codebase-audit/references/continuous.md and the dimension-11 section
+            of references/dimensions.md first, then:
+            1. `gh pr diff ${{ github.event.pull_request.number }}` — collect every public
+               type/member/namespace/config-key/port/path that this PR renamed, removed, or changed.
+            2. For each, grep the in-repo READMEs AND the wiki (clone it read-only via
+               scripts/fetch-wiki.sh) for now-stale references.
+            3. If anything is stale, post ONE concise PR comment listing each
+               `doc:line → what's now wrong → corrected value`. If a wiki page is affected, note that
+               the wiki is a separate repo the maintainer must update by hand (this job can't).
+            4. Nothing stale → post nothing. Clean is the default.
+
+            Hard constraints: read-only; at most ONE comment; no code changes. Apply the audit skill's
+            net-win bar — only flag genuinely stale or misleading docs, never style nits.

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,46 @@
+name: Issue Triage
+
+# Pre-triages every newly opened human issue: applies labels from the existing set and flags likely
+# duplicates / missing repro info — at most one comment, never closing or assigning. Read-only on
+# code. The @claude handler (claude.yml) is gated behind an @claude mention, so it does not overlap.
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    # Humans only — don't triage bot-filed issues.
+    if: github.event.issue.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Triage the issue
+        continue-on-error: true   # a triage hiccup must never block anything
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--allowed-tools "Bash,Read,Grep,Glob"'
+          prompt: |
+            Triage issue #${{ github.event.issue.number }} in ${{ github.repository }}, then stop.
+
+            1. Read it: `gh issue view ${{ github.event.issue.number }}`.
+            2. Apply labels with `gh issue edit` using ONLY labels that already exist
+               (`gh label list`) — pick the few that fit (e.g. bug, enhancement, question,
+               documentation, security, dependencies, ci, devops). Never invent a label.
+            3. Duplicate check: `gh issue list --state all --search "<key terms>"`. On a strong
+               match, post ONE short comment linking the probable duplicate(s) and asking the author
+               to confirm. No match → post nothing.
+            4. If a bug report is missing must-have info (repro steps, version, affected package),
+               post ONE short, friendly comment asking only for what's missing.
+
+            Hard constraints: at most ONE comment total; concise and polite; never close, assign, or
+            edit the issue body. A well-formed, clearly-labelled issue → apply labels and post nothing.


### PR DESCRIPTION
Implements the high-signal, read-only subset of the agentic-workflow menu in #537 — all on the **existing `claude-code-action` integration** (no `gh-aw` needed). See the [feasibility + decision comment](https://github.com/petrsvihlik/WopiHost/issues/537#issuecomment-4636598117) on the issue.

## What's added

| Workflow | Trigger | Behaviour |
|---|---|---|
| **`issue-triage.yml`** | `issues: opened` (humans only) | Labels from the existing set, flags likely duplicates / missing repro. ≤1 comment; never closes/assigns/edits. |
| **`ci-failure-diagnosis.yml`** | `workflow_run: failure` of *Build & Test* / *E2E (Collabora)* | Reads the failed logs, comments the root cause on the associated PR. Nothing on a master push. |
| **`docs-drift.yml`** | `pull_request` touching `src/**/*.cs` or `**/README.md` (internal PRs) | Runs the audit skill's documentation dimension (single-dimension mode) and comments on any stale doc/wiki reference — the `:5000`→`:5050` class, caught at PR time. |

All three: **read-only on code**, **≤1 comment**, `continue-on-error` so a hiccup never blocks a PR/CI.

## Design notes

- **`workflow_run` for CI diagnosis** runs in the base-repo context with secrets even for fork PRs — the one trigger that can comment on fork PRs safely (`pull_request` can't, per `claude-code-review.yml`).
- **`docs-drift` is internal-PRs-only** — same fork OIDC limitation as the existing review workflow.
- **No overlap with `claude.yml`** — that handler is gated behind an `@claude` mention, so triage-on-open doesn't double-fire.

## Declined (decided in the issue, not dropped)

#1 PR-time general audit (redundant with the review + monthly audit) · #5 test-coverage filler (proactive/write-scoped; coverage already 97.7%; the case where `gh-aw` safe-outputs would matter) · #6 dependency monitor (covered by Dependabot + CodeQL + native scanning) · #7 meta-agent (premature).

Closes #537.

🤖 Generated with [Claude Code](https://claude.com/claude-code)