### PR TITLE
web: postMessage action bar + core: GetShareUrl (files/containers)

### DIFF
--- a/sample/WopiHost.Web/Components/Layout/WopiLayout.razor
+++ b/sample/WopiHost.Web/Components/Layout/WopiLayout.razor
@@ -143,12 +143,28 @@
         }
 
         #wopi_share .card button {
-            padding: 8px 12px;
-            border: 1px solid #ccc;
+            padding: 8px 14px;
+            border: 1px solid #b0b0b0;
             border-radius: 6px;
-            background: #f3f3f3;
+            background: #e8e8e8;
+            color: #1f1f1f;
             cursor: pointer;
             font: inherit;
+        }
+
+        #wopi_share .card button:hover {
+            background: #dadada;
+        }
+
+        /* Primary affordance — readable on its own colour rather than inheriting white. */
+        #wopi_share_copy {
+            background: #0b5cad;
+            border-color: #0b5cad;
+            color: #fff;
+        }
+
+        #wopi_share_copy:hover {
+            background: #094a8c;
         }
 
         #wopi_share .close {
@@ -257,6 +273,14 @@
                     : {});
             });
         });
+
+        // Save only makes sense in edit mode. The host-page URL carries the WOPI action; a view
+        // link strips UserCanWrite from the token, so hide Save rather than offer a no-op.
+        var wopiAction = (new URLSearchParams(window.location.search).get('wopiaction') || 'view').toLowerCase();
+        if (wopiAction === 'view') {
+            var saveBtn = document.querySelector('#wopi_bar button[data-action="Action_Save"]');
+            if (saveBtn) { saveBtn.remove(); }
+        }
 
         // Collabora stays silent until the host announces readiness; Office for the Web also keys
         // its postMessage stream off this. Sent on the editor frame's load, with a fallback timer

--- a/sample/WopiHost.Web/Components/Layout/WopiLayout.razor
+++ b/sample/WopiHost.Web/Components/Layout/WopiLayout.razor
@@ -1,9 +1,12 @@
 @inherits LayoutComponentBase
 @inject IOptions<WopiOptions> WopiOptions
 
-@* Full-bleed iframe layout for the WOPI editor. The "Files" pill on top-left lets the user
-   navigate back; the postMessage handshake gives the WOPI client a chance to flush pending
-   saves before the host navigates away. *@
+@* Editor layout: a thin top action bar driving the WOPI host-page postMessage API, with the
+   editor iframe filling the space below it. The bar issues host->editor commands (Save / Print /
+   Close) and the script reacts to editor->host notifications (load status, modified flag, save
+   result, the editor's own Share/Close UI). See
+   https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/online/scenarios/postmessage
+   and Collabora's https://sdk.collaboraonline.com/docs/postmessage_api.html. *@
 
 <HeadContent>
     <meta http-equiv="x-ua-compatible" content="ie=edge">
@@ -17,57 +20,195 @@
             -ms-content-zooming: none;
         }
 
-        /* Floating "back to files" pill, top-left over the editor.
-           Avoid eating editor real estate via a thin top bar. */
-        #wopi_back {
+        #wopi_bar {
             position: fixed;
-            top: 8px;
-            left: 8px;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 40px;
             z-index: 2147483647;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 8px;
+            padding: 0 10px;
+            box-sizing: border-box;
+            background: #1f1f1f;
+            color: #fff;
+            font: 13px/1 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        }
+
+        #wopi_bar .group {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        #wopi_bar button {
             display: inline-flex;
             align-items: center;
             gap: 6px;
             padding: 6px 12px;
-            font: 13px/1 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            font: inherit;
             color: #fff;
-            background: rgba(0, 0, 0, 0.55);
-            border: 0;
-            border-radius: 999px;
+            background: transparent;
+            border: 1px solid transparent;
+            border-radius: 6px;
             cursor: pointer;
-            text-decoration: none;
-            backdrop-filter: blur(4px);
-            -webkit-backdrop-filter: blur(4px);
         }
 
-        #wopi_back:hover {
-            background: rgba(0, 0, 0, 0.75);
+        #wopi_bar button:hover:not(:disabled) {
+            background: rgba(255, 255, 255, 0.14);
         }
 
+        #wopi_bar button:disabled {
+            opacity: 0.4;
+            cursor: default;
+        }
+
+        #wopi_bar .sep {
+            width: 1px;
+            height: 20px;
+            background: rgba(255, 255, 255, 0.2);
+            margin: 0 4px;
+        }
+
+        #wopi_status {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            color: rgba(255, 255, 255, 0.8);
+            white-space: nowrap;
+        }
+
+        #wopi_modified {
+            font-size: 16px;
+            line-height: 1;
+        }
+
+        /* Editor frame fills everything below the bar. */
         #office_frame {
-            width: 100%;
-            height: 100%;
             position: absolute;
-            top: 0;
+            top: 40px;
             left: 0;
             right: 0;
             bottom: 0;
+            width: 100%;
+            height: calc(100% - 40px);
             margin: 0;
             border: none;
             display: block;
         }
+
+        #wopi_share {
+            position: fixed;
+            inset: 0;
+            z-index: 2147483647;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            background: rgba(0, 0, 0, 0.45);
+        }
+
+        #wopi_share[data-open="1"] {
+            display: flex;
+        }
+
+        #wopi_share .card {
+            background: #fff;
+            color: #1f1f1f;
+            width: min(440px, calc(100vw - 32px));
+            padding: 20px;
+            border-radius: 10px;
+            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+            font: 14px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        }
+
+        #wopi_share h2 {
+            margin: 0 0 12px;
+            font-size: 16px;
+        }
+
+        #wopi_share .row {
+            display: flex;
+            gap: 8px;
+        }
+
+        #wopi_share input {
+            flex: 1;
+            padding: 8px;
+            border: 1px solid #ccc;
+            border-radius: 6px;
+            font: inherit;
+        }
+
+        #wopi_share .card button {
+            padding: 8px 12px;
+            border: 1px solid #ccc;
+            border-radius: 6px;
+            background: #f3f3f3;
+            cursor: pointer;
+            font: inherit;
+        }
+
+        #wopi_share .close {
+            margin-top: 14px;
+            text-align: right;
+        }
     </style>
 </HeadContent>
 
-<button id="wopi_back" type="button" title="Close editor and return to files">← Files</button>
+<div id="wopi_bar" role="toolbar" aria-label="Document actions">
+    <div class="group">
+        <button id="wopi_files" type="button" title="Close editor and return to files">← Files</button>
+        <span class="sep"></span>
+        <button data-action="Action_Save" type="button" title="Save the document">💾 Save</button>
+        <button data-action="Action_Print" type="button" title="Print the document">🖨 Print</button>
+        <button id="wopi_share_btn" type="button" title="Share a link to this document">🔗 Share</button>
+        <button id="wopi_close" type="button" title="Close the document">✕ Close</button>
+    </div>
+    <div id="wopi_status">
+        <span id="wopi_modified" title="Unsaved changes" hidden>●</span>
+        <span id="wopi_statustext">Loading…</span>
+    </div>
+</div>
+
+<div id="wopi_share" role="dialog" aria-modal="true" aria-label="Share document">
+    <div class="card">
+        <h2>Share this document</h2>
+        <div class="row">
+            <input id="wopi_share_url" type="text" readonly aria-label="Shareable link" />
+            <button id="wopi_share_copy" type="button">Copy</button>
+        </div>
+        <div class="close">
+            <button id="wopi_share_dismiss" type="button">Close</button>
+        </div>
+    </div>
+</div>
 
 @Body
 
 <script type="text/javascript">
-    // Close handshake: Office for the Web / Collabora honour the WOPI postMessage
-    // "Action_Close" so they can flush pending saves before the host navigates away.
+    // Host-page side of the WOPI postMessage API. The host posts host->editor commands to the
+    // editor frame and reacts to editor->host notifications. Outgoing and incoming messages are
+    // both scoped to the WOPI client's origin so a stray frame can't drive or observe the host.
     (function () {
-        var btn = document.getElementById('wopi_back');
-        if (!btn) return;
+        var wopiClientOrigin = '@WopiOptions.Value.ClientUrl.GetLeftPart(System.UriPartial.Authority)';
+
+        function frame() { return document.getElementById('office_frame'); }
+
+        function post(messageId, values) {
+            var f = frame();
+            if (!f || !f.contentWindow) return;
+            f.contentWindow.postMessage(
+                JSON.stringify({ MessageId: messageId, SendTime: Date.now(), Values: values || {} }),
+                wopiClientOrigin);
+        }
+
+        var statusEl = document.getElementById('wopi_statustext');
+        var modifiedEl = document.getElementById('wopi_modified');
+        function setStatus(text) { if (statusEl) statusEl.textContent = text; }
+        function setModified(on) { if (modifiedEl) modifiedEl.hidden = !on; }
 
         var navigated = false;
         function goHome() {
@@ -76,34 +217,88 @@
             window.location.href = '/';
         }
 
-        // Restrict postMessage to the WOPI client's origin so the Action_Close payload is
-        // never delivered to a different document if the iframe ever navigates elsewhere.
-        var wopiClientOrigin = '@WopiOptions.Value.ClientUrl.GetLeftPart(System.UriPartial.Authority)';
+        // Close handshake: post Action_Close so the editor flushes pending saves, then navigate.
+        function requestClose() {
+            post('Action_Close', {});
+            setTimeout(goHome, 600);
+        }
 
-        btn.addEventListener('click', function () {
-            try {
-                var frame = document.getElementById('office_frame');
-                if (frame && frame.contentWindow) {
-                    frame.contentWindow.postMessage(
-                        JSON.stringify({ MessageId: 'Action_Close', SendTime: Date.now(), Values: {} }),
-                        wopiClientOrigin
-                    );
-                    // Give the client ~600ms to acknowledge / flush, then navigate.
-                    setTimeout(goHome, 600);
-                    return;
-                }
-            } catch (e) { /* fall through */ }
-            goHome();
+        // Share UI is host-owned: the editor's Share button (UI_Sharing) and the bar's Share
+        // button both open the host's own dialog. A production host would mint a real link here
+        // (e.g. via the WOPI GetShareUrl operation); the sample shares the current document URL.
+        var shareOverlay = document.getElementById('wopi_share');
+        function openShare() {
+            var input = document.getElementById('wopi_share_url');
+            if (input) input.value = window.location.href;
+            if (shareOverlay) shareOverlay.setAttribute('data-open', '1');
+        }
+        function closeShare() { if (shareOverlay) shareOverlay.removeAttribute('data-open'); }
+
+        // --- Bar wiring ---
+        document.getElementById('wopi_files').addEventListener('click', requestClose);
+        document.getElementById('wopi_close').addEventListener('click', requestClose);
+        document.getElementById('wopi_share_btn').addEventListener('click', openShare);
+        document.getElementById('wopi_share_dismiss').addEventListener('click', closeShare);
+        shareOverlay.addEventListener('click', function (e) {
+            if (e.target === shareOverlay) closeShare();
+        });
+        document.getElementById('wopi_share_copy').addEventListener('click', function () {
+            var input = document.getElementById('wopi_share_url');
+            if (!input) return;
+            input.select();
+            if (navigator.clipboard) { navigator.clipboard.writeText(input.value).catch(function () { }); }
+            else { document.execCommand('copy'); }
+        });
+        Array.prototype.forEach.call(document.querySelectorAll('#wopi_bar button[data-action]'), function (btn) {
+            btn.addEventListener('click', function () {
+                var action = btn.getAttribute('data-action');
+                post(action, action === 'Action_Save'
+                    ? { Notify: true, DontTerminateEdit: true, DontSaveIfUnmodified: true }
+                    : {});
+            });
         });
 
-        // Optional: if the client posts UI_Close back, treat it as confirmation.
+        // Collabora stays silent until the host announces readiness; Office for the Web also keys
+        // its postMessage stream off this. Sent on the editor frame's load, with a fallback timer
+        // in case the frame finished loading before this script attached its handler.
+        function announceReady() { post('Host_PostmessageReady', {}); }
+        (function wireReady() {
+            var f = frame();
+            if (!f) { setTimeout(wireReady, 100); return; }
+            f.addEventListener('load', announceReady);
+            setTimeout(announceReady, 1500);
+        })();
+
+        // --- editor -> host notifications ---
         window.addEventListener('message', function (e) {
-            try {
-                var msg = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
-                if (msg && (msg.MessageId === 'UI_Close' || msg.MessageId === 'Action_Close_Resp')) {
+            if (e.origin !== wopiClientOrigin) return;
+            var msg;
+            try { msg = typeof e.data === 'string' ? JSON.parse(e.data) : e.data; }
+            catch (_) { return; }
+            if (!msg || !msg.MessageId) return;
+            var v = msg.Values || {};
+
+            switch (msg.MessageId) {
+                case 'App_LoadingStatus':
+                    if (v.Status === 'Document_Loaded' || v.Status === 'Frame_Ready') setStatus('Ready');
+                    break;
+                case 'Doc_ModifiedStatus':       // Collabora
+                case 'Document_Modified':        // Office for the Web
+                    setModified(!!v.Modified);
+                    if (v.Modified) setStatus('Unsaved changes');
+                    break;
+                case 'Action_Save_Resp':
+                    setModified(false);
+                    setStatus('Saved');
+                    break;
+                case 'UI_Sharing':
+                    openShare();
+                    break;
+                case 'UI_Close':
+                case 'Action_Close_Resp':
                     goHome();
-                }
-            } catch (_) { /* ignore non-JSON messages from the iframe */ }
+                    break;
+            }
         });
     })();
 </script>

--- a/src/WopiHost.Abstractions/WopiCheckContainerInfo.cs
+++ b/src/WopiHost.Abstractions/WopiCheckContainerInfo.cs
@@ -63,5 +63,13 @@ public class WopiCheckContainerInfo
     /// </summary>
     public bool UserCanRename { get; set; }
 
+    /// <summary>
+    /// The Share URL types the host supports for this container. These values can be passed in the
+    /// X-WOPI-UrlType request header to the
+    /// <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/containers/getshareurl">GetShareUrl (containers)</see>
+    /// operation. Mirrors <c>SupportedShareUrlTypes</c> on CheckFileInfo.
+    /// </summary>
+    public IEnumerable<string> SupportedShareUrlTypes { get; set; } = [];
+
     #endregion
 }

--- a/src/WopiHost.Abstractions/WopiContainerOperations.cs
+++ b/src/WopiHost.Abstractions/WopiContainerOperations.cs
@@ -24,4 +24,9 @@ public static class WopiContainerOperations
     /// https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/containers/renamecontainer
     /// </summary>
     public const string RenameContainer = "RENAME_CONTAINER";
+
+    /// <summary>
+    /// https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/containers/getshareurl
+    /// </summary>
+    public const string GetShareUrl = "GET_SHARE_URL";
 }

--- a/src/WopiHost.Abstractions/WopiFileOperations.cs
+++ b/src/WopiHost.Abstractions/WopiFileOperations.cs
@@ -54,4 +54,9 @@ public static class WopiFileOperations
     /// Cobalt file operations
     /// </summary>
     public const string Cobalt = "COBALT";
+
+    /// <summary>
+    /// https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/getshareurl
+    /// </summary>
+    public const string GetShareUrl = "GET_SHARE_URL";
 }

--- a/src/WopiHost.Abstractions/WopiShareUrlTypes.cs
+++ b/src/WopiHost.Abstractions/WopiShareUrlTypes.cs
@@ -1,0 +1,19 @@
+namespace WopiHost.Abstractions;
+
+/// <summary>
+/// The Share URL types a host can advertise in <c>SupportedShareUrlTypes</c> and that a WOPI client
+/// passes in the <c>X-WOPI-UrlType</c> request header on the
+/// <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/getshareurl">GetShareUrl</see>
+/// operation.
+/// </summary>
+public static class WopiShareUrlTypes
+{
+    /// <summary>A read-only link to the resource.</summary>
+    public const string ReadOnly = "ReadOnly";
+
+    /// <summary>A read-write link to the resource.</summary>
+    public const string ReadWrite = "ReadWrite";
+
+    /// <summary>The full set the default host implementation can produce.</summary>
+    public static readonly string[] All = [ReadOnly, ReadWrite];
+}

--- a/src/WopiHost.Core/Endpoints/ContainerMutatingEndpoints.cs
+++ b/src/WopiHost.Core/Endpoints/ContainerMutatingEndpoints.cs
@@ -73,6 +73,30 @@ internal static class ContainerMutatingEndpoints
             .WithDescription("Spec: https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/containers/renamecontainer. " +
                 "Returns the new name on success; 400 with X-WOPI-InvalidContainerNameError on invalid input.")
             .RequireWopiPermission(WopiResourceType.Container, Permission.Rename);
+
+        // GetShareUrl is read-level — registered on the parent group, not the writable-gated one.
+        containers.MapPost("/{id}", GetShareUrl)
+            .WithMetadata(new WopiOverrideMetadata(WopiContainerOperations.GetShareUrl))
+            .WithSummary("GetShareUrl (X-WOPI-Override: GET_SHARE_URL).")
+            .WithDescription("Spec: https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/containers/getshareurl. " +
+                "Returns 501 when the requested X-WOPI-UrlType is unsupported.")
+            .RequireWopiPermission(WopiResourceType.Container, Permission.Read);
+    }
+
+    // Spec: returns { "ShareUrl": "..." } for a supported X-WOPI-UrlType, else 501. Mirrors the
+    // file-side GetShareUrl and reuses its share-link builder.
+    private static async Task<Results<NotFound, JsonHttpResult<ShareUrlResponse>, StatusCodeHttpResult>> GetShareUrl(
+        [AsParameters] GetContainerShareUrlRequest req)
+    {
+        var container = await req.Storage.GetWopiContainer(req.Id, req.CancellationToken).ConfigureAwait(false);
+        if (container is null) return TypedResults.NotFound();
+
+        if (string.IsNullOrEmpty(req.UrlType) || !WopiShareUrlTypes.All.Contains(req.UrlType, StringComparer.Ordinal))
+        {
+            return TypedResults.StatusCode(StatusCodes.Status501NotImplemented);
+        }
+
+        return TypedResults.Json(new ShareUrlResponse(FileMutatingEndpoints.BuildShareUrl(req.Http, req.Id, req.UrlType)));
     }
 
     private static async Task<CreateChildContainerResult> CreateChildContainer(
@@ -282,6 +306,14 @@ public sealed record RenameContainerResponse(string Name);
 // FileMutatingEndpoints. The nullable signal communicates the optional contract while the
 // attribute forces DI lookup at the binder so unregistered hosts still resolve a null instead
 // of triggering body-inference startup failure.
+
+/// <summary>Parameter bundle for <see cref="ContainerMutatingEndpoints.GetShareUrl"/>.</summary>
+internal readonly record struct GetContainerShareUrlRequest(
+    [FromRoute] string Id,
+    HttpContext Http,
+    IWopiStorageProvider Storage,
+    [FromHeader(Name = WopiHeaders.UrlType)] string? UrlType,
+    CancellationToken CancellationToken);
 
 /// <summary>Parameter bundle for <see cref="ContainerMutatingEndpoints.CreateChildContainer"/>.</summary>
 internal readonly record struct CreateChildContainerRequest(

--- a/src/WopiHost.Core/Endpoints/FileEndpoints.cs
+++ b/src/WopiHost.Core/Endpoints/FileEndpoints.cs
@@ -79,6 +79,7 @@ internal static class FileEndpoints
             SupportsLocks = req.LockProvider is not null,
             SupportsCoauth = req.CobaltProcessor is not null,
             SupportsUpdate = req.WritableStorage is not null,
+            SupportedShareUrlTypes = WopiShareUrlTypes.All,
         };
 
         var checkFileInfo = await req.Builder.BuildAsync(file, req.Http.ToWopiRequestInfo(), capabilities, userInfo, req.CancellationToken).ConfigureAwait(false);

--- a/src/WopiHost.Core/Endpoints/FileMutatingEndpoints.cs
+++ b/src/WopiHost.Core/Endpoints/FileMutatingEndpoints.cs
@@ -86,6 +86,15 @@ internal static class FileMutatingEndpoints
             .WithDescription("Spec: https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/putuserinfo. " +
                 "Body size capped at 1024 bytes per spec; oversized bodies yield 400.");
 
+        // GetShareUrl is read-level and needs no writable storage, so it's registered on the
+        // parent group (like PutUserInfo), not the writable-gated sub-group.
+        files.MapPost("/{id}", GetShareUrl)
+            .WithMetadata(new WopiOverrideMetadata(WopiFileOperations.GetShareUrl))
+            .WithSummary("GetShareUrl (X-WOPI-Override: GET_SHARE_URL).")
+            .WithDescription("Spec: https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/getshareurl. " +
+                "Returns 501 when the requested X-WOPI-UrlType is unsupported.")
+            .RequireWopiPermission(WopiResourceType.File, Permission.Read);
+
         mutating.MapPost("/{id}", DeleteFile)
             .WithMetadata(new WopiOverrideMetadata(WopiFileOperations.DeleteFile))
             .WithSummary("DeleteFile (X-WOPI-Override: DELETE).")
@@ -113,6 +122,30 @@ internal static class FileMutatingEndpoints
             .WithDescription("Spec: https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/lock. " +
                 "Dispatches by X-WOPI-Override inside the handler. Returns 409 with X-WOPI-Lock on every mismatch path.")
             .RequireWopiPermission(WopiResourceType.File, Permission.Update);
+    }
+
+    // Spec: returns { "ShareUrl": "..." } for a supported X-WOPI-UrlType, or 501 Not Implemented
+    // when the requested type isn't in SupportedShareUrlTypes. The sample mints a host-page-style
+    // link off the request authority; a production host would return its real sharing surface.
+    private static async Task<Results<NotFound, JsonHttpResult<ShareUrlResponse>, StatusCodeHttpResult>> GetShareUrl(
+        [AsParameters] GetFileShareUrlRequest req)
+    {
+        var file = await req.Storage.GetWopiFile(req.Id, req.CancellationToken).ConfigureAwait(false);
+        if (file is null) return TypedResults.NotFound();
+
+        if (string.IsNullOrEmpty(req.UrlType) || !WopiShareUrlTypes.All.Contains(req.UrlType, StringComparer.Ordinal))
+        {
+            return TypedResults.StatusCode(StatusCodes.Status501NotImplemented);
+        }
+
+        return TypedResults.Json(new ShareUrlResponse(BuildShareUrl(req.Http, req.Id, req.UrlType)));
+    }
+
+    /// <summary>Builds an absolute, host-page-style share link off the request authority.</summary>
+    internal static Uri BuildShareUrl(HttpContext http, string id, string urlType)
+    {
+        var baseUri = new Uri($"{http.Request.Scheme}://{http.Request.Host}");
+        return new Uri(baseUri, $"/share/{Uri.EscapeDataString(id)}?type={urlType}");
     }
 
     private static async Task<Results<NotFound, Ok, WopiLockMismatchResult, StatusCodeHttpResult>> PutFile(
@@ -624,6 +657,14 @@ public sealed record RenameFileResponse(string Name);
 // parameter is plain (non-nullable, no [FromServices]). Declaring it nullable with a
 // null-coalesce fallback at the call sites would silently mask a host's choice to register
 // JsonShapedWopiLockComparer, routing every lock-compare through Ordinal.
+
+/// <summary>Parameter bundle for <see cref="FileMutatingEndpoints.GetShareUrl"/>.</summary>
+internal readonly record struct GetFileShareUrlRequest(
+    [FromRoute] string Id,
+    HttpContext Http,
+    IWopiStorageProvider Storage,
+    [FromHeader(Name = WopiHeaders.UrlType)] string? UrlType,
+    CancellationToken CancellationToken);
 
 /// <summary>Parameter bundle for <see cref="FileMutatingEndpoints.PutFile"/>.</summary>
 internal readonly record struct PutFileRequest(

--- a/src/WopiHost.Core/Infrastructure/DefaultCheckContainerInfoBuilder.cs
+++ b/src/WopiHost.Core/Infrastructure/DefaultCheckContainerInfoBuilder.cs
@@ -37,6 +37,7 @@ public class DefaultCheckContainerInfoBuilder(
             UserCanRename = permissions.HasFlag(WopiContainerPermissions.UserCanRename),
             IsAnonymousUser = isAnonymous,
             IsEduUser = false,
+            SupportedShareUrlTypes = WopiShareUrlTypes.All,
         };
 
         return await extensions.OnCheckContainerInfoAsync(

--- a/src/WopiHost.Core/Infrastructure/WopiHeaders.cs
+++ b/src/WopiHost.Core/Infrastructure/WopiHeaders.cs
@@ -173,7 +173,13 @@ public static class WopiHeaders
     /// Wildcard characters are not permitted.
     /// </summary>
     public const string FileExtensionFilterList = "X-WOPI-FileExtensionFilterList";
-    
+
+    /// <summary>
+    /// The Share URL type requested on the GetShareUrl operation — one of
+    /// <see cref="WopiHost.Abstractions.WopiShareUrlTypes"/> (e.g. <c>ReadOnly</c>, <c>ReadWrite</c>).
+    /// </summary>
+    public const string UrlType = "X-WOPI-UrlType";
+
     /// <summary>
     /// A Base64-encoded string indicating a cryptographic signature of the request.
     /// Used to validate that the request originated from Office Online Server.

--- a/src/WopiHost.Core/Models/ShareUrlResponse.cs
+++ b/src/WopiHost.Core/Models/ShareUrlResponse.cs
@@ -1,0 +1,8 @@
+namespace WopiHost.Core.Models;
+
+/// <summary>
+/// Response body for the GetShareUrl operation — a single absolute share link.
+/// <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/getshareurl"/>.
+/// </summary>
+/// <param name="ShareUrl">The absolute share URL for the requested <c>X-WOPI-UrlType</c>.</param>
+public record ShareUrlResponse(Uri ShareUrl);

--- a/src/WopiHost.Core/README.md
+++ b/src/WopiHost.Core/README.md
@@ -93,6 +93,7 @@ WOPI uses a small set of routes; verb + `X-WOPI-Override` header pick the operat
 | `/wopi/files/{id}` | `POST` | `RENAME_FILE` | [`RenameFile`](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/renamefile) |
 | `/wopi/files/{id}` | `POST` | `DELETE` | [`DeleteFile`](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/deletefile) |
 | `/wopi/files/{id}` | `POST` | `PUT_USER_INFO` | [`PutUserInfo`](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/putuserinfo) |
+| `/wopi/files/{id}` | `POST` | `GET_SHARE_URL` | [`GetShareUrl`](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/getshareurl) |
 | `/wopi/files/{id}` | `POST` | `COBALT` | MS-FSSHTTP request batch (when [WopiHost.Cobalt](../WopiHost.Cobalt/README.md) is registered) |
 | `/wopi/files/{id}/ancestry` | `GET` | — | [`EnumerateAncestors`](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/enumerateancestors) |
 | `/wopi/files/{id}/ecosystem_pointer` | `GET` | — | Ecosystem pointer for the file |
@@ -101,6 +102,7 @@ WOPI uses a small set of routes; verb + `X-WOPI-Override` header pick the operat
 | `/wopi/containers/{id}/ancestry` | `GET` | — | [`EnumerateAncestors`](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/containers/enumerateancestors) |
 | `/wopi/containers/{id}/ecosystem_pointer` | `GET` | — | Ecosystem pointer for the container |
 | `/wopi/containers/{id}` | `POST` | `CREATE_CHILD_CONTAINER` / `CREATE_CHILD_FILE` / `RENAME_CONTAINER` / `DELETE_CONTAINER` | Container mutations |
+| `/wopi/containers/{id}` | `POST` | `GET_SHARE_URL` | [`GetShareUrl`](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/containers/getshareurl) |
 | `/wopi/folders/{id}` | `GET` | — | [`CheckFolderInfo`](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/folders/checkfolderinfo) (legacy OneNote) |
 | `/wopi/folders/{id}/children` | `GET` | — | [`EnumerateChildren (folders)`](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/folders/enumeratechildren) |
 | `/wopi/ecosystem` | `GET` | — | [`CheckEcosystem`](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/ecosystem/checkecosystem) |

--- a/test/WopiHost.IntegrationTests/ContainerMutatingEndpointTests.cs
+++ b/test/WopiHost.IntegrationTests/ContainerMutatingEndpointTests.cs
@@ -18,6 +18,41 @@ public sealed class ContainerMutatingEndpointTests(MutatingEndpointsFixture fixt
 {
     private readonly MutatingEndpointsFixture _fixture = fixture;
 
+    // ---- GetShareUrl -----------------------------------------------------
+
+    [Theory]
+    [InlineData("ReadOnly")]
+    [InlineData("ReadWrite")]
+    public async Task GetShareUrl_SupportedUrlType_Returns200WithAbsoluteShareUrl(string urlType)
+    {
+        var token = await _fixture.MintContainerTokenAsync(_fixture.RootContainerId);
+        using var client = _fixture.WopiBackend.CreateClient();
+
+        var req = new HttpRequestMessage(HttpMethod.Post, $"/wopi/containers/{_fixture.RootContainerId}?access_token={Uri.EscapeDataString(token)}");
+        req.Headers.Add("X-WOPI-Override", "GET_SHARE_URL");
+        req.Headers.Add("X-WOPI-UrlType", urlType);
+        var resp = await client.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        var shareUrl = doc.RootElement.GetProperty("ShareUrl").GetString();
+        Assert.True(Uri.IsWellFormedUriString(shareUrl, UriKind.Absolute));
+    }
+
+    [Fact]
+    public async Task GetShareUrl_UnsupportedUrlType_Returns501()
+    {
+        var token = await _fixture.MintContainerTokenAsync(_fixture.RootContainerId);
+        using var client = _fixture.WopiBackend.CreateClient();
+
+        var req = new HttpRequestMessage(HttpMethod.Post, $"/wopi/containers/{_fixture.RootContainerId}?access_token={Uri.EscapeDataString(token)}");
+        req.Headers.Add("X-WOPI-Override", "GET_SHARE_URL");
+        req.Headers.Add("X-WOPI-UrlType", "NotASupportedType");
+        var resp = await client.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.NotImplemented, resp.StatusCode);
+    }
+
     // ---- CreateChildContainer --------------------------------------------
 
     [Fact]

--- a/test/WopiHost.IntegrationTests/ContainerMutatingEndpointTests.cs
+++ b/test/WopiHost.IntegrationTests/ContainerMutatingEndpointTests.cs
@@ -53,6 +53,20 @@ public sealed class ContainerMutatingEndpointTests(MutatingEndpointsFixture fixt
         Assert.Equal(HttpStatusCode.NotImplemented, resp.StatusCode);
     }
 
+    [Fact]
+    public async Task GetShareUrl_MissingUrlTypeHeader_Returns501()
+    {
+        var token = await _fixture.MintContainerTokenAsync(_fixture.RootContainerId);
+        using var client = _fixture.WopiBackend.CreateClient();
+
+        var req = new HttpRequestMessage(HttpMethod.Post, $"/wopi/containers/{_fixture.RootContainerId}?access_token={Uri.EscapeDataString(token)}");
+        req.Headers.Add("X-WOPI-Override", "GET_SHARE_URL");
+        // No X-WOPI-UrlType header → treated as unsupported.
+        var resp = await client.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.NotImplemented, resp.StatusCode);
+    }
+
     // ---- CreateChildContainer --------------------------------------------
 
     [Fact]

--- a/test/WopiHost.IntegrationTests/FileMutatingEndpointTests.cs
+++ b/test/WopiHost.IntegrationTests/FileMutatingEndpointTests.cs
@@ -56,6 +56,21 @@ public sealed class FileMutatingEndpointTests(MutatingEndpointsFixture fixture)
         Assert.Equal(HttpStatusCode.NotImplemented, resp.StatusCode);
     }
 
+    [Fact]
+    public async Task GetShareUrl_MissingUrlTypeHeader_Returns501()
+    {
+        var fileId = await _fixture.CreateTempFileAsync([]);
+        var token = await _fixture.MintFileTokenAsync(fileId);
+        using var client = _fixture.WopiBackend.CreateClient();
+
+        var req = new HttpRequestMessage(HttpMethod.Post, $"/wopi/files/{fileId}?access_token={Uri.EscapeDataString(token)}");
+        req.Headers.Add("X-WOPI-Override", "GET_SHARE_URL");
+        // No X-WOPI-UrlType header → treated as unsupported.
+        var resp = await client.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.NotImplemented, resp.StatusCode);
+    }
+
     // ---- PutFile ---------------------------------------------------------
 
     [Fact]

--- a/test/WopiHost.IntegrationTests/FileMutatingEndpointTests.cs
+++ b/test/WopiHost.IntegrationTests/FileMutatingEndpointTests.cs
@@ -19,6 +19,43 @@ public sealed class FileMutatingEndpointTests(MutatingEndpointsFixture fixture)
 {
     private readonly MutatingEndpointsFixture _fixture = fixture;
 
+    // ---- GetShareUrl -----------------------------------------------------
+
+    [Theory]
+    [InlineData("ReadOnly")]
+    [InlineData("ReadWrite")]
+    public async Task GetShareUrl_SupportedUrlType_Returns200WithAbsoluteShareUrl(string urlType)
+    {
+        var fileId = await _fixture.CreateTempFileAsync([]);
+        var token = await _fixture.MintFileTokenAsync(fileId);
+        using var client = _fixture.WopiBackend.CreateClient();
+
+        var req = new HttpRequestMessage(HttpMethod.Post, $"/wopi/files/{fileId}?access_token={Uri.EscapeDataString(token)}");
+        req.Headers.Add("X-WOPI-Override", "GET_SHARE_URL");
+        req.Headers.Add("X-WOPI-UrlType", urlType);
+        var resp = await client.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        var shareUrl = doc.RootElement.GetProperty("ShareUrl").GetString();
+        Assert.True(Uri.IsWellFormedUriString(shareUrl, UriKind.Absolute));
+    }
+
+    [Fact]
+    public async Task GetShareUrl_UnsupportedUrlType_Returns501()
+    {
+        var fileId = await _fixture.CreateTempFileAsync([]);
+        var token = await _fixture.MintFileTokenAsync(fileId);
+        using var client = _fixture.WopiBackend.CreateClient();
+
+        var req = new HttpRequestMessage(HttpMethod.Post, $"/wopi/files/{fileId}?access_token={Uri.EscapeDataString(token)}");
+        req.Headers.Add("X-WOPI-Override", "GET_SHARE_URL");
+        req.Headers.Add("X-WOPI-UrlType", "NotASupportedType");
+        var resp = await client.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.NotImplemented, resp.StatusCode);
+    }
+
     // ---- PutFile ---------------------------------------------------------
 
     [Fact]

--- a/test/WopiHost.IntegrationTests/FileMutatingEndpointTests.cs
+++ b/test/WopiHost.IntegrationTests/FileMutatingEndpointTests.cs
@@ -63,7 +63,7 @@ public sealed class FileMutatingEndpointTests(MutatingEndpointsFixture fixture)
         var token = await _fixture.MintFileTokenAsync(fileId);
         using var client = _fixture.WopiBackend.CreateClient();
 
-        var req = new HttpRequestMessage(HttpMethod.Post, $"/wopi/files/{fileId}?access_token={Uri.EscapeDataString(token)}");
+        using var req = new HttpRequestMessage(HttpMethod.Post, $"/wopi/files/{fileId}?access_token={Uri.EscapeDataString(token)}");
         req.Headers.Add("X-WOPI-Override", "GET_SHARE_URL");
         // No X-WOPI-UrlType header → treated as unsupported.
         var resp = await client.SendAsync(req);


### PR DESCRIPTION
Two coupled pieces of #539: the host-page **postMessage** integration in `WopiHost.Web`, and the **GetShareUrl** WOPI operation in `WopiHost.Core` that lights up the validator's GetShareUrl group.

## 1. postMessage action bar (`WopiHost.Web`)

Grows the lone "← Files" pill (which already spoke `Action_Close`) into a thin top action bar — per the [postMessage scenario docs](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/online/scenarios/postmessage) and [Collabora's API](https://sdk.collaboraonline.com/docs/postmessage_api.html).

- **Host → editor:** Save (`Action_Save`), Print (`Action_Print`), Close / Files (`Action_Close` handshake → navigate)
- **Editor → host:** `App_LoadingStatus` → status; `Doc_ModifiedStatus`/`Document_Modified` → unsaved ● dot; `Action_Save_Resp` → "Saved"; `UI_Sharing` → share dialog; `UI_Close`/`Action_Close_Resp` → navigate
- **Host-owned Share dialog** with a copyable link; `Host_PostmessageReady` on frame load; all messages origin-scoped
- iframe keeps `name="office_frame"`, sits below the 40px bar → no overlap with Collabora's UI

## 2. GetShareUrl (`WopiHost.Core`)

Implements `GET_SHARE_URL` for **files and containers** — pure managed, no proprietary dep.

- `WopiShareUrlTypes` (`ReadOnly`/`ReadWrite`); read-level override on the parent group (no writable-storage requirement)
- Returns `{ "ShareUrl": <absolute Uri> }` for a supported `X-WOPI-UrlType`, **501** for unsupported (spec-exact)
- `SupportedShareUrlTypes` now advertised by default in **CheckFileInfo** and **CheckContainerInfo** (new property on the container model) — this is what flips the 6 validator tests from skipped to live
- New `X-WOPI-UrlType` header constant + `ShareUrlResponse` model
- **6 integration tests** (supported→200+absolute URL, unsupported→501, ×files+containers) — all green locally

## Verification

- `dotnet build WOPI.slnx` clean (warnings-as-errors); the 6 new integration tests pass.
- The **`wopi-validator` CI workflow** is the confirmation that the 6 GetShareUrl tests flip green (they can't be exercised locally).

## E2E / smoke safety

E2E targets only iframe-internal nodes + the browse Edit link; smoke targets only the browse page. Neither touches the editor chrome or the new endpoints. The E2E's own `Host_PostmessageReady`/`Action_Save` coexist with the bar's (idempotent).

Part of #539.

🤖 Generated with [Claude Code](https://claude.com/claude-code)