### PR TITLE
fix(deps): pin MessagePack to patched 2.5.301 to unbreak CI restore

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,10 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <!-- Enables overriding a transitive dependency's version from a PackageVersion entry below.
+         Required for the MessagePack security pin; remove together with that pin once it's
+         no longer needed. -->
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 
   <!-- Production packages — referenced by src/, sample/, infra/, and tests. -->
@@ -39,6 +43,13 @@
     <!-- Aspire integration for the Redis lock provider opt-in. Only the AppHost needs it. -->
     <PackageVersion Include="Aspire.Hosting.Redis" Version="13.4.3" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
+    <!-- Security pin (not referenced directly). Aspire 13.4.3 pulls MessagePack 2.5.192
+         transitively, which GHSA-hv8m-jj95-wg3x flags as a high-severity LZ4-decompression
+         crash; 2.5.301 is the first patched 2.5.x release. NuGet audit + warnings-as-errors
+         turns the advisory into a restore-breaking NU1903. Remove this (and the
+         CentralPackageTransitivePinningEnabled property above) once Aspire ships a
+         MessagePack >= 2.5.301 transitively. -->
+    <PackageVersion Include="MessagePack" Version="2.5.301" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
## What's broken

CI is red across open PRs (including #553) at the `dotnet restore` step, before anything builds:

```
error NU1903: Warning As Error: Package 'MessagePack' 2.5.192 has a known
high severity vulnerability, https://github.com/advisories/GHSA-hv8m-jj95-wg3x
  Failed to restore .../WopiHost.AppHost.csproj
  Failed to restore .../WopiHost.E2ETests.csproj
```

This is unrelated to whatever each PR changes — a new advisory (`GHSA-hv8m-jj95-wg3x`) landed against **MessagePack 2.5.192**, which **Aspire 13.4.3** pulls in transitively (`Aspire.Hosting.AppHost` in the AppHost, `Aspire.Hosting.Testing` in E2ETests — the only two projects affected). With NuGet audit + warnings-as-errors, the advisory becomes a restore-breaking `NU1903`.

The advisory: a crafted LZ4-compressed payload can crash the deserializer. Vulnerable `< 2.5.301` on the 2.5.x line; first patched is **2.5.301**.

## The fix

MessagePack isn't referenced directly, so overriding a transitive version under Central Package Management needs transitive pinning turned on. This PR:

- Enables `CentralPackageTransitivePinningEnabled` in `Directory.Packages.props`.
- Adds `<PackageVersion Include="MessagePack" Version="2.5.301" />` — same 2.5.x line, so API-compatible with what Aspire expects.

Both are annotated as a **temporary security pin**, with a comment pointing at the advisory and the removal condition (drop both once Aspire ships a MessagePack ≥ 2.5.301 transitively). No advisory suppression.

## Verification

No .NET SDK in the authoring environment, so restore couldn't be run locally — relying on CI here. Expectation: `NU1903` clears and the `API Compatibility` / `analyze` jobs get past restore.

https://claude.ai/code/session_016wHBEJ9cJkZrM5bgqwCZY8

---
_Generated by [Claude Code](https://claude.ai/code/session_016wHBEJ9cJkZrM5bgqwCZY8)_