### PR TITLE
feat(sample): editor top-panel actions — view↔edit, download, fullscreen (+ wire postMessage flags)

### DIFF
--- a/sample/WopiHost.Web/Components/Layout/WopiLayout.razor
+++ b/sample/WopiHost.Web/Components/Layout/WopiLayout.razor
@@ -73,6 +73,29 @@
             margin: 0 4px;
         }
 
+        #wopi_filename {
+            color: #fff;
+            padding: 6px 8px;
+            border-radius: 6px;
+            cursor: pointer;
+            max-width: 280px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        #wopi_filename:hover {
+            background: rgba(255, 255, 255, 0.14);
+        }
+
+        #wopi_rename_input {
+            font: inherit;
+            padding: 5px 8px;
+            border-radius: 6px;
+            border: 1px solid #888;
+            max-width: 280px;
+        }
+
         #wopi_status {
             display: inline-flex;
             align-items: center;
@@ -178,9 +201,13 @@
     <div class="group">
         <button id="wopi_files" type="button" title="Close editor and return to files">← Files</button>
         <span class="sep"></span>
+        <span id="wopi_filename" role="button" tabindex="0" title="Click to rename"></span>
+        <span class="sep"></span>
         <button data-action="Action_Save" type="button" title="Save the document">💾 Save</button>
         <button data-action="Action_Print" type="button" title="Print the document">🖨 Print</button>
         <button id="wopi_mode" type="button"></button>
+        <button id="wopi_download" type="button" title="Download a copy">⬇ Download</button>
+        <button id="wopi_fullscreen" type="button" title="Toggle full screen">⛶ Fullscreen</button>
         <button id="wopi_share_btn" type="button" title="Share a link to this document">🔗 Share</button>
         <button id="wopi_close" type="button" title="Close the document">✕ Close</button>
     </div>
@@ -216,6 +243,11 @@
             frame: '#office_frame',
             clientOrigin: '@WopiOptions.Value.ClientUrl.GetLeftPart(System.UriPartial.Authority)'
         });
+
+        // File identity for the toolbar (download URL, rename, title), emitted by Detail.razor.
+        var info = document.getElementById('wopi_fileinfo');
+        var fileId = info ? (info.dataset.id || '') : '';
+        var fileName = info ? (info.dataset.name || '') : '';
 
         var statusEl = document.getElementById('wopi_statustext');
         var modifiedEl = document.getElementById('wopi_modified');
@@ -285,6 +317,70 @@
                     : {});
             });
         });
+
+        // --- Filename, rename, download, fullscreen ---
+        var nameEl = document.getElementById('wopi_filename');
+        if (nameEl) { nameEl.textContent = fileName || '(untitled)'; }
+
+        // Inline rename: click the title to edit the stem (the extension is preserved server-side).
+        // The file id is stable across rename — the provider repoints it — so a reload keeps the
+        // editor on the same document under its new name.
+        function beginRename() {
+            if (!nameEl || !fileId) { return; }
+            var stem = fileName.replace(/\.[^.]*$/, '');
+            var input = document.createElement('input');
+            input.type = 'text';
+            input.id = 'wopi_rename_input';
+            input.value = stem;
+            nameEl.replaceWith(input);
+            input.focus();
+            input.select();
+            var settled = false;
+            function restore() { settled = true; input.replaceWith(nameEl); }
+            function commit() {
+                if (settled) { return; }
+                var next = input.value.trim();
+                if (!next || next === stem) { restore(); return; }
+                settled = true;
+                fetch('/files/' + encodeURIComponent(fileId) + '/rename?name=' + encodeURIComponent(next), { method: 'POST' })
+                    .then(function (r) {
+                        if (r.ok) { window.location.reload(); }
+                        else { r.text().then(function (t) { window.alert('Rename failed: ' + (t || r.status)); }); input.replaceWith(nameEl); }
+                    })
+                    .catch(function () { input.replaceWith(nameEl); });
+            }
+            input.addEventListener('keydown', function (e) {
+                if (e.key === 'Enter') { commit(); }
+                else if (e.key === 'Escape') { restore(); }
+            });
+            input.addEventListener('blur', commit);
+        }
+        if (nameEl) {
+            nameEl.addEventListener('click', beginRename);
+            nameEl.addEventListener('keydown', function (e) { if (e.key === 'Enter') { beginRename(); } });
+        }
+
+        // Download a copy via the host app's content endpoint. Content-Disposition: attachment means
+        // the browser saves the file without navigating away from the editor.
+        var downloadBtn = document.getElementById('wopi_download');
+        if (downloadBtn) {
+            downloadBtn.addEventListener('click', function () {
+                if (fileId) { window.location.href = '/files/' + encodeURIComponent(fileId) + '/content'; }
+            });
+        }
+
+        // Fullscreen the editor frame (handy for slideshow / presenter view).
+        var fullscreenBtn = document.getElementById('wopi_fullscreen');
+        if (fullscreenBtn) {
+            fullscreenBtn.addEventListener('click', function () {
+                if (document.fullscreenElement) { document.exitFullscreen(); return; }
+                var f = document.getElementById('office_frame');
+                if (f && f.requestFullscreen) { f.requestFullscreen().catch(function () { }); }
+            });
+            document.addEventListener('fullscreenchange', function () {
+                fullscreenBtn.textContent = document.fullscreenElement ? '⤢ Exit' : '⛶ Fullscreen';
+            });
+        }
 
         // Mode toggle: offer Edit while viewing and View while editing. The host-page URL carries
         // the WOPI action; a view link strips UserCanWrite from the token, so Save is also hidden

--- a/sample/WopiHost.Web/Components/Layout/WopiLayout.razor
+++ b/sample/WopiHost.Web/Components/Layout/WopiLayout.razor
@@ -74,26 +74,12 @@
         }
 
         #wopi_filename {
-            color: #fff;
+            color: rgba(255, 255, 255, 0.85);
             padding: 6px 8px;
-            border-radius: 6px;
-            cursor: pointer;
             max-width: 280px;
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
-        }
-
-        #wopi_filename:hover {
-            background: rgba(255, 255, 255, 0.14);
-        }
-
-        #wopi_rename_input {
-            font: inherit;
-            padding: 5px 8px;
-            border-radius: 6px;
-            border: 1px solid #888;
-            max-width: 280px;
         }
 
         #wopi_status {
@@ -201,7 +187,7 @@
     <div class="group">
         <button id="wopi_files" type="button" title="Close editor and return to files">← Files</button>
         <span class="sep"></span>
-        <span id="wopi_filename" role="button" tabindex="0" title="Click to rename"></span>
+        <span id="wopi_filename" title="File name"></span>
         <span class="sep"></span>
         <button data-action="Action_Save" type="button" title="Save the document">💾 Save</button>
         <button data-action="Action_Print" type="button" title="Print the document">🖨 Print</button>
@@ -244,7 +230,7 @@
             clientOrigin: '@WopiOptions.Value.ClientUrl.GetLeftPart(System.UriPartial.Authority)'
         });
 
-        // File identity for the toolbar (download URL, rename, title), emitted by Detail.razor.
+        // File identity for the toolbar (download URL, title), emitted by Detail.razor.
         var info = document.getElementById('wopi_fileinfo');
         var fileId = info ? (info.dataset.id || '') : '';
         var fileName = info ? (info.dataset.name || '') : '';
@@ -318,47 +304,9 @@
             });
         });
 
-        // --- Filename, rename, download, fullscreen ---
+        // --- Filename, download, fullscreen ---
         var nameEl = document.getElementById('wopi_filename');
         if (nameEl) { nameEl.textContent = fileName || '(untitled)'; }
-
-        // Inline rename: click the title to edit the stem (the extension is preserved server-side).
-        // The file id is stable across rename — the provider repoints it — so a reload keeps the
-        // editor on the same document under its new name.
-        function beginRename() {
-            if (!nameEl || !fileId) { return; }
-            var stem = fileName.replace(/\.[^.]*$/, '');
-            var input = document.createElement('input');
-            input.type = 'text';
-            input.id = 'wopi_rename_input';
-            input.value = stem;
-            nameEl.replaceWith(input);
-            input.focus();
-            input.select();
-            var settled = false;
-            function restore() { settled = true; input.replaceWith(nameEl); }
-            function commit() {
-                if (settled) { return; }
-                var next = input.value.trim();
-                if (!next || next === stem) { restore(); return; }
-                settled = true;
-                fetch('/files/' + encodeURIComponent(fileId) + '/rename?name=' + encodeURIComponent(next), { method: 'POST' })
-                    .then(function (r) {
-                        if (r.ok) { window.location.reload(); }
-                        else { r.text().then(function (t) { window.alert('Rename failed: ' + (t || r.status)); }); input.replaceWith(nameEl); }
-                    })
-                    .catch(function () { input.replaceWith(nameEl); });
-            }
-            input.addEventListener('keydown', function (e) {
-                if (e.key === 'Enter') { commit(); }
-                else if (e.key === 'Escape') { restore(); }
-            });
-            input.addEventListener('blur', commit);
-        }
-        if (nameEl) {
-            nameEl.addEventListener('click', beginRename);
-            nameEl.addEventListener('keydown', function (e) { if (e.key === 'Enter') { beginRename(); } });
-        }
 
         // Download a copy via the host app's content endpoint. Content-Disposition: attachment means
         // the browser saves the file without navigating away from the editor.

--- a/sample/WopiHost.Web/Components/Layout/WopiLayout.razor
+++ b/sample/WopiHost.Web/Components/Layout/WopiLayout.razor
@@ -180,6 +180,7 @@
         <span class="sep"></span>
         <button data-action="Action_Save" type="button" title="Save the document">💾 Save</button>
         <button data-action="Action_Print" type="button" title="Print the document">🖨 Print</button>
+        <button id="wopi_mode" type="button"></button>
         <button id="wopi_share_btn" type="button" title="Share a link to this document">🔗 Share</button>
         <button id="wopi_close" type="button" title="Close the document">✕ Close</button>
     </div>
@@ -221,17 +222,33 @@
         function setStatus(text) { if (statusEl) statusEl.textContent = text; }
         function setModified(on) { if (modifiedEl) modifiedEl.hidden = !on; }
 
-        var navigated = false;
-        function goHome() {
-            if (navigated) return;
-            navigated = true;
-            window.location.href = '/';
+        // Single guard for any host-page navigation (close, or a view<->edit switch).
+        var leaving = false;
+        function navigateTo(url) {
+            if (leaving) return;
+            leaving = true;
+            window.location.href = url;
         }
+        function goHome() { navigateTo('/'); }
 
         // Close handshake: ask the editor to flush pending saves, then navigate.
         function requestClose() {
             wopi.send(M.Action_Close, {});
             setTimeout(goHome, 600);
+        }
+
+        // View<->edit switch. Detail re-mints a token scoped to the action (a view link strips
+        // UserCanWrite), so flipping mode is a full host-page reload under the new wopiaction, not
+        // an in-place toggle. Leaving edit mode flushes first so the reload can't drop changes.
+        function goToAction(action) {
+            var params = new URLSearchParams(window.location.search);
+            params.set('wopiaction', action);
+            navigateTo(window.location.pathname + '?' + params.toString());
+        }
+        function switchToEdit() { goToAction('edit'); }
+        function switchToView() {
+            wopi.send(M.Action_Save, { Notify: true });
+            setTimeout(function () { goToAction('view'); }, 600);
         }
 
         // Share UI is host-owned: the editor's Share button (UI_Sharing) and the bar's Share
@@ -269,10 +286,23 @@
             });
         });
 
-        // Save only makes sense in edit mode. The host-page URL carries the WOPI action; a view
-        // link strips UserCanWrite from the token, so hide Save rather than offer a no-op.
+        // Mode toggle: offer Edit while viewing and View while editing. The host-page URL carries
+        // the WOPI action; a view link strips UserCanWrite from the token, so Save is also hidden
+        // in view mode rather than offered as a no-op.
         var wopiAction = (new URLSearchParams(window.location.search).get('wopiaction') || 'view').toLowerCase();
-        if (wopiAction === 'view') {
+        var modeBtn = document.getElementById('wopi_mode');
+        if (wopiAction === 'edit') {
+            if (modeBtn) {
+                modeBtn.textContent = '👁 View';
+                modeBtn.title = 'Switch to read-only view';
+                modeBtn.addEventListener('click', switchToView);
+            }
+        } else {
+            if (modeBtn) {
+                modeBtn.textContent = '✏️ Edit';
+                modeBtn.title = 'Switch to editing';
+                modeBtn.addEventListener('click', switchToEdit);
+            }
             var saveBtn = document.querySelector('#wopi_bar button[data-action="Action_Save"]');
             if (saveBtn) { saveBtn.remove(); }
         }
@@ -289,6 +319,7 @@
         wopi.on(M.Document_Modified, onModified);   // Office for the Web
         wopi.on(M.Action_Save_Resp, function () { setModified(false); setStatus('Saved'); });
         wopi.on(M.UI_Sharing, openShare);
+        wopi.on(M.UI_Edit, switchToEdit);  // editor's own Edit button (view mode)
         wopi.on(M.UI_Close, goHome);
         wopi.on(M.Action_Close_Resp, goHome);
     })();

--- a/sample/WopiHost.Web/Components/Pages/Detail.razor
+++ b/sample/WopiHost.Web/Components/Pages/Detail.razor
@@ -36,7 +36,7 @@ else
 
         <span id="frameholder"></span>
 
-        @* Carries the file id / name to the layout's toolbar script (download URL, rename, title).
+        @* Carries the file id / name to the layout's toolbar script (download URL, title).
            Attribute values are HTML-encoded by Razor, so a name with quotes is safe. *@
         <div id="wopi_fileinfo" data-id="@Id" data-name="@_fileName" hidden></div>
 

--- a/sample/WopiHost.Web/Components/Pages/Detail.razor
+++ b/sample/WopiHost.Web/Components/Pages/Detail.razor
@@ -36,6 +36,10 @@ else
 
         <span id="frameholder"></span>
 
+        @* Carries the file id / name to the layout's toolbar script (download URL, rename, title).
+           Attribute values are HTML-encoded by Razor, so a name with quotes is safe. *@
+        <div id="wopi_fileinfo" data-id="@Id" data-name="@_fileName" hidden></div>
+
         <script type="text/javascript">
             var frameholder = document.getElementById('frameholder');
             var office_frame = document.createElement('iframe');
@@ -63,6 +67,7 @@ else
     private string? _accessToken;
     private long _accessTokenTtl;
     private Uri? _favicon;
+    private string? _fileName;
     private string? _badRequestReason;
 
     protected override async Task OnInitializedAsync()
@@ -103,6 +108,7 @@ else
         _accessTokenTtl = expiresAt.ToUnixTimeMilliseconds();
 
         var extension = file.Extension.TrimStart('.');
+        _fileName = $"{file.Name}.{extension}";
         var options = WopiOptionsAccessor.Value;
         var urlBuilder = new WopiUrlBuilder(Discoverer, UrlBuilderLogger,
             new WopiUrlSettings { UiLlcc = ResolveUiCulture(options.UiCulture) });

--- a/sample/WopiHost.Web/Program.cs
+++ b/sample/WopiHost.Web/Program.cs
@@ -1,3 +1,4 @@
+using WopiHost.Abstractions;
 using WopiHost.Discovery;
 using WopiHost.FileSystemProvider;
 using WopiHost.ServiceDefaults;
@@ -56,6 +57,55 @@ app.UseStaticFiles();
 app.UseAntiforgery();
 
 app.MapRazorComponents<App>();
+
+// Sample-only host-app actions backing the editor toolbar's Download / Rename buttons. These call
+// the storage provider directly — they are NOT WOPI protocol operations — and, like the rest of
+// this sample, are anonymous: fine for a demo, not a template for production access control.
+app.MapGet("/files/{id}/content", async (string id, IWopiStorageProvider storage, CancellationToken ct) =>
+{
+    var file = await storage.GetWopiFile(id, ct);
+    if (file is null)
+    {
+        return Results.NotFound();
+    }
+    var downloadName = $"{file.Name}.{file.Extension.TrimStart('.')}";
+    var stream = await file.OpenReadAsync(ct);
+    return Results.File(stream, "application/octet-stream", downloadName);
+});
+
+app.MapPost("/files/{id}/rename", async (
+    string id,
+    string name,
+    IWopiStorageProvider storage,
+    IWopiWritableStorageProvider writable,
+    CancellationToken ct) =>
+{
+    if (string.IsNullOrWhiteSpace(name))
+    {
+        return Results.BadRequest("A new name is required.");
+    }
+    var file = await storage.GetWopiFile(id, ct);
+    if (file is null)
+    {
+        return Results.NotFound();
+    }
+    // The caller edits only the stem; the original extension is reattached so the file type can't
+    // be changed by accident. The provider treats the result as the full single-segment filename.
+    var requestedName = $"{name}.{file.Extension.TrimStart('.')}";
+    try
+    {
+        return await writable.RenameWopiFile(id, requestedName, ct) ? Results.Ok() : Results.NotFound();
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(ex.Message);
+    }
+    catch (InvalidOperationException ex)
+    {
+        // Target name already exists (the provider's WOPI 409 path).
+        return Results.Conflict(ex.Message);
+    }
+}).DisableAntiforgery();
 
 app.MapHealthChecks("/health");
 

--- a/sample/WopiHost.Web/Program.cs
+++ b/sample/WopiHost.Web/Program.cs
@@ -58,9 +58,9 @@ app.UseAntiforgery();
 
 app.MapRazorComponents<App>();
 
-// Sample-only host-app actions backing the editor toolbar's Download / Rename buttons. These call
-// the storage provider directly — they are NOT WOPI protocol operations — and, like the rest of
-// this sample, are anonymous: fine for a demo, not a template for production access control.
+// Sample-only host-app action backing the editor toolbar's Download button. Streams the file via
+// the storage provider directly (not a WOPI protocol operation) and, like the rest of this sample,
+// is anonymous: fine for a demo, not a template for production access control.
 app.MapGet("/files/{id}/content", async (string id, IWopiStorageProvider storage, CancellationToken ct) =>
 {
     var file = await storage.GetWopiFile(id, ct);
@@ -72,40 +72,6 @@ app.MapGet("/files/{id}/content", async (string id, IWopiStorageProvider storage
     var stream = await file.OpenReadAsync(ct);
     return Results.File(stream, "application/octet-stream", downloadName);
 });
-
-app.MapPost("/files/{id}/rename", async (
-    string id,
-    string name,
-    IWopiStorageProvider storage,
-    IWopiWritableStorageProvider writable,
-    CancellationToken ct) =>
-{
-    if (string.IsNullOrWhiteSpace(name))
-    {
-        return Results.BadRequest("A new name is required.");
-    }
-    var file = await storage.GetWopiFile(id, ct);
-    if (file is null)
-    {
-        return Results.NotFound();
-    }
-    // The caller edits only the stem; the original extension is reattached so the file type can't
-    // be changed by accident. The provider treats the result as the full single-segment filename.
-    var requestedName = $"{name}.{file.Extension.TrimStart('.')}";
-    try
-    {
-        return await writable.RenameWopiFile(id, requestedName, ct) ? Results.Ok() : Results.NotFound();
-    }
-    catch (ArgumentException ex)
-    {
-        return Results.BadRequest(ex.Message);
-    }
-    catch (InvalidOperationException ex)
-    {
-        // Target name already exists (the provider's WOPI 409 path).
-        return Results.Conflict(ex.Message);
-    }
-}).DisableAntiforgery();
 
 app.MapHealthChecks("/health");
 

--- a/sample/WopiHost.Web/wwwroot/js/wopi-postmessage.js
+++ b/sample/WopiHost.Web/wwwroot/js/wopi-postmessage.js
@@ -29,7 +29,9 @@
         Doc_ModifiedStatus: 'Doc_ModifiedStatus',       // Collabora; Values.Modified: bool
         Document_Modified: 'Document_Modified',         // Office for the Web equivalent of the above
 
-        // Editor -> host: UI affordances, each gated by a *PostMessage host capability flag.
+        // Editor -> host: UI affordances. Each corresponds to a *PostMessage flag the host
+        // advertises in CheckFileInfo; the client (not the host) reads the flag and decides whether
+        // to surface the affordance and emit the message. The trailing comment names that flag.
         UI_Sharing: 'UI_Sharing',                       // FileSharingPostMessage — editor's Share button
         UI_Close: 'UI_Close',                           // ClosePostMessage — editor's Close button
         UI_Edit: 'UI_Edit',                             // EditModePostMessage — switch from view to edit

--- a/sample/WopiHost/Program.cs
+++ b/sample/WopiHost/Program.cs
@@ -74,6 +74,10 @@ public partial class Program
 
             builder.Services.AddOpenApi();
 
+            // Advertise the host page's postMessage capabilities (Share / Close / view<->edit).
+            // Registered before AddWopi so it wins over the core's TryAddSingleton default.
+            builder.Services.AddSingleton<IWopiHostExtensions, SampleWopiHostExtensions>();
+
             builder.Services.AddWopi();
 
             // Signing key for WOPI access tokens. MUST match whatever the URL-generating

--- a/sample/WopiHost/SampleWopiHostExtensions.cs
+++ b/sample/WopiHost/SampleWopiHostExtensions.cs
@@ -1,0 +1,30 @@
+using WopiHost.Abstractions;
+
+namespace WopiHost;
+
+/// <summary>
+/// Sample <see cref="IWopiHostExtensions"/> that advertises the host page's postMessage
+/// capabilities. The paired front end (WopiHost.Web's <c>WopiLayout</c>) handles the matching
+/// editor-to-host messages: <c>UI_Sharing</c> (Share), <c>UI_Close</c> (Close), and <c>UI_Edit</c>
+/// (the view&#8596;edit switch).
+/// </summary>
+/// <remarks>
+/// These are advertisements, not server-side checks: the WOPI client reads them from
+/// <c>CheckFileInfo</c> and decides whether to surface the affordance and emit the message.
+/// Office for the Web additionally posts only to <see cref="WopiCheckFileInfo.PostMessageOrigin"/>,
+/// so it would need that set to the front-end origin; Collabora (the dev-loop client) ignores the
+/// field, so it is left unset here.
+/// </remarks>
+public class SampleWopiHostExtensions : WopiHostExtensions
+{
+    /// <inheritdoc />
+    public override Task<WopiCheckFileInfo> OnCheckFileInfoAsync(WopiCheckFileInfoContext context, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        var checkFileInfo = context.CheckFileInfo;
+        checkFileInfo.FileSharingPostMessage = true;
+        checkFileInfo.ClosePostMessage = true;
+        checkFileInfo.EditModePostMessage = true;
+        return Task.FromResult(checkFileInfo);
+    }
+}

--- a/src/WopiHost.Abstractions/WopiCheckFileInfo.cs
+++ b/src/WopiHost.Abstractions/WopiCheckFileInfo.cs
@@ -499,12 +499,12 @@ public class WopiCheckFileInfo : IWopiHostCapabilities
     public bool AppStateHistoryPostMessage { get; set; }
 
     /// <summary>
-    /// A Boolean value that indicates that the host supports the <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/putuserinfo">PutUserInfo</see> operation.
+    /// A Boolean value that, when set to true, indicates the host expects to receive the UI_Close PostMessage when the Close UI in Microsoft 365 for the web is activated.
     /// </summary>
     public bool ClosePostMessage { get; set; }
 
     /// <summary>
-    /// A string value containing information about the user. This string can be passed from a WOPI client to the host by means of a <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/putuserinfo">PutUserInfo</see> operation. If the host has a UserInfo string for the user, they must include it in this property.
+    /// A Boolean value that, when set to true, indicates the host expects to receive the UI_Edit PostMessage when the Edit UI in Microsoft 365 for the web is activated.
     /// </summary>
     public bool EditModePostMessage { get; set; }
 


### PR DESCRIPTION
## What

Builds out the `WopiHost.Web` editor top panel. Started as the postMessage capability-flag wiring + a view↔edit switch (follow-up to #559); grew to a small suite of host-page toolbar actions.

## Top-panel actions

- **View↔Edit toggle** — offers **✏️ Edit** while viewing and **👁 View** while editing; both reopen Detail under the new `wopiaction` (action-scoped token ⇒ full reload). Leaving edit posts `Action_Save` first. The editor's own `UI_Edit` message is handled too, so Collabora's built-in Edit button works as well.
- **Filename** — the document name is shown in the bar (read-only).
- **Download** — `GET /files/{id}/content` streams the file with `Content-Disposition: attachment`, so the browser saves it without leaving the editor.
- **Fullscreen** — toggles fullscreen on the editor frame (handy for slideshow/presenter view).

> **Rename was attempted and reverted.** The frontend and the WOPI backend are separate processes, each with its own startup-built `InMemoryFileIds` map (id = SHA-256 of path). A rename via the frontend moved the file + updated only the frontend's map; the backend's map still pointed the id at the old path, so the next `CheckFileInfo` threw `FileNotFoundException`. A correct cross-process rename needs a shared id store or backend re-enumeration — out of scope for a sample toolbar.

## postMessage capability flags

`SampleWopiHostExtensions` advertises `FileSharingPostMessage` / `ClosePostMessage` / `EditModePostMessage` in `CheckFileInfo` (registered before `AddWopi()`, mirroring the Validator sample). Also tightened the `wopi-postmessage.js` catalog comment and fixed copy-paste XML-doc errors on `WopiCheckFileInfo.ClosePostMessage` / `EditModePostMessage`.

## Design notes

- **Toolbar gets file id/name** from a hidden `data-*` element rendered by `Detail.razor` (Razor HTML-encodes it) — no fragile layout-cascade assumption.
- The download endpoint uses the storage provider **directly** (not a WOPI op) and is **anonymous**, like the rest of the sample.
- **Collabora-focused.** `PostMessageOrigin` left unset (Collabora ignores it; Office would need it + AppHost plumbing — noted follow-up). No public API change, so the API Compatibility gate stays green.

## Verification

No .NET SDK in my sandbox, so CI does the compile. The toolbar JS + the download endpoint aren't covered by automated tests, so they want a manual pass on the Collabora lane (`AppHost:UseCollabora=true`): open a doc → toggle Edit/View, Download, Fullscreen.

https://claude.ai/code/session_01TZvgCbG5yJYjKoBVi3SAcR