### PR TITLE
Fix codebase + security audit findings; add security-audit skill

### DIFF
--- a/.claude/skills/codebase-audit/references/do-not-refile.md
+++ b/.claude/skills/codebase-audit/references/do-not-refile.md
@@ -104,3 +104,19 @@ add it here with the reason. This ledger is what keeps repeat audits quiet and f
 - **`ProcessLock` assigning `X-WOPI-ItemVersion = file.Version` unconditionally is fine.** Assigning
   a null string to `Headers[...]` yields `StringValues.Empty`, which suppresses the header — no need
   to null-guard it the way `GetFile` does.
+
+## Verified this run (added 2026-06-15)
+
+- **CA2007 / CA1707 / CA1056 disabled in the root `.editorconfig` are deliberately re-enabled at
+  `warning` for `src/` via `src/.editorconfig`.** The root disables them so sample/test/infra stay
+  quiet; `src/.editorconfig` turns them back on so packaged libraries ARE held to
+  `ConfigureAwait(false)`, underscore-free public names, and `Uri`-typed URL properties. Don't
+  re-file "CA2007 disabled globally → library code missing ConfigureAwait" — the split is intentional
+  and the analyzer enforces it in `src/` (warnings-as-errors makes a genuine miss a build break).
+- **`CobaltSession.cs` `catch (Exception)` in the faulted-session-cache path is correct.** It evicts
+  the faulted `Lazy<Task<>>` entry (race-safe KeyValuePair overload), logs, and `throw;` — a fail-safe
+  rethrow that prevents a permanently-cached faulted task, not a swallow. The mechanical scan flags
+  it; interpret, don't file.
+- **Azure provider scans lazily (`EnsureInitializedAsync`) where the FS provider scans in its
+  constructor.** Acceptable design difference — the Azure scan is async network I/O that can't run in
+  a ctor. Not sibling drift.

--- a/.claude/skills/codebase-audit/references/playbook.md
+++ b/.claude/skills/codebase-audit/references/playbook.md
@@ -67,9 +67,3 @@ new candidate out, add it there with the reason — that's what stops the next r
   client-controlled name/id and confirm they ALL run the same guard — an intra-class omission is as
   real as a cross-provider one. Cross-reference the test suite: "FS has this test, the twin doesn't"
   often points straight at an unguarded path.
-- **Environment: no .NET toolchain in the web-session sandbox.** `dotnet`/`msbuild` aren't installed
-  and the install host is network-blocked, so a run here cannot build or run tests locally — CI on
-  the PR is the validation gate. Edit precisely (warnings-as-errors + analyzers bite) by modelling
-  every change on an existing sibling, verify referenced symbols by reading source, and state in the
-  PR that CI is the gate. The doc-fetch (`fetch-wiki.sh`) is likewise network-blocked here, so the
-  wiki can't be verified in-session — note it as a coverage gap.

--- a/.claude/skills/codebase-audit/references/playbook.md
+++ b/.claude/skills/codebase-audit/references/playbook.md
@@ -55,3 +55,21 @@ Read them in context before filing:
 
 The running list of investigated-and-rejected items lives in `do-not-refile.md`. When a run rules a
 new candidate out, add it there with the reason — that's what stops the next run re-investigating it.
+
+## Added 2026-06-15
+
+- **Diff a provider's OWN mutation methods against each other — not just against its sibling
+  provider.** The Azure create-name path-traversal backstop gap (`CreateWopiChildFile`/
+  `CreateWopiChildContainer` omitted the `CheckValidFileName`/`CheckValidContainerName` guard that the
+  same class's `RenameWopiFile`/`RenameWopiContainer` and `GetSuggestedName*` all apply) was missed by
+  a sibling-*provider* diff but caught from the test-coverage angle (the FS provider had the
+  rejection test; Azure didn't). Generalize: for each provider, list every method that takes a
+  client-controlled name/id and confirm they ALL run the same guard — an intra-class omission is as
+  real as a cross-provider one. Cross-reference the test suite: "FS has this test, the twin doesn't"
+  often points straight at an unguarded path.
+- **Environment: no .NET toolchain in the web-session sandbox.** `dotnet`/`msbuild` aren't installed
+  and the install host is network-blocked, so a run here cannot build or run tests locally — CI on
+  the PR is the validation gate. Edit precisely (warnings-as-errors + analyzers bite) by modelling
+  every change on an existing sibling, verify referenced symbols by reading source, and state in the
+  PR that CI is the gate. The doc-fetch (`fetch-wiki.sh`) is likewise network-blocked here, so the
+  wiki can't be verified in-session — note it as a coverage gap.

--- a/.claude/skills/security-audit/SKILL.md
+++ b/.claude/skills/security-audit/SKILL.md
@@ -100,7 +100,8 @@ next run doesn't re-investigate it.
 Walk the threat model; don't grep blindly. Breadth comes from covering every boundary, depth from
 proving reachability on the ones that matter.
 
-1. **Mechanical security scan.** Run `scripts/security-scan.sh` from the repo root. It greps the
+1. **Mechanical security scan.** Run `.claude/skills/security-audit/scripts/security-scan.sh` (it
+   `cd`s to the repo root itself via `git rev-parse --show-toplevel`, so it works from anywhere). It greps the
    stable security-relevant patterns (broad `catch`, `Enum.Parse` on input, `==`/`SequenceEqual`
    near "proof"/"token"/"hmac", `new Random(`, `postMessage(...,'*')`, `ValidateIssuer=false` &
    friends, secrets near `Log`, `DtdProcessing`/`XmlResolver`, `Path.Combine` with non-rooted input,
@@ -205,7 +206,8 @@ sharper, or quieter, write it back into the skill's files — then commit. Captu
   with the reachability reason, so it isn't re-investigated.
 - **A technique that found (or would have found) a real issue** → add it to `references/threat-model.md`
   under the relevant boundary (e.g. "diff sibling providers for an omitted guard").
-- **A lead category the mechanical scan kept mis-firing on** → refine `scripts/security-scan.sh` and
+- **A lead category the mechanical scan kept mis-firing on** → refine
+  `.claude/skills/security-audit/scripts/security-scan.sh` and
   note it in the threat model's "noisy leads."
 - **A new attack class** not yet covered → add a boundary/dimension to `references/threat-model.md`.
 - **A finding you fixed this session** → note the resolving PR/commit next to the item.

--- a/.claude/skills/security-audit/SKILL.md
+++ b/.claude/skills/security-audit/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: security-audit
+description: >-
+  Run a repeatable, threat-model-driven security audit of the WopiHost codebase and produce a
+  tracker-ready findings report. Use this whenever the user wants a security-focused sweep — a
+  WOPI threat-model review, "is this safe to ship", token/JWT and WOPI-proof validation, access-token
+  scoping and authorization-bypass, path traversal in a storage provider, secret handling (keys,
+  tokens, proof headers in logs), constant-time comparison, weak randomness, postMessage / origin
+  validation, XXE in discovery-XML parsing, dependency CVEs, dev-only escape hatches, or info
+  disclosure. Trigger on phrasings like "security audit", "security review", "threat model",
+  "pen-test the host", "check for auth bypass / path traversal / secret leakage", "is the token
+  handling safe", "harden the host", or "find security holes" — even when the user doesn't say the
+  word "audit". This is the security counterpart to `codebase-audit` (which is the broad
+  code-quality sweep); reach for this one when the lens is specifically security.
+---
+
+# Security audit
+
+A standing, repeatable **security** health-check for WopiHost — the security-specialized sibling of
+`codebase-audit`. Where that skill sweeps broad code quality, this one walks the WopiHost **threat
+model** boundary by boundary and holds each trust transition to a security bar. It reproduces the
+methodology behind this repo's prior security work (the proof-validation hardening, the per-resource
+token scoping, the path-traversal guards, the dev-only proof-disable gate) so the host stays safe
+across many runs — without re-flagging decisions already verified as intentional.
+
+## What makes this repeatable (read first)
+
+The single thing that keeps a recurring security audit useful instead of noisy is a **do-not-re-file
+ledger**: items earlier runs investigated and deliberately rejected as non-issues or accepted risk
+with a documented rationale. Every run MUST load it and suppress anything on it.
+
+1. Read `references/do-not-refile.md` — the verified-intentional / accepted-risk ledger. Treat each
+   entry as out-of-bounds unless the surrounding code has materially changed, in which case
+   re-verify before resurfacing.
+2. Read `references/threat-model.md` — the WopiHost trust boundaries, attacker model, and the
+   per-dimension security checklist with the concrete patterns that have genuinely been wrong (or
+   genuinely right) here. This is the skill's how-to-look memory.
+3. Read the root `CLAUDE.md` — several "smells" are documented security conventions (the dev-only
+   `DisableProofValidation` flag that throws outside Development, the action-scoped `wopi:fperms`
+   token rule, the SHA-256 id scheme, the per-OS path canonicalization). Findings are measured
+   against these.
+4. Check open issues/PRs and the repo's `SECURITY.md` / security issue template so a finding
+   cross-references an existing tracker rather than duplicating it.
+
+Then run the scan, verify each lead by building the concrete attack, and report.
+
+## The bar: a real security win, proven — never a hypothetical
+
+A security finding ships only if it is **a concrete weakness an attacker (or a careless caller)
+could exploit, or a real defense-in-depth gap on a trust boundary**, verified against the source —
+not a generic "could be hardened." Apply this test before filing:
+
+> Can I name the actor, the entry point, the input, and the impact? Is there a path from
+> attacker-controlled data to the bad outcome that the current code does **not** already block?
+
+If the honest answer is "the framework already blocks this," "nothing untrusted reaches here," "the
+upstream layer already validates," or "this is theoretical with no reachable path," **drop it** — or,
+if it's a meaningful belt-and-suspenders gap on a security boundary (a shipped library with no
+backstop, a guard one sibling applies and another doesn't), file it at the right (usually Medium)
+severity and **say explicitly why it isn't directly exploitable**. Honesty about reachability is the
+whole game: a security report that cries wolf trains the maintainer to ignore it. A tight list of
+true issues, each with a named attack path, is the goal.
+
+**Reachability is mandatory.** For every candidate, trace the data flow from the trust boundary to
+the sink. WopiHost's endpoints validate a lot up front (token auth, name sanitisation in the
+endpoint layer before the provider, proof on mutation) — so a provider-level "missing check" is
+often already covered on the HTTP path and is only a *library-consumer* / defense-in-depth issue.
+Distinguish the two; never imply direct exploitability you didn't trace.
+
+### Do NOT file — security anti-findings
+
+These make the report worse, not safer. Each has a real reason it's not a finding here.
+
+- **Constant-time comparison of a non-secret.** WOPI **lock ids are opaque client-chosen
+  identifiers, not secrets** — comparing them with `==`/`Ordinal` is correct, not a timing channel.
+  Constant-time matters only for proof signatures / HMACs / tokens / keys (and WOPI proof uses RSA
+  signature *verification*, not a secret-byte compare, so it doesn't apply there either).
+- **"Disable the dev escape hatch."** `Wopi:Security:DisableProofValidation` is dev-only **and already
+  throws on startup outside Development** — that is the correct design (Collabora can't sign), not a
+  hole. Only a finding if the throw-outside-Development guard is *missing*.
+- **XXE on discovery XML.** `XElement.Load`/`Parse` on modern .NET default to `DtdProcessing.Prohibit`
+  with no external resolver, so DTD/external-entity expansion is already disabled by the platform —
+  and the discovery endpoint is a host-trusted WOPI client, not arbitrary input. Don't file unless an
+  `XmlReaderSettings`/`XmlResolver` is explicitly configured to *re-enable* it.
+- **Hardening with no reachable threat.** Adding rate limits, headers, or checks "for defense" where
+  no attacker path exists and nothing in the threat model calls for it — that's churn dressed as
+  security.
+- **Re-flagging accepted, documented risk.** The sample frontends' anonymous access, the in-memory
+  single-process lock provider's lack of cross-instance exclusion, the FS provider's "sample
+  purposes only" TOCTOU — all documented trade-offs. Check the ledger.
+- **Weak-RNG false alarms.** `Guid.NewGuid()` for a *non-security* value (a fallback file-name stem,
+  a per-test container name) is fine; only flag `System.Random`/`Guid` minting something that must be
+  *unguessable* (token, nonce, signing key — those already use `RandomNumberGenerator`).
+
+When a candidate matches one of these, record it in the do-not-re-file section with the reason so the
+next run doesn't re-investigate it.
+
+## Method
+
+Walk the threat model; don't grep blindly. Breadth comes from covering every boundary, depth from
+proving reachability on the ones that matter.
+
+1. **Mechanical security scan.** Run `scripts/security-scan.sh` from the repo root. It greps the
+   stable security-relevant patterns (broad `catch`, `Enum.Parse` on input, `==`/`SequenceEqual`
+   near "proof"/"token"/"hmac", `new Random(`, `postMessage(...,'*')`, `ValidateIssuer=false` &
+   friends, secrets near `Log`, `DtdProcessing`/`XmlResolver`, `Path.Combine` with non-rooted input,
+   `DisableProofValidation`). These are **leads, not findings** — every one is read in context and
+   reachability-traced.
+
+2. **Boundary-by-boundary walk** (see `references/threat-model.md` for each boundary's checklist).
+   For each trust boundary — (a) WOPI client ↔ host (proof + token), (b) browser ↔ frontend
+   (origin/postMessage/token-in-URL), (c) host ↔ storage provider (path traversal / reserved names),
+   (d) host ↔ lock provider (atomicity / DoS), (e) host ↔ discovery (XML/HTTPS), (f) config & secrets
+   — enumerate the inputs that cross it and confirm the code validates/authorizes/escapes before the
+   sink. If subagents are available, fan out one reviewer per boundary; otherwise walk them in turn.
+   The **sibling-implementation diff** is high-yield here too: a guard one provider applies and a
+   twin omits is a likely real gap (this is how the Azure create-name path-traversal backstop gap was
+   found — FS guarded, Azure didn't).
+
+3. **Prove reachability, then apply the bar.** Open the file at each lead, trace attacker input →
+   sink, and decide: directly exploitable (High+), defense-in-depth/library-consumer gap (usually
+   Medium, say so), or already-blocked (drop). Mark survivors **[verified]** with the attack path.
+
+4. **Classify + anchor + attack path.** Every finding gets a severity, a boundary/dimension, a
+   `file:line`, the **named attack path** (actor → input → sink → impact), and a remediation. Lead
+   the report with the highest-severity, highest-confidence issues.
+
+## Severity
+
+Severity is exploitability × impact, security-framed:
+
+- **Critical** — remotely exploitable, unauthenticated or trivially authenticated, high impact:
+  auth bypass, signature/proof check that doesn't verify, arbitrary file read/write reachable from a
+  WOPI request, token forgery, secret exfiltration.
+- **High** — exploitable with some precondition (a specific config, an authenticated low-priv user),
+  high impact: path traversal reachable through an endpoint, a view token that grants write a real
+  client honors, JWT validation with a disabled check, a secret written to logs.
+- **Medium** — defense-in-depth gap on a security boundary, not directly exploitable through the
+  shipped surface (upstream already validates; a library-consumer-only path; a sibling-inconsistent
+  guard); or info disclosure of limited value. **State why it isn't directly exploitable.**
+- **Low** — hardening nicety with a plausible-but-narrow threat, or a security-relevant clarity/
+  consistency fix.
+
+When unsure between two levels, pick the lower and justify — under-claiming keeps trust; over-claiming
+burns it.
+
+## Output
+
+Produce a single markdown report, ready to paste into a (private, if Critical/High) security tracker
+issue. Use this structure:
+
+```
+## Security audit (<YYYY-MM-DD>)
+
+<one-line scope: boundaries walked, how many findings, headline.>
+
+### Critical
+- [ ] **<title>** **[verified]** — [`path:line`](path#Lline). **Attack path:** <actor → input → sink → impact>. <why it matters>. **Fix:** <remediation>.
+
+### High
+- [ ] ...
+
+### Medium
+- [ ] ... (each notes why it is *not* directly exploitable)
+
+### Low
+- [ ] ...
+
+---
+
+### Threat-model coverage
+| Boundary | Walked | Notes (what was verified safe) |
+|---|---|---|
+| WOPI client ↔ host (proof/token) | ✅ | |
+| Browser ↔ frontend (origin/token) | ✅ | |
+| Host ↔ storage (path traversal) | ✅ | |
+| Host ↔ lock (atomicity/DoS) | ✅ | |
+| Host ↔ discovery (XML/HTTPS) | ✅ | |
+| Config & secrets | ✅ | |
+
+---
+
+### Do not re-file (verified non-issues / accepted risk)
+<Carry forward every entry from references/do-not-refile.md, PLUS any new candidate this run
+investigated and rejected, each with the reason. This regenerated section is what the next run folds
+back into the ledger.>
+```
+
+Rules for the report:
+- Phrase each finding in third person, concrete, with the attack path spelled out — no vague "could
+  be insecure."
+- Reference `file:line` with a real, confirmed anchor; never invent line numbers.
+- For Medium/Low, explicitly state the reachability limit (what already blocks direct exploitation).
+- Cross-reference existing issues/PRs and `SECURITY.md` when a finding is already tracked.
+- **Disclosure discipline:** if a Critical/High is genuinely exploitable, recommend a *private*
+  channel (the repo's security policy / a draft advisory) rather than a public issue, and keep the
+  public-facing writeup free of a working exploit.
+
+## Self-improvement (do this at the end of every run)
+
+This skill sharpens each run. Whenever a run teaches you something that makes the next one faster,
+sharper, or quieter, write it back into the skill's files — then commit. Capture, specifically:
+
+- **A candidate that turned out a non-issue / accepted risk** → add it to `references/do-not-refile.md`
+  with the reachability reason, so it isn't re-investigated.
+- **A technique that found (or would have found) a real issue** → add it to `references/threat-model.md`
+  under the relevant boundary (e.g. "diff sibling providers for an omitted guard").
+- **A lead category the mechanical scan kept mis-firing on** → refine `scripts/security-scan.sh` and
+  note it in the threat model's "noisy leads."
+- **A new attack class** not yet covered → add a boundary/dimension to `references/threat-model.md`.
+- **A finding you fixed this session** → note the resolving PR/commit next to the item.
+
+Keep these files lean and true — a bloated ledger is as useless as an empty one. When you commit
+skill updates, say what the run taught.

--- a/.claude/skills/security-audit/references/do-not-refile.md
+++ b/.claude/skills/security-audit/references/do-not-refile.md
@@ -1,0 +1,86 @@
+# Do not re-file — verified non-issues & accepted risk (security)
+
+Every entry here was investigated by a security run (or a focused fix) and **deliberately rejected**:
+either it's not reachable, the framework already blocks it, or it's a documented accepted risk. A new
+run treats these as out-of-bounds and must not re-file them — unless the surrounding code has
+materially changed, in which case re-verify before resurfacing. Keep it current: when a run rules a
+new candidate out, add it here with the reachability reason.
+
+## Authentication / proof
+
+- **WOPI proof validation uses RSA signature verification, not a secret-byte compare** — so
+  constant-time comparison does not apply. `WopiProofValidator` calls `RSACryptoServiceProvider.
+  VerifyData`; there is no `==`/`SequenceEqual` of a secret to make constant-time.
+- **`RSACryptoServiceProvider` / `ImportCspBlob` / `ExportCspBlob` are required and safe.** The WOPI
+  proof byte layout mandates the CSP-blob key format; these members are cross-platform in modern .NET
+  (production `WopiProofValidator` and the existing proof tests use them ungated under warnings-as-
+  errors). Not a CA1416 or platform-security issue.
+- **`catch (Exception)` in `WopiProofValidator.ValidateProofAsync` is correct fail-closed.** It's
+  filtered `when (!IsCriticalUnwindException(ex))` (OOM/SO/ThreadAbort rethrow) and returns `false`
+  (deny) on everything else — exactly what a security gate should do.
+- **The loose resource-id ↔ token binding in `WopiAuthorizationHandler` is intentional.** A single
+  WOPI token legitimately navigates from a file to its ancestor container / siblings (the protocol
+  and the MS validator rely on it); a strict per-resource bind would break it. The id is logged on
+  mismatch for audit. The *permission* gate still fires — that's the real control.
+
+## Authorization / tokens
+
+- **Lock ids and resource ids are not secrets.** Comparing them with `==`/`Ordinal` is correct; they
+  are opaque client-chosen identifiers, not credentials — no timing side-channel.
+- **`Guid.NewGuid()` for non-security values is fine.** The fallback file/container-name stems
+  (`ContainerMutatingEndpoints`) and per-test container names are not tokens/nonces; only flag `Guid`/
+  `System.Random` when the value must be unguessable. The dev signing key already uses
+  `RandomNumberGenerator.GetBytes`.
+
+## Input validation / storage
+
+- **FS provider path traversal is guarded.** `CreateWopiChildFile`/`Rename*` reject non-single-
+  segment names via `CheckValidFileName`/`IsValidSingleSegmentName` (`.`/`..`/separators/invalid
+  chars), and the endpoint layer validates the name before the provider. No re-rooting gap.
+- **Azure provider id scheme hashes the path as-is (case-sensitive).** This is correct (Azure blob
+  names are case-sensitive); the FS provider case-folds because Win/macOS filesystems are case-
+  insensitive. The divergence is intentional, not an injection/confusion bug.
+
+## XML / transport
+
+- **Discovery XML parsing is not XXE-exposed.** `XElement.Load`/`Parse` default to
+  `DtdProcessing.Prohibit` with no external `XmlResolver` on modern .NET, so DTD/external-entity
+  expansion is already disabled; the discovery doc is a host-trusted client. Only a finding if an
+  `XmlReaderSettings`/`XmlResolver` is explicitly configured to re-enable it.
+- **Proof-key is read from the discovery-document root, net-zone-independent — intentional.** Real
+  OOS/M365 docs put `<proof-key>` as a root sibling of `<net-zone>`; scoping it under the selected
+  zone would break proof validation. Pinned by a test; do not "fix" the root lookup.
+
+## Config & secrets
+
+- **`Wopi:Security:DisableProofValidation` is a dev-only flag and is guarded.** It swaps in a no-op
+  proof validator for clients (Collabora) that can't sign, and **throws on startup outside
+  Development** (`sample/WopiHost/Program.cs`). Correct design — only a finding if that guard is
+  removed.
+- **The sample frontends' anonymous access is an accepted, documented model.** They're samples; the
+  security invariant that *does* apply is action-scoped token minting (a view link must not mint
+  write) — that is enforced and tested, not waived.
+
+## Accepted-risk (documented design trade-offs)
+
+- **`MemoryLockProvider` is single-process** — no cross-instance exclusion by design; use the Azure/
+  Redis providers for distributed deployments. Not a security finding.
+- **The file-system provider is "for sample purposes"** and carries a benign local-disk TOCTOU
+  (`File.Exists` → mutate). Documented; the Azure provider uses conditional ETag/lease writes.
+
+## Verified this run (added 2026-06-15)
+
+- **`PutUserInfo` carries no `RequireWopiPermission` — and that's fine.** Every endpoint under the
+  `/wopi` group inherits the group-level `.RequireAuthorization()` (`WopiEndpointRouteBuilderExtensions`),
+  so PutUserInfo still requires an authenticated token (anonymous → 401). PUT_USER_INFO is not
+  permission-gated in the WOPI spec, it writes only the caller's own info to MemoryCache (capped 1024
+  bytes), and `Permission.Read` is implied for any valid token anyway — so a per-endpoint permission
+  would be cosmetic, not a control. Not an authz gap.
+- **The Validator's `IssueValidatorToken` mints a full file+container token deliberately.** It's the
+  Microsoft-WOPI-validator conformance harness (the `/_test` token route), which uses one token to
+  exercise every operation; there is no view-vs-edit action to scope by. Distinct from the Validator's
+  user-facing `HostPage` (which has a `WopiAction` and was scoped this run). Not a token-over-scoping
+  finding.
+- **`wopi-postmessage.js` validates the inbound origin.** `onMessage` short-circuits on
+  `e.origin !== clientOrigin`, and `send` posts to the configured `clientOrigin` (never `'*'`). Both
+  directions of the postMessage channel are origin-checked. Safe.

--- a/.claude/skills/security-audit/references/threat-model.md
+++ b/.claude/skills/security-audit/references/threat-model.md
@@ -1,0 +1,152 @@
+# WopiHost threat model & security checklist
+
+The boundaries each security run walks, the attacker model, and the concrete per-boundary checks —
+drawn from this repo's real security-relevant code so a run knows where the sharp edges are. Every
+candidate still needs source verification, a `file:line` anchor, and a traced attack path.
+
+## Attacker model
+
+A WopiHost deployment sits between three actors, each a distinct trust level:
+
+- **The WOPI client** (Office for the web / M365, Collabora, ONLYOFFICE) — semi-trusted. It is
+  authenticated by the **access token** it presents and (for mutation) by the **X-WOPI-Proof**
+  signature. A malicious or compromised client, or an attacker who can replay/forge a request, is in
+  scope: the host must not let a token do more than it was scoped for, must verify proof signatures,
+  and must treat every client-supplied id / target name / header as untrusted input.
+- **The browser user** of the sample frontends — semi-trusted. Drives the host pages; receives an
+  access token in a URL; exchanges `postMessage` with the embedded client iframe. In scope: token
+  over-scoping (a view link minting write), `postMessage` to/from the wrong origin, token leakage.
+- **The host operator / config** — trusted, but fallible. In scope: a dev-only escape hatch reaching
+  production, an insecure default, a secret committed or logged.
+
+Out of scope (documented accepted risk — see the ledger): the sample frontends' anonymous access
+model, the single-process MemoryLockProvider's lack of cross-instance exclusion, and the FS
+provider's "sample purposes only" local-disk TOCTOU.
+
+## Boundary 1 — WOPI client ↔ host: token & proof
+
+The load-bearing authentication boundary. Two independent mechanisms.
+
+- **Access-token validation (JWT).** `TokenValidationParameters` must validate signature + lifetime,
+  and issuer/audience when configured. A disabled check (`ValidateIssuer=false`,
+  `ValidateLifetime=false`, `RequireSignedTokens=false`, `SignatureValidator` that returns without
+  verifying) is a finding. The ephemeral dev signing key must come from `RandomNumberGenerator`, not
+  `Guid`/`Random`. Verify `JwtAccessTokenService` and `AccessTokenHandler`.
+- **Proof validation (X-WOPI-Proof).** On mutation the host verifies the client's RSA signature over
+  the spec's byte layout (access token + URL + timestamp) using the **discovery** proof keys
+  (current + old, for rotation). Checks: the signature is actually *verified* (RSA `VerifyData`, not
+  skipped); both current and old keys are tried; the timestamp is range-checked against replay; the
+  failure path **fails closed** (returns false / 401) and filters only async-rude exceptions
+  (OOM/SO/ThreadAbort rethrow). This is **not** a secret-byte compare — constant-time does not apply.
+  Verify `WopiProofValidator`.
+- **Authorization — permission scoping.** Every mutating endpoint carries
+  `RequireWopiPermission(resourceType, Permission.*)`; the handler maps the token's `wopi:fperms` /
+  `wopi:cperms` flags to the required permission and **fails closed** (an authenticated-but-
+  unauthorized token → 403, not 401). Checks: a `ReadOnly` token is denied every edit permission; no
+  endpoint that mutates is missing its `RequireWopiPermission`; `Read` is the only implied grant.
+- **Token-trading prevention.** A freshly minted child / relative / ancestor resource gets a token
+  **bound to the new resource id** (via `IWopiResourceTokenMinter`), never the inbound token — so a
+  client can't trade a token for one scoped to a resource it shouldn't reach.
+- **Technique that pays off:** the resource-binding is *intentionally* loose (one token navigates
+  file→ancestors), documented in `WopiAuthorizationHandler` — don't file that as a missing check; do
+  confirm the *permission* gate still fires.
+
+## Boundary 2 — browser ↔ frontend: origin, postMessage, token-in-URL
+
+- **`postMessage` target origin.** The host page must post to the **configured client origin**, never
+  `'*'`, and must **verify `event.origin`** on inbound messages. A wildcard target leaks the access
+  token to any origin that ends up framed; an unchecked inbound origin lets any page drive the host.
+  Verify the extracted postMessage module in `sample/WopiHost.Web` and any host page.
+- **Token scoping by action (the invisible one).** A **view** link must not mint a token carrying
+  `UserCanWrite`/`UserCanRename`. Collabora derives view-vs-edit from CheckFileInfo permission flags
+  off a single URL, so an over-permissive token silently opens edit mode — invisible against OOS/M365
+  (which ship distinct view/edit URLs). Check **every** token-mint site in all three sample frontends
+  (`WopiHost.Web`, `WopiHost.Web.Oidc`, `WopiHost.Validator`): non-edit actions strip write+rename,
+  keep interaction-only flags (Attend/Present). This is a real, recurring finding here.
+- **Info disclosure.** Developer exception pages / stack traces gated behind `IsDevelopment()`; no
+  token or proof header echoed into HTML or logs.
+
+## Boundary 3 — host ↔ storage provider: path traversal & reserved names
+
+The highest-impact class for the FS provider; a flat-namespace variant for Azure.
+
+- **FS path traversal (potential arbitrary read/write).** A client-controlled relative/suggested
+  target or id that resolves outside the configured root (`..`, absolute path, UNC, alternate data
+  stream). Confirm the provider rejects non-single-segment names (`CheckValidFileName` /
+  `IsValidSingleSegmentName`) **and/or** canonicalises + re-roots (`Path.GetFullPath` +
+  `StartsWith(root)`) before any `File.*`/`Directory.*`. The endpoint layer also validates the name
+  *before* the provider — so trace both layers and state which one blocks it.
+- **Azure flat-namespace variant (lower impact, real gap).** Azure blob names are flat: `..` is a
+  literal, so there's no container escape — but an unguarded `name` still lets a client create a blob
+  at an unintended nested path or collide with the reserved folder marker (`.wopi.folder`). The guard
+  is the same `CheckValidFileName`/`CheckValidContainerName`. **Sibling-diff technique:** a guard the
+  FS provider applies and Azure omits (or that one Azure method applies and its twin doesn't) is a
+  likely finding — this is exactly how the Azure `CreateWopiChild*` backstop gap surfaced.
+- **Reachability note:** because the endpoint layer sanitises first, a provider-level miss is usually
+  a *defense-in-depth / library-consumer* gap (Medium), not direct RCE — say so explicitly.
+
+## Boundary 4 — host ↔ lock provider: atomicity & DoS
+
+- **Lock atomicity (correctness/integrity).** RefreshLock / UnlockAndRelock must be a true
+  compare-and-swap **inside** the provider (ConcurrentDictionary.TryUpdate / ETag- or lease-
+  conditional write / Redis WATCH-MULTI-EXEC), not a check-then-act in the endpoint — a race lets one
+  client steal/extend another's lock. Verify all three providers.
+- **Lock ids are NOT secrets.** They're opaque client-chosen identifiers — `==`/`Ordinal` comparison
+  is correct, not a timing channel. Do not file constant-time-compare on lock ids.
+- **DoS / exhaustion.** Locks auto-expire (spec 30 min) so a crashed client can't wedge a file
+  forever; expiry is enforced on read. A `MaxFileSize` bounds PutFile. Note (don't file) that the
+  in-memory provider is single-process by design.
+
+## Boundary 5 — host ↔ discovery: XML & transport
+
+- **XXE / DTD.** `XElement.Load`/`Parse` on modern .NET default to `DtdProcessing.Prohibit` with no
+  external resolver, so external-entity expansion is already off — **only** a finding if an
+  `XmlReaderSettings`/`XmlResolver` is explicitly set to re-enable DTD/entity resolution. The
+  discovery endpoint is also a host-trusted client.
+- **Transport.** Discovery and client URLs should be HTTPS in production; the discovery cache honours
+  the configured NetZone. The proof-key element is read from the document root (net-zone-independent)
+  — pin that invariant in tests, don't "fix" it.
+
+## Boundary 6 — config & secrets
+
+- **Dev-only escape hatches refused in production.** `Wopi:Security:DisableProofValidation` swaps in a
+  no-op proof validator and **must throw on startup outside Development**. Confirm the guard exists;
+  its presence is correct design, not a hole.
+- **Secrets never logged or thrown.** Access tokens, signing/proof keys, `Authorization` /
+  `X-WOPI-Proof` header values, file contents — never passed to `ILogger` or an exception message.
+  Lock ids and resource ids are not secrets (fine to log).
+- **Weak randomness only for security values.** `RandomNumberGenerator` for tokens/nonces/keys;
+  `Guid.NewGuid()` is fine for a non-security value (a fallback file-name stem, a test container).
+- **Secure defaults.** `DefaultFilePermissions`/`DefaultContainerPermissions` and any
+  `Validate*=false` default scrutinised; a dependency CVE (`NU1903`/`NU1901`) is a supply-chain
+  finding.
+
+## Noisy leads — interpret, don't auto-file
+
+The mechanical scan casts wide; these are mostly false positives here (mirror of `codebase-audit`'s
+list, security-framed):
+
+- `==`/`SequenceEqual`/`string.Equals` **on a lock id or resource id** — not secrets, not a timing
+  channel.
+- `catch (Exception)` in `WopiProofValidator` / telemetry filter — already filtered with a `when
+  (!IsCritical…)` and fails closed; read the filter before filing.
+- `Guid.NewGuid()` — only a finding if it mints something that must be unguessable; the name-stem and
+  per-test-container uses are fine.
+- `RSACryptoServiceProvider` / `ImportCspBlob` — required for the WOPI proof byte layout; cross-
+  platform in modern .NET; not a CA1416/security issue.
+- `DisableProofValidation` hits — the flag is dev-only *and guarded*; only a finding if the
+  throw-outside-Development guard is gone.
+- `XElement.Load`/`Parse` — XXE is off by platform default; not a finding absent an explicit resolver.
+
+## Techniques that pay off here
+
+- **Sibling-provider guard diff.** Diff the FS vs Azure storage providers (and a provider's own
+  create vs rename methods) for a validation guard one applies and another omits — the Azure
+  `CreateWopiChild*` path-traversal backstop gap was found this way.
+- **Trace endpoint → provider for every client-supplied name/id.** The endpoint layer validates a lot
+  up front; a provider "miss" is often already blocked there. Decide direct-exploit vs defense-in-
+  depth and state which.
+- **Walk each WOPI mutation's auth metadata.** Grep `RequireWopiPermission` and confirm every
+  mutating route carries one and maps to the right `Permission.*` — a missing one is an authz bypass.
+- **Token-mint sweep across the three frontends.** Grep every place a token is minted; confirm
+  non-edit actions strip write/rename. Recurring real finding.

--- a/.claude/skills/security-audit/scripts/security-scan.sh
+++ b/.claude/skills/security-audit/scripts/security-scan.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Mechanical SECURITY scan for the security-audit skill.
+#
+# Prints file:line LEADS for the stable, security-relevant patterns — NOT findings. Every hit must
+# be read in context AND reachability-traced (attacker input → sink) before it earns a place in the
+# report. Many are false positives here; cross-check references/do-not-refile.md and the threat
+# model's "noisy leads". Run from the repo root. Prefers ripgrep (rg); falls back to grep.
+
+set -u
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" || exit 1
+
+if command -v rg >/dev/null 2>&1; then
+  GLOBS=(-g '!**/artifacts/**' -g '!**/bin/**' -g '!**/obj/**' -g '!**/*.g.cs')
+  scan() { rg -n --no-heading "${GLOBS[@]}" "$@" 2>/dev/null; }
+else
+  scan() { grep -rnE --include='*.cs' --exclude-dir={artifacts,bin,obj} "$@" 2>/dev/null | grep -v '\.g\.cs:'; }
+fi
+section() { printf '\n========== %s ==========\n' "$1"; }
+
+section "JWT validation disabled (issuer/audience/lifetime/signature) — must all validate"
+scan -t cs 'Validate(Issuer|Audience|Lifetime|IssuerSigningKey)[[:space:]]*=[[:space:]]*false|RequireSignedTokens[[:space:]]*=[[:space:]]*false|RequireExpirationTime[[:space:]]*=[[:space:]]*false|SignatureValidator[[:space:]]*=' src sample
+
+section "Possible non-constant-time compare near a SECRET (proof/token/hmac/signature/key) — NOT lock/resource ids"
+scan -t cs -i '(proof|token|hmac|signature|secret|signing).{0,40}(==|!=|\.Equals\(|SequenceEqual)|(==|!=|\.Equals\(|SequenceEqual).{0,40}(proof|token|hmac|signature|secret|signing)' src
+
+section "Weak RNG for security values (System.Random / Guid for token/nonce/key) — verify it's a security value"
+scan -t cs 'new Random\(|Guid\.NewGuid\(\)|Random\.Shared' src sample
+
+section "Secrets possibly written to logs/exceptions (token/proof/key/Authorization near Log*/Exception)"
+scan -t cs -i '(Log[A-Za-z]*|Exception)\(.{0,60}(token|proof|signingkey|authorization|x-wopi-proof)|(token|proof|signingkey|authorization)\b.{0,40}(Log[A-Za-z]*\()' src sample
+
+section "XML parsing — XXE/DTD only if a resolver/DtdProcessing is explicitly enabled"
+scan -t cs 'DtdProcessing|XmlResolver|XmlUrlResolver|XmlReaderSettings' src sample
+
+section "Wildcard postMessage target origin (token leak) — host pages"
+if command -v rg >/dev/null 2>&1; then
+  rg -n --no-heading -g '!**/bin/**' -g '!**/obj/**' "postMessage\([^)]*['\"]\*['\"]" sample 2>/dev/null
+else
+  grep -rnE "postMessage\([^)]*['\"]\*['\"]" sample --exclude-dir={bin,obj} 2>/dev/null
+fi
+
+section "Inbound postMessage without an origin check (grep handlers; verify event.origin is validated)"
+if command -v rg >/dev/null 2>&1; then
+  rg -n --no-heading -g '!**/bin/**' -g '!**/obj/**' "addEventListener\(\s*['\"]message|onmessage" sample 2>/dev/null
+else
+  grep -rnE "addEventListener\(\s*['\"]message|onmessage" sample --exclude-dir={bin,obj} 2>/dev/null
+fi
+
+section "Token mint sites — confirm non-Edit actions strip UserCanWrite/UserCanRename (view-token scoping)"
+scan -t cs -i 'FilePermissions[[:space:]]*=|GetFilePermissionsAsync|UserCanWrite|UserCanRename|Mint.*Token|IssueAsync' sample
+
+section "Mutating endpoints — every one needs RequireWopiPermission (grep both to cross-check for a missing gate)"
+scan -t cs 'MapPost|MapPut|MapDelete|RequireWopiPermission' src/WopiHost.Core/Endpoints
+
+section "Path composition from a (possibly client-controlled) name/target — confirm a single-segment guard precedes it"
+scan -t cs 'Path\.Combine\(|GetBlobClient\(|\+[[:space:]]*"/"[[:space:]]*\+[[:space:]]*name|parentPath[[:space:]]*\+' src
+
+section "Dev-only proof-validation disable — confirm it throws outside Development"
+scan -t cs -i 'DisableProofValidation|IsDevelopment|NoopProofValidator|disable.*proof' src sample
+
+section "Stack-trace / detailed-error exposure — must be gated behind IsDevelopment()"
+scan -t cs -i 'UseDeveloperExceptionPage|\.StackTrace|ex\.ToString\(\)|DeveloperExceptionPage' src sample
+
+section "Dependency CVE suppressions / pins (verify the pin is to a patched version)"
+if command -v rg >/dev/null 2>&1; then
+  rg -n --no-heading 'NU1903|NU1901|NU1902|VulnerablePackage' Directory.Packages.props Directory.Build.props 2>/dev/null
+else
+  grep -rnE 'NU1903|NU1901|NU1902|VulnerablePackage' Directory.Packages.props Directory.Build.props 2>/dev/null
+fi
+
+printf '\n--- end of security scan. These are LEADS; trace attacker input -> sink and apply the bar. ---\n'

--- a/sample/README.md
+++ b/sample/README.md
@@ -28,7 +28,7 @@ Three runnable samples + a folder of test documents. The recommended way to laun
 
 | Key | Sample value | Purpose |
 |---|---|---|
-| `Wopi:HostUrl` | `"http://wopihost"` | Base URI of the backend (above). Used to construct WopiSrc URLs. AppHost overrides this to `http://host.docker.internal:5000` when `AppHost:UseCollabora=true`, so callbacks from the Collabora container resolve to the host machine. |
+| `Wopi:HostUrl` | `"http://wopihost"` | Base URI of the backend (above). Used to construct WopiSrc URLs. AppHost overrides this to `http://host.docker.internal:5050` when `AppHost:UseCollabora=true`, so callbacks from the Collabora container resolve to the host machine. |
 | `Wopi:ClientUrl` | `"https://ffc-onenote.officeapps.live.com"` | Base URI of the WOPI client. Used by the discovery cache. |
 | `Wopi:Discovery:NetZone` | `"ExternalHttps"` | Which discovery zone to read URL templates from. Values: see [`NetZoneEnum`](../src/WopiHost.Discovery/NetZoneEnum.cs). |
 | `Wopi:UiCulture` | (unset) | Optional IETF BCP 47 tag (e.g. `en-US`) for the `UI_LLCC` placeholder. Defaults to `CultureInfo.CurrentUICulture`. |
@@ -63,7 +63,7 @@ dotnet run --project src/WopiValidator/WopiValidator.csproj --framework net10.0 
   -l 0
 ```
 
-`28752` is the validator's [launchSettings](WopiHost.Validator/Properties/launchSettings.json) port for `dotnet run`. Under Aspire orchestration it is `7000` instead — adjust `-w` accordingly.
+`28752` is the validator's [launchSettings](WopiHost.Validator/Properties/launchSettings.json) port for `dotnet run`. Under Aspire orchestration the port is allocated dynamically (the validator is registered with `WithHttpsEndpoint()`); read it off the Aspire dashboard and adjust `-w` accordingly.
 
 ## Hosting in IIS / Docker
 

--- a/sample/WopiHost.Validator/Pages/HostPage.cshtml.cs
+++ b/sample/WopiHost.Validator/Pages/HostPage.cshtml.cs
@@ -49,6 +49,15 @@ public class HostPageModel(
         ], "validator"));
 
         var permissions = await permissionProvider.GetFilePermissionsAsync(hostUser, file, cancellationToken);
+
+        // Scope by the requested action: a "view" link must not mint a write-capable token. Collabora
+        // derives view-vs-edit from CheckFileInfo permission flags (single editor URL), so an
+        // over-permissive token silently opens edit mode; OOS / M365 distinct URLs would mask it.
+        if (WopiAction != WopiActionEnum.Edit)
+        {
+            permissions &= ~(WopiFilePermissions.UserCanWrite | WopiFilePermissions.UserCanRename);
+        }
+
         var token = await accessTokenService.IssueAsync(new WopiAccessTokenRequest
         {
             UserId = wopiOptions.Value.UserId,

--- a/src/WopiHost.AzureStorageProvider/WopiAzureStorageProvider.cs
+++ b/src/WopiHost.AzureStorageProvider/WopiAzureStorageProvider.cs
@@ -19,8 +19,9 @@ namespace WopiHost.AzureStorageProvider;
 /// freshly-created folders are addressable until something is written to them.
 /// </para>
 /// <para>
-/// Identifiers are deterministic hex-SHA-256 of the lowercased blob path (see <see cref="BlobIdMap"/>),
-/// matching the scheme used by <c>WopiHost.FileSystemProvider</c>. Identifiers are stable across
+/// Identifiers are deterministic hex-SHA-256 of the blob path hashed as-is (case-sensitive, because
+/// Azure blob names are; the file-system provider applies the same hash but case-folds — see
+/// <see cref="BlobIdMap"/>). Identifiers are stable across
 /// process restarts as long as paths don't change. A rename preserves the identifier by re-pointing
 /// the in-memory map to the new path.
 /// </para>
@@ -343,6 +344,13 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
     public async Task<IWopiWritableFile?> CreateWopiChildFile(string containerId, string name, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(containerId);
+        // The name is client-controlled (relative/suggested target); reject anything that isn't a
+        // single path segment before composing the blob path — the path-traversal / reserved-name
+        // guard the file-system provider and RenameWopiFile already apply.
+        if (!await CheckValidFileName(name, cancellationToken).ConfigureAwait(false))
+        {
+            throw new ArgumentException("Invalid characters in the name.", nameof(name));
+        }
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
         if (!_idMap.TryGetPath(containerId, out var parentPath))
         {
@@ -369,6 +377,13 @@ public partial class WopiAzureStorageProvider : IWopiStorageProvider, IWopiWrita
     public async Task<IWopiContainer?> CreateWopiChildContainer(string containerId, string name, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(containerId);
+        // The name is client-controlled; reject anything that isn't a single path segment before
+        // composing the blob prefix — the path-traversal / reserved-name guard RenameWopiContainer
+        // and the file-system provider already apply.
+        if (!await CheckValidContainerName(name, cancellationToken).ConfigureAwait(false))
+        {
+            throw new ArgumentException("Invalid characters in the name.", nameof(name));
+        }
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
         if (!_idMap.TryGetPath(containerId, out var parentPath))
         {

--- a/src/WopiHost.AzureStorageProvider/WopiBlobFile.cs
+++ b/src/WopiHost.AzureStorageProvider/WopiBlobFile.cs
@@ -16,7 +16,7 @@ namespace WopiHost.AzureStorageProvider;
 /// <see cref="WopiBlobFile"/> per request, which keeps cached state implicitly fresh.
 /// </para>
 /// <para>
-/// Identifiers are hex-SHA-256 of the lowercased blob path (see <see cref="BlobIdMap"/>). The blob's ETag is
+/// Identifiers are hex-SHA-256 of the blob path hashed as-is, case-sensitively (see <see cref="BlobIdMap"/>). The blob's ETag is
 /// surfaced as <see cref="Version"/>; this is more meaningful than a timestamp because every byte-level
 /// change produces a new ETag.
 /// </para>

--- a/src/WopiHost.Discovery/WopiDiscoverer.cs
+++ b/src/WopiHost.Discovery/WopiDiscoverer.cs
@@ -114,7 +114,7 @@ public partial class WopiDiscoverer : IDiscoverer, IDisposable
 
         var query = (await GetAppsAsync().ConfigureAwait(false)).Elements()
             .Where(e => string.Equals(e.Attribute(AttrActionExtension)?.Value, extension, StringComparison.OrdinalIgnoreCase) &&
-                e.Attribute(AttrActionName)?.Value.Equals(actionString, StringComparison.InvariantCultureIgnoreCase) == true);
+                e.Attribute(AttrActionName)?.Value.Equals(actionString, StringComparison.OrdinalIgnoreCase) == true);
 
         return query.Any();
     }
@@ -126,10 +126,10 @@ public partial class WopiDiscoverer : IDiscoverer, IDisposable
 
         var query = (await GetAppsAsync().ConfigureAwait(false)).Elements()
             .Where(e => string.Equals(e.Attribute(AttrActionExtension)?.Value, extension, StringComparison.OrdinalIgnoreCase) &&
-                e.Attribute(AttrActionName)?.Value.Equals(actionString, StringComparison.InvariantCultureIgnoreCase) == true)
+                e.Attribute(AttrActionName)?.Value.Equals(actionString, StringComparison.OrdinalIgnoreCase) == true)
             .Select(e => e.Attribute(AttrActionRequires)?.Value.Split(','));
 
-        return query?.FirstOrDefault() ?? [];
+        return query.FirstOrDefault() ?? [];
     }
 
     ///<inheritdoc />
@@ -138,7 +138,7 @@ public partial class WopiDiscoverer : IDiscoverer, IDisposable
         var actionString = action.ToString().ToUpperInvariant();
         var query = (await GetAppsAsync().ConfigureAwait(false)).Elements()
             .Where(e => string.Equals(e.Attribute(AttrActionExtension)?.Value, extension, StringComparison.OrdinalIgnoreCase) &&
-                e.Attribute(AttrActionName)?.Value.Equals(actionString, StringComparison.InvariantCultureIgnoreCase) == true)
+                e.Attribute(AttrActionName)?.Value.Equals(actionString, StringComparison.OrdinalIgnoreCase) == true)
             .Select(e => e.Attribute(AttrActionUrl)?.Value);
         return query.FirstOrDefault();
     }

--- a/src/WopiHost.MemoryLockProvider/MemoryLockProvider.cs
+++ b/src/WopiHost.MemoryLockProvider/MemoryLockProvider.cs
@@ -72,11 +72,21 @@ public partial class MemoryLockProvider : IWopiLockProvider
     /// <inheritdoc />
     public Task<WopiLockInfo?> AddLockAsync(string fileId, string lockId, CancellationToken cancellationToken = default)
     {
+        var now = _timeProvider.GetUtcNow();
+        // An expired-but-resident lock is contractually "no lock" (GetLockAsync evicts it), so drop a
+        // stale entry before TryAdd — otherwise it would spuriously reject a takeover that the Azure
+        // and Redis providers allow. The KeyValuePair overload removes only the exact stale record,
+        // leaving a concurrent acquire that already replaced it intact.
+        if (_locks.TryGetValue(fileId, out var stale) && stale.IsExpiredAt(now))
+        {
+            _ = _locks.TryRemove(new KeyValuePair<string, WopiLockInfo>(fileId, stale));
+        }
+
         var lockInfo = new WopiLockInfo
         {
             FileId = fileId,
             LockId = lockId,
-            DateCreated = _timeProvider.GetUtcNow(),
+            DateCreated = now,
         };
         if (_locks.TryAdd(fileId, lockInfo))
         {

--- a/src/WopiHost.MemoryLockProvider/README.md
+++ b/src/WopiHost.MemoryLockProvider/README.md
@@ -4,7 +4,7 @@
 [![NuGet](https://img.shields.io/nuget/dt/WopiHost.MemoryLockProvider.svg)](https://www.nuget.org/packages/WopiHost.MemoryLockProvider)
 
 Process-local in-memory implementation of [`IWopiLockProvider`](../WopiHost.Abstractions/IWopiLockProvider.cs).
-Backed by a static `ConcurrentDictionary<string, WopiLockInfo>`. Locks auto-expire after 30 minutes per the [WOPI spec](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/lock); expired entries are evicted on read.
+Backed by a static `ConcurrentDictionary<string, WopiLockInfo>`. Locks auto-expire after 30 minutes per the [WOPI spec](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/lock); expired entries are evicted lazily — on read, or when a new lock is added over an expired entry for the same file (a takeover, matching the Azure/Redis providers).
 
 Use it for development, single-instance hosts, and tests. **Don't** use it for multi-instance deployments — locks are not shared across processes and are lost on restart.
 

--- a/src/WopiHost.MemoryLockProvider/README.md
+++ b/src/WopiHost.MemoryLockProvider/README.md
@@ -4,7 +4,7 @@
 [![NuGet](https://img.shields.io/nuget/dt/WopiHost.MemoryLockProvider.svg)](https://www.nuget.org/packages/WopiHost.MemoryLockProvider)
 
 Process-local in-memory implementation of [`IWopiLockProvider`](../WopiHost.Abstractions/IWopiLockProvider.cs).
-Backed by a static `ConcurrentDictionary<string, WopiLockInfo>`. Locks auto-expire after 30 minutes per the [WOPI spec](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/lock); expired entries are evicted lazily — on read, or when a new lock is added over an expired entry for the same file (a takeover, matching the Azure/Redis providers).
+Backed by a per-instance `ConcurrentDictionary<string, WopiLockInfo>` that `AddMemoryLockProvider()` registers as a singleton, so there's one shared store per process. Locks auto-expire after 30 minutes per the [WOPI spec](https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/lock); expired entries are evicted lazily — on read, or when a new lock is added over an expired entry for the same file (a takeover, matching the Azure/Redis providers).
 
 Use it for development, single-instance hosts, and tests. **Don't** use it for multi-instance deployments — locks are not shared across processes and are lost on restart.
 

--- a/src/WopiHost.Url/WopiUrlBuilder.cs
+++ b/src/WopiHost.Url/WopiUrlBuilder.cs
@@ -24,7 +24,7 @@ public partial class WopiUrlBuilder(
     [GeneratedRegex("<(?<name>\\w*)=(?<value>\\w*)&*>")]
     private static partial Regex UrlParamRegex();
 
-    private readonly IDiscoverer _wopiDiscoverer = discoverer;
+    private readonly IDiscoverer _wopiDiscoverer = discoverer ?? throw new ArgumentNullException(nameof(discoverer));
     private readonly ILogger<WopiUrlBuilder> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
     /// <summary>

--- a/test/WopiHost.AzureStorageProvider.Tests/WopiAzureStorageProviderTests.cs
+++ b/test/WopiHost.AzureStorageProvider.Tests/WopiAzureStorageProviderTests.cs
@@ -258,6 +258,38 @@ public class WopiAzureStorageProviderTests(AzuriteFixture azurite)
         Assert.True(await provider.CheckValidFileName("my-file_2.docx"));
     }
 
+    [Theory]
+    [InlineData("../escape.txt")]
+    [InlineData("a/b.txt")]
+    [InlineData("..")]
+    [InlineData(".")]
+    [InlineData(BlobIdMap.FolderMarker)]
+    public async Task CreateWopiChildFile_TraversalOrReservedName_Throws(string name)
+    {
+        // The name is client-controlled (relative/suggested target); a name that isn't a single
+        // path segment must be rejected before it's composed into a blob path so it can't escape
+        // the container or collide with the reserved folder marker. The predicate is covered by
+        // CheckValidName_RejectsIllegalNames; this pins that the create path actually calls it.
+        var (provider, _) = await CreateProviderAsync();
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.CreateWopiChildFile(provider.RootContainer.Identifier, name));
+    }
+
+    [Theory]
+    [InlineData("../escape")]
+    [InlineData("a/b")]
+    [InlineData("..")]
+    [InlineData(".")]
+    [InlineData(BlobIdMap.FolderMarker)]
+    public async Task CreateWopiChildContainer_TraversalOrReservedName_Throws(string name)
+    {
+        var (provider, _) = await CreateProviderAsync();
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => provider.CreateWopiChildContainer(provider.RootContainer.Identifier, name));
+    }
+
     [Fact]
     public async Task GetAncestors_File_IncludesParentChain()
     {

--- a/test/WopiHost.Discovery.Tests/WopiDiscovererProofKeyTests.cs
+++ b/test/WopiHost.Discovery.Tests/WopiDiscovererProofKeyTests.cs
@@ -36,6 +36,37 @@ public class WopiDiscovererProofKeyTests
     }
 
     [Fact]
+    public async Task GetProofKeysAsync_SpecificNetZone_StillResolvesRootProofKey()
+    {
+        // Proof-key lookup reads the discovery-document root and is deliberately NOT scoped by
+        // NetZone (unlike the <app> lookup). The key here sits at the root, not inside <net-zone>,
+        // so a net-zone-scoped lookup would miss it — pinning that a specific zone doesn't break
+        // proof resolution on real OOS/M365 docs served from an external zone.
+        var xml = XElement.Parse(
+            """
+            <wopi-discovery>
+                <net-zone name="external-https">
+                    <app name="Word">
+                        <action ext="docx" name="edit" urlsrc="https://word.example/we/" />
+                    </app>
+                </net-zone>
+                <proof-key value="v" oldvalue="ov" />
+            </wopi-discovery>
+            """);
+        var fileProvider = A.Fake<IDiscoveryFileProvider>();
+        A.CallTo(() => fileProvider.GetDiscoveryXmlAsync()).Returns(Task.FromResult(xml));
+        var sut = new WopiDiscoverer(
+            fileProvider,
+            Options.Create(new DiscoveryOptions { NetZone = NetZoneEnum.ExternalHttps }),
+            NullLogger<WopiDiscoverer>.Instance);
+
+        var keys = await sut.GetProofKeysAsync();
+
+        Assert.Equal("v", keys.Value);
+        Assert.Equal("ov", keys.OldValue);
+    }
+
+    [Fact]
     public async Task GetProofKeysAsync_NoProofKeyElement_ReturnsAllNullProperties()
     {
         var xml = XElement.Parse("<wopi-discovery />");

--- a/test/WopiHost.Discovery.Tests/WopiDiscovererTests.cs
+++ b/test/WopiHost.Discovery.Tests/WopiDiscovererTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
 using System.Xml.Linq;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -254,5 +255,28 @@ public class WopiDiscovererTests
 
         _wopiDiscoverer.Dispose();
         _wopiDiscoverer.Dispose();
+    }
+
+    [Fact]
+    public async Task GetProofKeysAsync_RealCspBlob_ImportsIntoRsaProvider()
+    {
+        // The checked-in OWA2013 discovery XML carries Microsoft's real proof-key CSP blobs in its
+        // root <proof-key value=.. oldvalue=..>. WopiProofValidator feeds exactly this base64
+        // through RSACryptoServiceProvider.ImportCspBlob, so the fixture's bytes must round-trip
+        // into a usable key on the runtime that ships the host.
+        InitDiscoverer(XmlOwa2013, NetZoneEnum.InternalHttp);
+
+        var keys = await _wopiDiscoverer.GetProofKeysAsync();
+
+        Assert.False(string.IsNullOrEmpty(keys.Value));
+        Assert.False(string.IsNullOrEmpty(keys.OldValue));
+
+        using var rsa = new RSACryptoServiceProvider();
+        rsa.ImportCspBlob(Convert.FromBase64String(keys.Value!));
+        Assert.True(rsa.KeySize > 0);
+
+        using var rsaOld = new RSACryptoServiceProvider();
+        rsaOld.ImportCspBlob(Convert.FromBase64String(keys.OldValue!));
+        Assert.True(rsaOld.KeySize > 0);
     }
 }

--- a/test/WopiHost.IntegrationTests/ContainerMutatingEndpointTests.cs
+++ b/test/WopiHost.IntegrationTests/ContainerMutatingEndpointTests.cs
@@ -214,7 +214,7 @@ public sealed class ContainerMutatingEndpointTests(MutatingEndpointsFixture fixt
 
         // First create a file with a known name…
         var name = $"file-{Guid.NewGuid():N}.txt";
-        var first = new HttpRequestMessage(HttpMethod.Post, $"/wopi/containers/{_fixture.RootContainerId}?access_token={Uri.EscapeDataString(token)}")
+        using var first = new HttpRequestMessage(HttpMethod.Post, $"/wopi/containers/{_fixture.RootContainerId}?access_token={Uri.EscapeDataString(token)}")
         {
             Content = new ByteArrayContent("file-body"u8.ToArray()),
         };
@@ -225,7 +225,7 @@ public sealed class ContainerMutatingEndpointTests(MutatingEndpointsFixture fixt
 
         // …then ask for it again under specific (relative) mode with no overwrite → 409 + the
         // X-WOPI-ValidRelativeTarget header the negotiator surfaces on a name collision.
-        var second = new HttpRequestMessage(HttpMethod.Post, $"/wopi/containers/{_fixture.RootContainerId}?access_token={Uri.EscapeDataString(token)}")
+        using var second = new HttpRequestMessage(HttpMethod.Post, $"/wopi/containers/{_fixture.RootContainerId}?access_token={Uri.EscapeDataString(token)}")
         {
             Content = new ByteArrayContent("file-body"u8.ToArray()),
         };

--- a/test/WopiHost.IntegrationTests/ContainerMutatingEndpointTests.cs
+++ b/test/WopiHost.IntegrationTests/ContainerMutatingEndpointTests.cs
@@ -207,6 +207,37 @@ public sealed class ContainerMutatingEndpointTests(MutatingEndpointsFixture fixt
     }
 
     [Fact]
+    public async Task CreateChildFile_WithRelativeTarget_OnExisting_Returns_409()
+    {
+        var token = await _fixture.MintContainerTokenAsync(_fixture.RootContainerId);
+        using var client = _fixture.WopiBackend.CreateClient();
+
+        // First create a file with a known name…
+        var name = $"file-{Guid.NewGuid():N}.txt";
+        var first = new HttpRequestMessage(HttpMethod.Post, $"/wopi/containers/{_fixture.RootContainerId}?access_token={Uri.EscapeDataString(token)}")
+        {
+            Content = new ByteArrayContent("file-body"u8.ToArray()),
+        };
+        first.Headers.Add("X-WOPI-Override", "CREATE_CHILD_FILE");
+        first.Headers.Add("X-WOPI-RelativeTarget", name);
+        var firstResp = await client.SendAsync(first);
+        Assert.Equal(HttpStatusCode.OK, firstResp.StatusCode);
+
+        // …then ask for it again under specific (relative) mode with no overwrite → 409 + the
+        // X-WOPI-ValidRelativeTarget header the negotiator surfaces on a name collision.
+        var second = new HttpRequestMessage(HttpMethod.Post, $"/wopi/containers/{_fixture.RootContainerId}?access_token={Uri.EscapeDataString(token)}")
+        {
+            Content = new ByteArrayContent("file-body"u8.ToArray()),
+        };
+        second.Headers.Add("X-WOPI-Override", "CREATE_CHILD_FILE");
+        second.Headers.Add("X-WOPI-RelativeTarget", name);
+        var secondResp = await client.SendAsync(second);
+
+        Assert.Equal(HttpStatusCode.Conflict, secondResp.StatusCode);
+        Assert.True(secondResp.Headers.Contains("X-WOPI-ValidRelativeTarget"));
+    }
+
+    [Fact]
     public async Task CreateChildFile_BothHeaders_Returns_501()
     {
         var token = await _fixture.MintContainerTokenAsync(_fixture.RootContainerId);

--- a/test/WopiHost.IntegrationTests/FileMutatingEndpointTests.cs
+++ b/test/WopiHost.IntegrationTests/FileMutatingEndpointTests.cs
@@ -334,6 +334,46 @@ public sealed class FileMutatingEndpointTests(MutatingEndpointsFixture fixture)
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
     }
 
+    [Fact]
+    public async Task PutFile_ReadOnlyToken_LacksWritePermission_Returns_403()
+    {
+        // End-to-end authorization: a token minted with WopiFilePermissions.ReadOnly fails the
+        // Permission.Update gate (WopiAuthorizationHandler short-circuits on the ReadOnly flag),
+        // so the live auth pipeline rejects PutFile with 403 Forbidden — the JWT principal is
+        // authenticated, it simply lacks write permission (authorization runs before the handler).
+        var fileId = await _fixture.CreateTempFileAsync([]);
+        var token = await _fixture.MintFileTokenAsync(fileId, WopiFilePermissions.ReadOnly);
+        using var client = _fixture.WopiBackend.CreateClient();
+
+        var req = new HttpRequestMessage(HttpMethod.Put, $"/wopi/files/{fileId}/contents?access_token={Uri.EscapeDataString(token)}")
+        {
+            Content = new ByteArrayContent("should-be-rejected"u8.ToArray()),
+        };
+        var resp = await client.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("RENAME_FILE")]
+    [InlineData("DELETE")]
+    public async Task MutatingOverride_ReadOnlyToken_LacksWritePermission_Returns_403(string @override)
+    {
+        // Same gate over the X-WOPI-Override POST routes: RENAME_FILE requires Permission.Rename,
+        // DELETE requires Permission.Delete — both denied for a ReadOnly token, so each returns 403
+        // before the handler runs.
+        var fileId = await _fixture.CreateTempFileAsync("body"u8.ToArray(), extension: ".txt");
+        var token = await _fixture.MintFileTokenAsync(fileId, WopiFilePermissions.ReadOnly);
+        using var client = _fixture.WopiBackend.CreateClient();
+
+        var req = new HttpRequestMessage(HttpMethod.Post, $"/wopi/files/{fileId}?access_token={Uri.EscapeDataString(token)}");
+        req.Headers.Add("X-WOPI-Override", @override);
+        req.Headers.Add("X-WOPI-RequestedName", "renamed");
+        var resp = await client.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+
     // ---- RenameFile ------------------------------------------------------
 
     [Fact]

--- a/test/WopiHost.IntegrationTests/FileMutatingEndpointTests.cs
+++ b/test/WopiHost.IntegrationTests/FileMutatingEndpointTests.cs
@@ -324,7 +324,7 @@ public sealed class FileMutatingEndpointTests(MutatingEndpointsFixture fixture)
         var token = await _fixture.MintFileTokenAsync(fileId);
         using var client = _fixture.WopiBackend.CreateClient();
 
-        var req = new HttpRequestMessage(HttpMethod.Put, $"/wopi/files/{fileId}/contents?access_token={Uri.EscapeDataString(token)}")
+        using var req = new HttpRequestMessage(HttpMethod.Put, $"/wopi/files/{fileId}/contents?access_token={Uri.EscapeDataString(token)}")
         {
             Content = new ByteArrayContent("hello"u8.ToArray()),
         };
@@ -345,7 +345,7 @@ public sealed class FileMutatingEndpointTests(MutatingEndpointsFixture fixture)
         var token = await _fixture.MintFileTokenAsync(fileId, WopiFilePermissions.ReadOnly);
         using var client = _fixture.WopiBackend.CreateClient();
 
-        var req = new HttpRequestMessage(HttpMethod.Put, $"/wopi/files/{fileId}/contents?access_token={Uri.EscapeDataString(token)}")
+        using var req = new HttpRequestMessage(HttpMethod.Put, $"/wopi/files/{fileId}/contents?access_token={Uri.EscapeDataString(token)}")
         {
             Content = new ByteArrayContent("should-be-rejected"u8.ToArray()),
         };
@@ -366,7 +366,7 @@ public sealed class FileMutatingEndpointTests(MutatingEndpointsFixture fixture)
         var token = await _fixture.MintFileTokenAsync(fileId, WopiFilePermissions.ReadOnly);
         using var client = _fixture.WopiBackend.CreateClient();
 
-        var req = new HttpRequestMessage(HttpMethod.Post, $"/wopi/files/{fileId}?access_token={Uri.EscapeDataString(token)}");
+        using var req = new HttpRequestMessage(HttpMethod.Post, $"/wopi/files/{fileId}?access_token={Uri.EscapeDataString(token)}");
         req.Headers.Add("X-WOPI-Override", @override);
         req.Headers.Add("X-WOPI-RequestedName", "renamed");
         var resp = await client.SendAsync(req);

--- a/test/WopiHost.MemoryLockProvider.Tests/MemoryLockProviderTests.cs
+++ b/test/WopiHost.MemoryLockProvider.Tests/MemoryLockProviderTests.cs
@@ -37,6 +37,32 @@ public class MemoryLockProviderTests
     }
 
     [Fact]
+    public async Task AddLockAsync_ExpiredLockResident_TakesOver_ViaDirectStateSeed()
+    {
+        // An expired-but-resident lock is contractually "no lock", so AddLockAsync must evict it and
+        // succeed (a takeover), matching the Azure/Redis providers. Seeds a stale record directly
+        // into per-instance state with a DateCreated an hour back — well past the 30-minute
+        // WopiLockInfo.ExpirationMinutes window — then asserts the new lock replaced it.
+        var provider = new MemoryLockProvider(NullLogger<MemoryLockProvider>.Instance);
+        var fileId = $"expired-takeover-{Guid.NewGuid()}";
+        provider.SeedLockForTesting(fileId, new WopiLockInfo
+        {
+            FileId = fileId,
+            LockId = "stale",
+            DateCreated = DateTimeOffset.UtcNow.AddHours(-1),
+        });
+
+        var result = await provider.AddLockAsync(fileId, "new-lock");
+
+        Assert.NotNull(result);
+        Assert.Equal("new-lock", result.LockId);
+
+        var stored = await provider.GetLockAsync(fileId);
+        Assert.NotNull(stored);
+        Assert.Equal("new-lock", stored.LockId);
+    }
+
+    [Fact]
     public void TwoInstances_OwnIndependentLockState()
     {
         // State must be per-instance: a static dictionary would make two instances share a single

--- a/test/WopiHost.SmokeTests/README.md
+++ b/test/WopiHost.SmokeTests/README.md
@@ -27,11 +27,11 @@ DOM-only Playwright smoke tests for the sample frontends (`sample/WopiHost.Web`,
 ## Running locally
 
 ```bash
-# 1. Build (this also makes the playwright.ps1 helper script available under bin/)
+# 1. Build (this also makes the playwright.ps1 helper script available under artifacts/bin/)
 dotnet build test/WopiHost.SmokeTests
 
 # 2. Install Chromium (one-off; idempotent)
-pwsh test/WopiHost.SmokeTests/bin/Debug/net10.0/playwright.ps1 install chromium
+pwsh artifacts/bin/WopiHost.SmokeTests/debug/playwright.ps1 install chromium
 
 # 3. Run
 dotnet test test/WopiHost.SmokeTests


### PR DESCRIPTION
Addresses the audit in #562 — all 6 Medium + 9 Low findings, plus the two security-relevant items, and adds a new `security-audit` skill.

Closes #562.

## Fixes (correctness / security)
- **Azure provider name guard** — `CreateWopiChildFile`/`CreateWopiChildContainer` now run the client-controlled name through `CheckValidFileName`/`CheckValidContainerName` before composing the blob path, the path-traversal / reserved-name guard the FS provider and the Azure `Rename*` methods already apply. Defense-in-depth for a direct library consumer (the endpoint layer already sanitises on the HTTP path; Azure's flat namespace prevents container escape).
- **Validator view-token scoping** — the host page strips `UserCanWrite | UserCanRename` when the action isn't `Edit`, matching `WopiHost.Web` / `Web.Oidc` (Collabora derives view-vs-edit from CheckFileInfo flags).
- **MemoryLockProvider.AddLockAsync** — evicts an expired-but-resident lock before `TryAdd`, so an expired lock is a takeover (matching Azure/Redis and the `GetLockAsync` contract) instead of a spurious rejection.

## Cleanups
- `WopiDiscoverer`: `OrdinalIgnoreCase` for the action-name match (was `InvariantCultureIgnoreCase`, inconsistent within the predicate) + drop a dead null-conditional.
- `WopiUrlBuilder`: null-guard the `discoverer` ctor arg like the adjacent `logger`.
- Doc fixes: the "lowercased blob path" id-scheme comments (hashed as-is, case-sensitively); SmokeTests Playwright path (`artifacts/bin/...`); sample README AppHost port (`5050`) and Aspire-allocated validator port.

## Tests added
Azure create-with-traversal/reserved-name rejection; memory-lock expired-takeover; end-to-end **403** for a `ReadOnly` token on PutFile / RENAME_FILE / DELETE; CreateChildFile relative-target **409**; proof-key net-zone independence; real CSP-blob `ImportCspBlob` round-trip.

## New skill
`.claude/skills/security-audit/` — a repeatable, threat-model-driven security audit (the security counterpart to `codebase-audit`): six trust boundaries, a reachability-first bar, a do-not-refile ledger, `security-scan.sh`, and a self-improvement loop. Running it this session surfaced no new exploitable issues beyond the two fixes above. This run's learnings are also folded into the `codebase-audit` ledger/playbook.

## Validation note
The audit/build environment had **no .NET toolchain and no network to install one**, so this branch was **not built or tested locally** — every change was modelled on an existing sibling and verified by reading source, but **CI is the build/test gate**. Worth a close eye on the new tests (the Azure ones are Docker/Azurite-gated and run in CI only).

https://claude.ai/code/session_01XVsAeXEoiGXhpNVttoamBm

---
_Generated by [Claude Code](https://claude.ai/code/session_01XVsAeXEoiGXhpNVttoamBm)_