### PR TITLE
chore: bump collabora/code to 26.04.1.4.1

### DIFF
--- a/infra/WopiHost.AppHost/Program.cs
+++ b/infra/WopiHost.AppHost/Program.cs
@@ -259,7 +259,7 @@ if (builder.Configuration.GetValue("AppHost:IncludeOidcSample", defaultValue: fa
 // while loolwsd is still binding.
 if (useCollabora)
 {
-    var collabora = builder.AddContainer("collabora", "collabora/code")
+    var collabora = builder.AddContainer("collabora", "collabora/code", "26.04.1.4.1")
            // host.docker.internal needs an explicit --add-host=host.docker.internal:host-gateway on
            // Linux Docker Engine — Docker Desktop on Mac/Windows wires it implicitly, but the Linux
            // daemon doesn't. Without this, Collabora's WOPI callbacks from inside the container can't


### PR DESCRIPTION
## Summary
- Bumps the `collabora/code` image used by `WopiHost.AppHost` from unpinned (`collabora/code` with no tag, resolving to `:latest`) to `collabora/code:26.04.1.4.1` (latest stable as of 2026-07-01).
- No breaking changes flagged in upstream release notes (the CollaboraOnline/online GitHub releases page publishes Helm chart releases only; no WOPI-relevant breaking changes were surfaced from the Docker Hub tag history or available release metadata).

## Test plan
- [ ] `dotnet build infra/WopiHost.AppHost`
- [ ] `dotnet run --project infra/WopiHost.AppHost` with `AppHost:UseCollabora=true`, open `http://localhost:6000`, verify a document loads in the iframe and edits round-trip.

---
_Generated by [Claude Code](https://claude.ai/code/session_015HGcKQKC9C79F3B9ryf4fh)_