### PR TITLE
fix(deps): Pin Microsoft.OpenApi 2.7.5 (NU1903) and bump the nuget group

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <!-- Enables overriding a transitive dependency's version from a PackageVersion entry below.
-         Required for the MessagePack security pin; remove together with that pin once it's
-         no longer needed. -->
+         Required for the MessagePack and Microsoft.OpenApi security pins; remove together with
+         those pins once they're no longer needed. -->
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 
@@ -23,7 +23,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.6" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.9" />
     <PackageVersion Include="Scrutor" Version="7.0.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />
@@ -50,6 +50,12 @@
          CentralPackageTransitivePinningEnabled property above) once Aspire ships a
          MessagePack >= 2.5.301 transitively. -->
     <PackageVersion Include="MessagePack" Version="2.5.301" />
+    <!-- Security pin (not referenced directly). Microsoft.AspNetCore.OpenApi pulls
+         Microsoft.OpenApi 2.0.0 transitively, which GHSA-v5pm-xwqc-g5wc flags as a
+         high-severity stack overflow when parsing circular schema references; 2.7.5 is the
+         first patched 2.x release. Remove once Microsoft.AspNetCore.OpenApi ships
+         Microsoft.OpenApi >= 2.7.5 transitively. -->
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
   </ItemGroup>
 
   <!--
@@ -85,9 +91,9 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.61.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="Testcontainers" Version="4.12.0" />
-    <PackageVersion Include="Testcontainers.Azurite" Version="4.12.0" />
-    <PackageVersion Include="Testcontainers.Redis" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers" Version="4.13.0" />
+    <PackageVersion Include="Testcontainers.Azurite" Version="4.13.0" />
+    <PackageVersion Include="Testcontainers.Redis" Version="4.13.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <!-- Runner-free packages used only by WopiHost.Abstractions.Testing — the shared conformance
          library is a class library, not a test project, so it can't pull in the xunit.v3


### PR DESCRIPTION
## Summary

Master fails to restore with **NU1903**: `Microsoft.AspNetCore.OpenApi` pulls in `Microsoft.OpenApi` 2.0.0 transitively, which [GHSA-v5pm-xwqc-g5wc](https://github.com/advisories/GHSA-v5pm-xwqc-g5wc) flags as a high-severity vulnerability (stack overflow when parsing OpenAPI documents with circular schema references). With `TreatWarningsAsErrors` on, the audit warning breaks restore in `sample/WopiHost` and `test/WopiHost.IntegrationTests`.

- Pins `Microsoft.OpenApi` at **2.7.5** (first patched 2.x release) in `Directory.Packages.props`, using the already-enabled `CentralPackageTransitivePinningEnabled` — same pattern as the existing MessagePack security pin, including a removal note for when `Microsoft.AspNetCore.OpenApi` ships a patched version transitively.
- Folds in the dependency bumps from #580, which was blocked by this same NU1903: `Scalar.AspNetCore` 2.16.6 → 2.16.9 and `Testcontainers` / `Testcontainers.Azurite` / `Testcontainers.Redis` 4.12.0 → 4.13.0. Supersedes #580.

## Verification

- `dotnet build WOPI.slnx -p:IncludeCobalt=false` — 0 warnings, 0 errors (previously failed restore with NU1903 ×2).
- `project.assets.json` for both previously failing projects resolves `Microsoft.OpenApi/2.7.5`.
- Unit tests: WopiHost.Core.Tests (362), WopiHost.MemoryLockProvider.Tests (37), WopiHost.Discovery.Tests (89) — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
