### PR TITLE
docs(deps): Name the unblock condition on the JunitXml.TestLogger pin

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -86,9 +86,11 @@
     <PackageVersion Include="Aspire.Hosting.Testing" Version="13.4.4" />
     <PackageVersion Include="FakeItEasy" Version="9.0.1" />
     <!-- Emits JUnit XML test results for Codecov Test Analytics (flaky-test / failure
-         reporting). Consumed via the `junit` VSTest logger in CI. Pinned below 8.0.0:
-         that release links against Microsoft.Testing.Platform 2.0, which outranks the
-         1.9.1 pulled in transitively by xunit.v3 and breaks the build with CS1705. -->
+         reporting). Consumed via the `junit` VSTest logger in CI. Pinned below 8.0.0: the
+         8.x line is compiled against Microsoft.Testing.Platform v2, while xunit.v3 3.x
+         ships MTP 1.x, so mixing them breaks the build with CS1705 in every test project.
+         Bump to 8.x together with the xunit.v3 4.x upgrade — the first xunit line with
+         MTP v2 support. -->
     <PackageVersion Include="JunitXml.TestLogger" Version="7.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.9" />


### PR DESCRIPTION
## Summary

Comment-only follow-up to #583. The JunitXml.TestLogger pin said *why* 8.0.0 breaks the build (CS1705) but not *when* the pin can be lifted. Verified against #566's current CI failure and the NuGet metadata:

- JunitXml.TestLogger 8.x is compiled against Microsoft.Testing.Platform **2.0.2**; xunit.v3 3.x ships MTP **1.9.1** — mixing them fails CS1705 in every test project.
- xunit.v3 first supports MTP v2 in its **4.x line** (currently prerelease).

The comment now states that the 8.x bump goes together with the future xunit.v3 4.x upgrade, so the removal condition is discoverable in the file itself.

## Verification

`dotnet build WOPI.slnx -p:IncludeCobalt=false` — 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
