### PR TITLE
fix: resolve all 2026-07 codebase-audit findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ dotnet run --project sample/WopiHost
 - Centralized package management via `Directory.Packages.props` — specify versions there, not in individual `.csproj` files.
 - Single-targeted on `net10.0` (libraries, samples, infra, tests). The v8 line was the last to support `net8.0` / `net9.0`; v9 onward is net10 only. The `tools/wopi-validator/` helper project stays on `net8.0` because the upstream `Microsoft.Office.WopiValidator` NuGet does.
 - Build output is centralized under `artifacts/` at the repo root (`UseArtifactsOutput=true` in `Directory.Build.props`) — there are no per-project `bin/`/`obj/` folders.
-- Package validation baseline is `8.0.0` — avoid breaking public API changes in NuGet-packaged libraries. Bump in lockstep with releases (auto-bumped by `.github/workflows/release.yml` after each stable release). Packages without a prior release on NuGet.org opt out via `EnablePackageValidation=false` in their `.csproj`.
+- Package validation is enabled — avoid breaking public API changes in NuGet-packaged libraries. The baseline tracks the latest stable release (auto-bumped by `.github/workflows/release.yml`; see `PackageValidationBaselineVersion` in `Directory.Build.props` for the current value). Packages without a prior release on NuGet.org opt out via `EnablePackageValidation=false` in their `.csproj`.
 - `InternalsVisibleTo` is auto-configured for `*.Tests` assemblies.
 
 ## Codebase audit skill
@@ -72,7 +72,7 @@ This is a modular **WOPI protocol host** implementation that integrates custom d
 - **WopiHost.MemoryLockProvider** — Default in-memory lock provider (per-instance `ConcurrentDictionary`, 30-min expiry). Single-process only.
 - **WopiHost.AzureStorageProvider** — Azure Blob storage provider (alternative to FileSystemProvider). See its README for the connection-string config flow.
 - **WopiHost.AzureLockProvider** — Azure-blob-backed distributed lock provider (alternative to MemoryLockProvider). Strongest cross-instance exclusion via Azure blob leases.
-- **WopiHost.RedisLockProvider** — Redis-backed distributed lock provider. Best-effort, single-Redis (does not implement Redlock — see its README for rationale). Atomicity via Lua scripts; TTL-driven WOPI expiry.
+- **WopiHost.RedisLockProvider** — Redis-backed distributed lock provider. Best-effort, single-Redis (does not implement Redlock — see its README for rationale). Atomicity via Redis transactions (`WATCH` + `MULTI`/`EXEC` conditions); TTL-driven WOPI expiry.
 - **WopiHost.Abstractions.Testing** — Shared `LockProviderConformanceTests` and `StorageProviderConformanceTests` xUnit classes that every `IWopiLockProvider` / `IWopiStorageProvider` implementation runs through. Provider-specific test projects derive a sealed subclass and supply a factory; xUnit picks up the inherited `[Fact]` tests automatically. Adding a future provider = one more conformance subclass.
 
 ### Dependency Chain

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,10 +38,10 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.4" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="13.4.4" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.6" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="13.4.6" />
     <!-- Aspire integration for the Redis lock provider opt-in. Only the AppHost needs it. -->
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.4.4" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.4.6" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
   </ItemGroup>
 
@@ -53,9 +53,6 @@
     patched release to watch for.
   -->
   <ItemGroup Label="Transitive security pins">
-    <!-- Aspire pulls MessagePack 2.5.192, which GHSA-hv8m-jj95-wg3x flags as a high-severity
-         LZ4-decompression crash; 2.5.301 is the first patched 2.5.x release. -->
-    <PackageVersion Include="MessagePack" Version="2.5.301" />
     <!-- Microsoft.AspNetCore.OpenApi pulls Microsoft.OpenApi 2.0.0, which GHSA-v5pm-xwqc-g5wc
          flags as a high-severity stack overflow on circular schema references; 2.7.5 is the
          first patched 2.x release. -->
@@ -83,7 +80,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.4.4" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.4.6" />
     <PackageVersion Include="FakeItEasy" Version="9.0.1" />
     <!-- Emits JUnit XML test results for Codecov Test Analytics (flaky-test / failure
          reporting). Consumed via the `junit` VSTest logger in CI. Pinned below 8.0.0: the

--- a/infra/WopiHost.AppHost/WopiHost.AppHost.csproj
+++ b/infra/WopiHost.AppHost/WopiHost.AppHost.csproj
@@ -1,5 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
-<Sdk Name="Aspire.AppHost.Sdk" Version="13.4.3" />
+<!-- Keep in lockstep with the Aspire.Hosting.* versions in Directory.Packages.props.
+     Dependabot's nuget ecosystem scans PackageReference/PackageVersion elements only,
+     so this Sdk element needs a manual bump alongside every Aspire.Hosting.* bump. -->
+<Sdk Name="Aspire.AppHost.Sdk" Version="13.4.4" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/infra/WopiHost.AppHost/WopiHost.AppHost.csproj
+++ b/infra/WopiHost.AppHost/WopiHost.AppHost.csproj
@@ -2,7 +2,7 @@
 <!-- Keep in lockstep with the Aspire.Hosting.* versions in Directory.Packages.props.
      Dependabot's nuget ecosystem scans PackageReference/PackageVersion elements only,
      so this Sdk element needs a manual bump alongside every Aspire.Hosting.* bump. -->
-<Sdk Name="Aspire.AppHost.Sdk" Version="13.4.4" />
+<Sdk Name="Aspire.AppHost.Sdk" Version="13.4.6" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/sample/WopiHost.Web.Oidc/README.md
+++ b/sample/WopiHost.Web.Oidc/README.md
@@ -10,7 +10,7 @@ This sample exists to demonstrate the [M365 business flow](https://learn.microso
 |---|---|---|
 | Authentication | None (anonymous) | Cookie + OpenID Connect |
 | User identity in WOPI token | Hardcoded `"Anonymous"` | OIDC `sub` / `name` / `email` claims |
-| File permissions | All-write | Resolved from OIDC role claims at mint time |
+| File permissions | Write on Edit action only (same view/edit scoping, no per-user roles) | Resolved from OIDC role claims at mint time |
 | Hostpage | Consumer flow | Business flow (`business_user=1`) |
 | New endpoints | — | `/account/login`, `/account/logout`, `/account/denied` |
 

--- a/sample/WopiHost.Web/Program.cs
+++ b/sample/WopiHost.Web/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http.HttpResults;
 using WopiHost.Abstractions;
 using WopiHost.Discovery;
 using WopiHost.FileSystemProvider;
@@ -61,16 +62,16 @@ app.MapRazorComponents<App>();
 // Sample-only host-app action backing the editor toolbar's Download button. Streams the file via
 // the storage provider directly (not a WOPI protocol operation) and, like the rest of this sample,
 // is anonymous: fine for a demo, not a template for production access control.
-app.MapGet("/files/{id}/content", async (string id, IWopiStorageProvider storage, CancellationToken ct) =>
+app.MapGet("/files/{id}/content", async Task<Results<NotFound, FileStreamHttpResult>> (string id, IWopiStorageProvider storage, CancellationToken ct) =>
 {
     var file = await storage.GetWopiFile(id, ct);
     if (file is null)
     {
-        return Results.NotFound();
+        return TypedResults.NotFound();
     }
     var downloadName = $"{file.Name}.{file.Extension.TrimStart('.')}";
     var stream = await file.OpenReadAsync(ct);
-    return Results.File(stream, "application/octet-stream", downloadName);
+    return TypedResults.File(stream, "application/octet-stream", downloadName);
 });
 
 app.MapHealthChecks("/health");

--- a/src/WopiHost.Cobalt/CoauthoringSessionTracker.cs
+++ b/src/WopiHost.Cobalt/CoauthoringSessionTracker.cs
@@ -40,9 +40,9 @@ public partial class CoauthoringSessionTracker(ILogger<CoauthoringSessionTracker
     /// </summary>
     public void AddOrRefreshSession(string fileId, string userId, string userName)
     {
-        var files_sessions = s_sessions.GetOrAdd(fileId, _ => new ConcurrentDictionary<string, EditorSession>());
-        var added = !files_sessions.ContainsKey(userId);
-        files_sessions[userId] = new EditorSession(userId, userName, DateTimeOffset.UtcNow);
+        var fileSessions = s_sessions.GetOrAdd(fileId, _ => new ConcurrentDictionary<string, EditorSession>());
+        var added = !fileSessions.ContainsKey(userId);
+        fileSessions[userId] = new EditorSession(userId, userName, DateTimeOffset.UtcNow);
         if (added)
         {
             LogEditorJoined(_logger, userId, userName, fileId);
@@ -54,13 +54,13 @@ public partial class CoauthoringSessionTracker(ILogger<CoauthoringSessionTracker
     /// </summary>
     public void RemoveSession(string fileId, string userId)
     {
-        if (s_sessions.TryGetValue(fileId, out var files_sessions))
+        if (s_sessions.TryGetValue(fileId, out var fileSessions))
         {
-            if (files_sessions.TryRemove(userId, out _))
+            if (fileSessions.TryRemove(userId, out _))
             {
                 LogEditorLeft(_logger, userId, fileId);
             }
-            if (files_sessions.IsEmpty)
+            if (fileSessions.IsEmpty)
             {
                 s_sessions.TryRemove(fileId, out _);
             }
@@ -72,13 +72,13 @@ public partial class CoauthoringSessionTracker(ILogger<CoauthoringSessionTracker
     /// </summary>
     public int GetActiveEditorCount(string fileId)
     {
-        if (!s_sessions.TryGetValue(fileId, out var files_sessions))
+        if (!s_sessions.TryGetValue(fileId, out var fileSessions))
         {
             return 0;
         }
 
         var cutoff = DateTimeOffset.UtcNow - s_sessionTimeout;
-        return files_sessions.Values.Count(s => s.LastActivity > cutoff);
+        return fileSessions.Values.Count(s => s.LastActivity > cutoff);
     }
 
     /// <summary>
@@ -86,13 +86,13 @@ public partial class CoauthoringSessionTracker(ILogger<CoauthoringSessionTracker
     /// </summary>
     public bool IsAlone(string fileId, string userId)
     {
-        if (!s_sessions.TryGetValue(fileId, out var files_sessions))
+        if (!s_sessions.TryGetValue(fileId, out var fileSessions))
         {
             return true;
         }
 
         var cutoff = DateTimeOffset.UtcNow - s_sessionTimeout;
-        var activeEditors = files_sessions.Values
+        var activeEditors = fileSessions.Values
             .Where(s => s.LastActivity > cutoff)
             .ToList();
 
@@ -111,13 +111,13 @@ public partial class CoauthoringSessionTracker(ILogger<CoauthoringSessionTracker
     public EditorsTable GetEditorsTable(string fileId)
     {
         var result = new EditorsTable();
-        if (!s_sessions.TryGetValue(fileId, out var files_sessions))
+        if (!s_sessions.TryGetValue(fileId, out var fileSessions))
         {
             return result;
         }
 
         var cutoff = DateTimeOffset.UtcNow - s_sessionTimeout;
-        foreach (var session in files_sessions.Values.Where(s => s.LastActivity > cutoff))
+        foreach (var session in fileSessions.Values.Where(s => s.LastActivity > cutoff))
         {
             var clientId = DeriveClientId(session.UserId);
             result[clientId] = new EditorsTableEntryNew(

--- a/src/WopiHost.Core/Endpoints/FileEndpoints.cs
+++ b/src/WopiHost.Core/Endpoints/FileEndpoints.cs
@@ -67,10 +67,10 @@ internal static class FileEndpoints
         // Capabilities must mirror what's actually wired up — advertising features the host
         // can't deliver would lie to the WOPI client. Cobalt provides the multi-user editing
         // surface, so SupportsCoauth tracks its registration alongside SupportsCobalt.
-        // SupportsUpdate must reflect writable-storage presence; without it PutFile /
-        // RenameFile / DeleteFile all 501 via RequiresWritableStorageEndpointFilter, and
-        // DefaultCheckFileInfoBuilder cascades SupportsUpdate=false into
-        // UserCanNotWriteRelative=true per
+        // SupportsUpdate / SupportsRename / SupportsDeleteFile must reflect writable-storage
+        // presence; without it PutFile / RenameFile / DeleteFile all 501 via
+        // RequiresWritableStorageEndpointFilter, and DefaultCheckFileInfoBuilder cascades
+        // SupportsUpdate=false into UserCanNotWriteRelative=true per
         // https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/putrelativefile.
         var capabilities = new WopiHostCapabilities
         {
@@ -79,6 +79,8 @@ internal static class FileEndpoints
             SupportsLocks = req.LockProvider is not null,
             SupportsCoauth = req.CobaltProcessor is not null,
             SupportsUpdate = req.WritableStorage is not null,
+            SupportsRename = req.WritableStorage is not null,
+            SupportsDeleteFile = req.WritableStorage is not null,
             SupportedShareUrlTypes = WopiShareUrlTypes.All,
             SupportsAddActivities = true,
         };

--- a/src/WopiHost.Discovery/README.md
+++ b/src/WopiHost.Discovery/README.md
@@ -76,8 +76,10 @@ public interface IDiscoverer
 The default `HttpDiscoveryFileProvider` fetches discovery over HTTP. To use a fixed XML (testing) or a custom transport, register your own implementation. `FileSystemDiscoveryFileProvider` ships in this package and is what the discovery tests use:
 
 ```csharp
-services.AddSingleton<IDiscoveryFileProvider>(_ =>
-    new FileSystemDiscoveryFileProvider("path/to/discovery.xml"));
+services.AddSingleton<IDiscoveryFileProvider>(sp =>
+    new FileSystemDiscoveryFileProvider(
+        "path/to/discovery.xml",
+        sp.GetRequiredService<ILogger<FileSystemDiscoveryFileProvider>>()));
 services.AddSingleton<IDiscoverer, WopiDiscoverer>();
 services.Configure<DiscoveryOptions>(o => o.NetZone = NetZoneEnum.ExternalHttps);
 ```

--- a/src/WopiHost.Discovery/ServiceCollectionExtensions.cs
+++ b/src/WopiHost.Discovery/ServiceCollectionExtensions.cs
@@ -20,7 +20,10 @@ public static class ServiceCollectionExtensions
         Action<DiscoveryOptions> configureDiscoveryOptions)
         where TOptions : class, IDiscoveryOptions
     {
-        services.Configure<DiscoveryOptions>(configureDiscoveryOptions);
+        services.AddOptions<DiscoveryOptions>()
+            .Configure(configureDiscoveryOptions)
+            .Validate(o => o.RefreshInterval > TimeSpan.Zero, "RefreshInterval must be positive.")
+            .ValidateOnStart();
 
         services.AddHttpClient<IDiscoveryFileProvider, HttpDiscoveryFileProvider>((sp, client) =>
         {

--- a/src/WopiHost.RedisLockProvider/README.md
+++ b/src/WopiHost.RedisLockProvider/README.md
@@ -1,6 +1,6 @@
 # WopiHost.RedisLockProvider
 
-`IWopiLockProvider` implementation backed by Redis, with atomic compare-and-swap via Lua scripts and TTL-driven WOPI expiry.
+`IWopiLockProvider` implementation backed by Redis, with atomic compare-and-swap via Redis transactions (`WATCH` + `MULTI`/`EXEC`) and TTL-driven WOPI expiry.
 
 ## When to pick this over the other lock providers
 
@@ -22,7 +22,7 @@ If your Redis instance fails over to a replica with stale state mid-WOPI-session
 
 ## Atomicity
 
-Each non-trivial operation is a Lua script evaluated on the Redis server with `EVAL`. Lua scripts run to completion without interleaving with other commands, so the "match-then-mutate" steps land as a single observable transaction. The conformance suite's `RefreshLockAsync_ConcurrentSwapBetweenObservationAndCAS_DoesNotRefresh` test exercises this path against this provider too — a stale caller's expected lock id no longer matches the Redis-resident value when the script runs.
+Each compare-and-swap operation (refresh, unlock-and-relock) runs as a Redis transaction: `IDatabase.CreateTransaction()` guarded by `AddCondition(Condition.StringEqual(key, snapshot))`. The condition maps onto Redis's `WATCH` primitive, which aborts the `MULTI`/`EXEC` if the key's value changed between the read and the write — so the "match-then-mutate" steps land as a single observable transaction. This costs one extra round-trip compared to a Lua `EVAL` compare+set, but keeps the implementation in C# with no embedded scripting language; the WOPI lock path isn't hot enough to care about the extra hop. The conformance suite's `RefreshLockAsync_ConcurrentSwapBetweenObservationAndCAS_DoesNotRefresh` test exercises this path against this provider too — a stale caller's snapshot no longer matches the Redis-resident value when the transaction runs, so it aborts.
 
 ## Registration
 

--- a/src/WopiHost.Url/README.md
+++ b/src/WopiHost.Url/README.md
@@ -14,7 +14,7 @@ dotnet add package WopiHost.Url
 ## Use
 
 ```csharp
-var urlBuilder = new WopiUrlBuilder(discoverer, new WopiUrlSettings
+var urlBuilder = new WopiUrlBuilder(discoverer, logger, new WopiUrlSettings
 {
     UiLlcc = CultureInfo.CurrentUICulture,
 });
@@ -61,7 +61,9 @@ Add raw `key/value` pairs directly via the dictionary indexer for placeholders n
 
 ```csharp
 services.AddWopiDiscovery<WopiHostOptions>(o => Configuration.GetSection("Wopi:Discovery").Bind(o));
-services.AddSingleton(sp => new WopiUrlBuilder(sp.GetRequiredService<IDiscoverer>()));
+services.AddSingleton(sp => new WopiUrlBuilder(
+    sp.GetRequiredService<IDiscoverer>(),
+    sp.GetRequiredService<ILogger<WopiUrlBuilder>>()));
 ```
 
 `WopiUrlBuilder` is cheap to construct but the underlying `IDiscoverer` holds the discovery-XML cache, so register it as a singleton. Pass per-call settings via the `urlSettings` argument on `GetFileUrlAsync` instead of constructing a new builder.

--- a/src/WopiHost.Url/WopiUrlSettings.cs
+++ b/src/WopiHost.Url/WopiUrlSettings.cs
@@ -62,10 +62,11 @@ public class WopiUrlSettings : Dictionary<string, string>
 
     /// <summary>
     /// Indicates that the WOPI server MAY include the preferred UI language in the format described in [RFC1766].
+    /// Returns <see langword="null"/> when the placeholder has not been set.
     /// </summary>
-    public CultureInfo UiLlcc
+    public CultureInfo? UiLlcc
     {
-        get => new(this[Placeholders.UiLlcc]);
+        get => TryGetValue(Placeholders.UiLlcc, out var value) ? new CultureInfo(value) : null;
         set
         {
             if (value != null)
@@ -77,10 +78,11 @@ public class WopiUrlSettings : Dictionary<string, string>
 
     /// <summary>
     /// Indicates that the WOPI server MAY include preferred data language in the format described in [RFC1766] for cases where language can affect data calculation.
+    /// Returns <see langword="null"/> when the placeholder has not been set.
     /// </summary>
-    public CultureInfo DcLlcc
+    public CultureInfo? DcLlcc
     {
-        get => new(this[Placeholders.DcLlcc]);
+        get => TryGetValue(Placeholders.DcLlcc, out var value) ? new CultureInfo(value) : null;
         set
         {
             if (value != null)
@@ -92,101 +94,124 @@ public class WopiUrlSettings : Dictionary<string, string>
 
     /// <summary>
     /// Indicates that the WOPI server MAY include the value "true" to use the output of this action embedded in a web page.
+    /// Returns <see langword="false"/> when the placeholder has not been set.
     /// </summary>
     public bool Embedded
     {
-        get => Convert.ToBoolean(this[Placeholders.Embedded], CultureInfo.InvariantCulture);
+        get => TryGetValue(Placeholders.Embedded, out var value) && Convert.ToBoolean(value, CultureInfo.InvariantCulture);
         set => this[Placeholders.Embedded] = value.ToString(CultureInfo.InvariantCulture);
     }
 
     /// <summary>
     /// Indicates that the WOPI server MAY include the value "true" to prevent the attendee from navigating a file. For example, when using the attendee action (see st_wopi-action-values in section 3.1.5.1.1.2.3.1).
+    /// Returns <see langword="false"/> when the placeholder has not been set.
     /// </summary>
     public bool DisableAsync
     {
-        get => Convert.ToBoolean(this[Placeholders.DisableAsync], CultureInfo.InvariantCulture);
+        get => TryGetValue(Placeholders.DisableAsync, out var value) && Convert.ToBoolean(value, CultureInfo.InvariantCulture);
         set => this[Placeholders.DisableAsync] = value.ToString(CultureInfo.InvariantCulture);
     }
 
     /// <summary>
     /// Indicates that the WOPI server MAY include the value "true" to load a view of the document that does not create or join a broadcast session. This view looks and behaves like a regular broadcast frame.
+    /// Returns <see langword="false"/> when the placeholder has not been set.
     /// </summary>
     public bool DisableBroadcast
     {
-        get => Convert.ToBoolean(this[Placeholders.DisableBroadcast], CultureInfo.InvariantCulture);
+        get => TryGetValue(Placeholders.DisableBroadcast, out var value) && Convert.ToBoolean(value, CultureInfo.InvariantCulture);
         set => this[Placeholders.DisableBroadcast] = value.ToString(CultureInfo.InvariantCulture);
     }
 
     /// <summary>
     /// Indicates that the WOPI server MAY include the value "true" to load the file type in full-screen mode.
+    /// Returns <see langword="false"/> when the placeholder has not been set.
     /// </summary>
     public bool Fullscreen
     {
-        get => Convert.ToBoolean(this[Placeholders.Fullscreen], CultureInfo.InvariantCulture);
+        get => TryGetValue(Placeholders.Fullscreen, out var value) && Convert.ToBoolean(value, CultureInfo.InvariantCulture);
         set => this[Placeholders.Fullscreen] = value.ToString(CultureInfo.InvariantCulture);
     }
 
     /// <summary>
     /// Indicates that the WOPI server MAY include the value "true" to load the file type with a minimal user interface.
+    /// Returns <see langword="false"/> when the placeholder has not been set.
     /// </summary>
     public bool Recording
     {
-        get => Convert.ToBoolean(this[Placeholders.Recording], CultureInfo.InvariantCulture);
+        get => TryGetValue(Placeholders.Recording, out var value) && Convert.ToBoolean(value, CultureInfo.InvariantCulture);
         set => this[Placeholders.Recording] = value.ToString(CultureInfo.InvariantCulture);
     }
 
     /// <summary>
     /// Indicates that the WOPI server MAY include a value to designate the theme used. Current values are "1" to indicate a light-colored theme and "2" to indicate a darker colored theme.
+    /// Returns 0 when the placeholder has not been set.
     /// </summary>
     public int ThemeId
     {
-        get => Convert.ToInt32(this[Placeholders.ThemeId], CultureInfo.InvariantCulture);
+        get => TryGetValue(Placeholders.ThemeId, out var value) ? Convert.ToInt32(value, CultureInfo.InvariantCulture) : 0;
         set => this[Placeholders.ThemeId] = value.ToString(CultureInfo.InvariantCulture);
     }
 
     /// <summary>
     /// Indicates that the WOPI server MAY include the value "1" to indicate that the user is a business user.
+    /// Returns 0 when the placeholder has not been set.
     /// </summary>
     public int BusinessUser
     {
-        get => Convert.ToInt32(this[Placeholders.BusinessUser], CultureInfo.InvariantCulture);
+        get => TryGetValue(Placeholders.BusinessUser, out var value) ? Convert.ToInt32(value, CultureInfo.InvariantCulture) : 0;
         set => this[Placeholders.BusinessUser] = value.ToString(CultureInfo.InvariantCulture);
     }
 
     /// <summary>
     /// Indicates that the WOPI server MAY include the value "1" to load a view of the document that does not create or join a chat session.
+    /// Returns 0 when the placeholder has not been set.
     /// </summary>
     public int DisableChat
     {
-        get => Convert.ToInt32(this[Placeholders.DisableChat], CultureInfo.InvariantCulture);
+        get => TryGetValue(Placeholders.DisableChat, out var value) ? Convert.ToInt32(value, CultureInfo.InvariantCulture) : 0;
         set => this[Placeholders.DisableChat] = value.ToString(CultureInfo.InvariantCulture);
     }
 
     /// <summary>
     /// Makes a purple, clickable box appear when set to 1. Microsoft has not documented this value.
+    /// Returns 0 when the placeholder has not been set.
     /// </summary>
     public int Perfstats
     {
-        get => Convert.ToInt32(this[Placeholders.Perfstats], CultureInfo.InvariantCulture);
+        get => TryGetValue(Placeholders.Perfstats, out var value) ? Convert.ToInt32(value, CultureInfo.InvariantCulture) : 0;
         set => this[Placeholders.Perfstats] = value.ToString(CultureInfo.InvariantCulture);
     }
 
     /// <summary>
     /// This value can be passed by hosts to associate an Office for the web session with a host session identifier. This can help Office for the web engineers more quickly find logs for troubleshooting purposes based on a host-specific session identifier.
+    /// Returns <see langword="null"/> when the placeholder has not been set.
     /// </summary>
-    public string HostSessionId
+    public string? HostSessionId
     {
-        get => this[Placeholders.HostSessionId];
-        set => this[Placeholders.HostSessionId] = value;
+        get => TryGetValue(Placeholders.HostSessionId, out var value) ? value : null;
+        set
+        {
+            if (value != null)
+            {
+                this[Placeholders.HostSessionId] = value;
+            }
+        }
     }
 
     /// <summary>
     /// This placeholder can be replaced by any string value. If provided, this value will be passed back to the host in subsequent CheckFileInfo and CheckFolderInfo calls in the X-WOPI-SessionContext request header. There is no defined limit for the length of this string; however, since it is passed on the query string, it is subject to the overall Office for the web URL length limit of 2048 bytes.
+    /// Returns <see langword="null"/> when the placeholder has not been set.
     /// </summary>
-    public string SessionContext
+    public string? SessionContext
     {
-        get => this[Placeholders.SessionContext];
-        set => this[Placeholders.SessionContext] = value;
+        get => TryGetValue(Placeholders.SessionContext, out var value) ? value : null;
+        set
+        {
+            if (value != null)
+            {
+                this[Placeholders.SessionContext] = value;
+            }
+        }
     }
 
     /// <summary>
@@ -200,7 +225,8 @@ public class WopiUrlSettings : Dictionary<string, string>
     {
         get
         {
-            _ = Enum.TryParse(this[Placeholders.ValidatorTestCategory], out ValidatorTestCategoryEnum validator);
+            _ = TryGetValue(Placeholders.ValidatorTestCategory, out var value);
+            _ = Enum.TryParse(value, out ValidatorTestCategoryEnum validator);
             return validator;
         }
         set => this[Placeholders.ValidatorTestCategory] = value.ToString();

--- a/test/WopiHost.Abstractions.Testing/WopiProofPayload.cs
+++ b/test/WopiHost.Abstractions.Testing/WopiProofPayload.cs
@@ -1,0 +1,44 @@
+using System.Text;
+
+namespace WopiHost.Abstractions.Testing;
+
+/// <summary>
+/// Builds the canonical X-WOPI-Proof byte layout defined by MS-WOPI: a 4-byte big-endian length
+/// prefix before each of the UTF-8 access token, the UTF-8 upper-cased request URL, and the
+/// 8-byte big-endian X-WOPI-TimeStamp ticks. WOPI clients sign these bytes with their proof key;
+/// hosts verify the signature against the same layout.
+/// </summary>
+public static class WopiProofPayload
+{
+    /// <summary>
+    /// Assembles the canonical proof bytes for <paramref name="accessToken"/>,
+    /// <paramref name="hostUrl"/> (already case-folded to upper-invariant, the form the
+    /// signature covers), and the <paramref name="timestampTicks"/> sent in X-WOPI-TimeStamp.
+    /// </summary>
+    public static byte[] Build(string accessToken, string hostUrl, long timestampTicks)
+    {
+        ArgumentNullException.ThrowIfNull(accessToken);
+        ArgumentNullException.ThrowIfNull(hostUrl);
+
+        var tokenBytes = Encoding.UTF8.GetBytes(accessToken);
+        var hostBytes = Encoding.UTF8.GetBytes(hostUrl);
+        var tsBytes = BitConverter.GetBytes(timestampTicks);
+        Array.Reverse(tsBytes);
+
+        var buffer = new List<byte>(4 + tokenBytes.Length + 4 + hostBytes.Length + 4 + tsBytes.Length);
+        buffer.AddRange(BigEndian(tokenBytes.Length));
+        buffer.AddRange(tokenBytes);
+        buffer.AddRange(BigEndian(hostBytes.Length));
+        buffer.AddRange(hostBytes);
+        buffer.AddRange(BigEndian(tsBytes.Length));
+        buffer.AddRange(tsBytes);
+        return [.. buffer];
+    }
+
+    private static byte[] BigEndian(int value)
+    {
+        var bytes = BitConverter.GetBytes(value);
+        Array.Reverse(bytes);
+        return bytes;
+    }
+}

--- a/test/WopiHost.Core.Tests/Security/Authentication/WopiProofValidatorTests.cs
+++ b/test/WopiHost.Core.Tests/Security/Authentication/WopiProofValidatorTests.cs
@@ -1,10 +1,10 @@
 using System.Globalization;
 using System.Security.Cryptography;
-using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Primitives;
 using Moq;
+using WopiHost.Abstractions.Testing;
 using WopiHost.Core.Extensions;
 using WopiHost.Core.Infrastructure;
 using WopiHost.Core.Security.Authentication;
@@ -153,7 +153,7 @@ public class WopiProofValidatorTests
         var ticks = _time.GetUtcNow().UtcDateTime.Ticks;
         var ctx = BuildHttpContext(timestampOverride: ticks.ToString(CultureInfo.InvariantCulture));
 
-        var canonical = BuildCanonicalProof(AccessToken, BuildExpectedHostUrl(), ticks);
+        var canonical = WopiProofPayload.Build(AccessToken, BuildExpectedHostUrl(), ticks);
         // X-WOPI-Proof bogus, but X-WOPI-ProofOld signed with current key
         ctx.Request.Headers[WopiHeaders.Proof] = Convert.ToBase64String(new byte[256]);
         ctx.Request.Headers[WopiHeaders.ProofOld] =
@@ -292,33 +292,9 @@ public class WopiProofValidatorTests
     private static string BuildExpectedHostUrl()
         => $"{Scheme}://{Host}{Path}{QueryString}".ToUpperInvariant();
 
-    private static byte[] BuildCanonicalProof(string accessToken, string hostUrl, long ticks)
-    {
-        var tokenBytes = Encoding.UTF8.GetBytes(accessToken);
-        var hostBytes = Encoding.UTF8.GetBytes(hostUrl);
-        var tsBytes = BitConverter.GetBytes(ticks);
-        Array.Reverse(tsBytes);
-
-        var buffer = new List<byte>(4 + tokenBytes.Length + 4 + hostBytes.Length + 4 + tsBytes.Length);
-        buffer.AddRange(BigEndian(tokenBytes.Length));
-        buffer.AddRange(tokenBytes);
-        buffer.AddRange(BigEndian(hostBytes.Length));
-        buffer.AddRange(hostBytes);
-        buffer.AddRange(BigEndian(tsBytes.Length));
-        buffer.AddRange(tsBytes);
-        return [.. buffer];
-    }
-
-    private static byte[] BigEndian(int value)
-    {
-        var bytes = BitConverter.GetBytes(value);
-        Array.Reverse(bytes);
-        return bytes;
-    }
-
     private static void SignAndApply(HttpRequest request, RSACryptoServiceProvider signer, long ticks)
     {
-        var canonical = BuildCanonicalProof(AccessToken, BuildExpectedHostUrl(), ticks);
+        var canonical = WopiProofPayload.Build(AccessToken, BuildExpectedHostUrl(), ticks);
         var signature = signer.SignData(canonical, "SHA256");
         request.Headers[WopiHeaders.Proof] = Convert.ToBase64String(signature);
     }

--- a/test/WopiHost.Core.Tests/WopiHost.Core.Tests.csproj
+++ b/test/WopiHost.Core.Tests/WopiHost.Core.Tests.csproj
@@ -4,6 +4,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\WopiHost.Core\WopiHost.Core.csproj" />
+		<ProjectReference Include="..\WopiHost.Abstractions.Testing\WopiHost.Abstractions.Testing.csproj" />
 	</ItemGroup>
 	<ItemGroup>
 	  <Folder Include="Controllers\" />

--- a/test/WopiHost.IntegrationTests/FileEndpointTests.cs
+++ b/test/WopiHost.IntegrationTests/FileEndpointTests.cs
@@ -29,6 +29,24 @@ public sealed class FileEndpointTests(ReadOnlyEndpointsFixture fixture)
     }
 
     [Fact]
+    public async Task CheckFileInfo_AdvertisesUpdateRenameDelete_WithWritableStorage()
+    {
+        // Counterpart of ReadOnlyHostCheckFileInfoTests: with a writable storage provider
+        // registered (the FileSystem provider is writable), all three write capabilities
+        // must be advertised.
+        var token = await _fixture.MintFileTokenAsync(_fixture.FirstFileId);
+        using var client = _fixture.WopiBackend.CreateClient();
+
+        var resp = await client.GetAsync($"/wopi/files/{_fixture.FirstFileId}?access_token={Uri.EscapeDataString(token)}");
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var payload = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(await resp.Content.ReadAsStringAsync());
+        Assert.True(payload.GetProperty("SupportsUpdate").GetBoolean());
+        Assert.True(payload.GetProperty("SupportsRename").GetBoolean());
+        Assert.True(payload.GetProperty("SupportsDeleteFile").GetBoolean());
+    }
+
+    [Fact]
     public async Task CheckFileInfo_Returns_404_ForMissingFile()
     {
         var missing = new string('0', 64); // SHA-256-shaped but non-existent

--- a/test/WopiHost.IntegrationTests/ProofValidationIntegrationTests.cs
+++ b/test/WopiHost.IntegrationTests/ProofValidationIntegrationTests.cs
@@ -1,9 +1,9 @@
 using System.Globalization;
 using System.Net;
 using System.Security.Cryptography;
-using System.Text;
 using Microsoft.AspNetCore.Mvc.Testing;
 using WopiHost.Abstractions;
+using WopiHost.Abstractions.Testing;
 using WopiHost.Core.Infrastructure;
 using WopiHost.IntegrationTests.Fixtures;
 using Xunit;
@@ -195,34 +195,10 @@ public sealed class ProofValidationIntegrationTests : IAsyncLifetime, IDisposabl
         var request = new HttpRequestMessage(method, url);
         // Match the validator: case-fold the URL to upper-invariant before hashing — same
         // contract WOPI clients sign against.
-        var canonical = BuildCanonicalProof(_accessToken, url.ToUpperInvariant(), ticks);
+        var canonical = WopiProofPayload.Build(_accessToken, url.ToUpperInvariant(), ticks);
         var signature = signer.SignData(canonical, "SHA256");
         request.Headers.Add(WopiHeaders.Proof, Convert.ToBase64String(signature));
         request.Headers.Add(WopiHeaders.Timestamp, ticks.ToString(CultureInfo.InvariantCulture));
         return request;
-    }
-
-    private static byte[] BuildCanonicalProof(string accessToken, string hostUrl, long ticks)
-    {
-        var tokenBytes = Encoding.UTF8.GetBytes(accessToken);
-        var hostBytes = Encoding.UTF8.GetBytes(hostUrl);
-        var tsBytes = BitConverter.GetBytes(ticks);
-        Array.Reverse(tsBytes);
-
-        var buffer = new List<byte>(4 + tokenBytes.Length + 4 + hostBytes.Length + 4 + tsBytes.Length);
-        buffer.AddRange(BigEndian(tokenBytes.Length));
-        buffer.AddRange(tokenBytes);
-        buffer.AddRange(BigEndian(hostBytes.Length));
-        buffer.AddRange(hostBytes);
-        buffer.AddRange(BigEndian(tsBytes.Length));
-        buffer.AddRange(tsBytes);
-        return [.. buffer];
-    }
-
-    private static byte[] BigEndian(int value)
-    {
-        var bytes = BitConverter.GetBytes(value);
-        Array.Reverse(bytes);
-        return bytes;
     }
 }

--- a/test/WopiHost.IntegrationTests/README.md
+++ b/test/WopiHost.IntegrationTests/README.md
@@ -27,7 +27,7 @@ dotnet test test/WopiHost.IntegrationTests
 dotnet test test/WopiHost.IntegrationTests --filter "FullyQualifiedName!~OidcStartupTests"
 ```
 
-The Docker-backed tests use [`Xunit.SkippableFact`](https://github.com/AArnott/Xunit.SkippableFact) to mark themselves as **skipped** (not failed) when Docker is unavailable, so the build stays green.
+The Docker-backed tests use xUnit v3's built-in `Assert.SkipUnless(...)` to mark themselves as **skipped** (not failed) when Docker is unavailable, so the build stays green.
 
 ## How the test factories fit together
 

--- a/test/WopiHost.IntegrationTests/ReadOnlyHostCheckFileInfoTests.cs
+++ b/test/WopiHost.IntegrationTests/ReadOnlyHostCheckFileInfoTests.cs
@@ -1,0 +1,62 @@
+using System.Net;
+using System.Text.Json;
+using WopiHost.Abstractions;
+using WopiHost.IntegrationTests.Fixtures;
+using Xunit;
+
+namespace WopiHost.IntegrationTests;
+
+/// <summary>
+/// CheckFileInfo capability advertising on a host without writable storage: SupportsUpdate,
+/// SupportsRename, and SupportsDeleteFile must all be false, because PutFile / RenameFile /
+/// DeleteFile 501 via <c>RequiresWritableStorageEndpointFilter</c>. A read-only host that
+/// advertises them would make a WOPI client render Rename/Delete affordances that always fail.
+/// </summary>
+public sealed class ReadOnlyHostCheckFileInfoTests : IDisposable
+{
+    private const string SigningSecret = "readonly-capabilities-shared-key-32b!";
+    private static readonly FixtureUser s_user = new("readonly-user", "ReadOnly User", "readonly@example.com");
+
+    private readonly WopiBackendFactory _backend;
+
+    public ReadOnlyHostCheckFileInfoTests()
+    {
+        _backend = new WopiBackendFactory(SigningSecret, configureServices: services =>
+        {
+            services.RemoveAll<IWopiWritableStorageProvider>();
+            // DefaultWopiNewChildFileNegotiator has a hard constructor dependency on
+            // IWopiWritableStorageProvider, so its registration must go too — it is only
+            // reachable from endpoints that 501 on a read-only host anyway.
+            services.RemoveAll<IWopiNewChildFileNegotiator>();
+        });
+    }
+
+    [Fact]
+    public async Task CheckFileInfo_WithoutWritableStorage_DoesNotAdvertiseUpdateRenameDelete()
+    {
+        using var scope = _backend.Services.CreateScope();
+        var storage = scope.ServiceProvider.GetRequiredService<IWopiStorageProvider>();
+        var fileId = await FirstFileIdAsync(storage);
+        var token = await FixtureTokens.MintFileTokenAsync(_backend, s_user, fileId, WopiFilePermissions.UserCanWrite);
+        using var client = _backend.CreateClient();
+
+        var resp = await client.GetAsync($"/wopi/files/{fileId}?access_token={Uri.EscapeDataString(token)}");
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var payload = JsonSerializer.Deserialize<JsonElement>(await resp.Content.ReadAsStringAsync());
+        Assert.False(payload.GetProperty("SupportsUpdate").GetBoolean());
+        Assert.False(payload.GetProperty("SupportsRename").GetBoolean());
+        Assert.False(payload.GetProperty("SupportsDeleteFile").GetBoolean());
+    }
+
+    private static async Task<string> FirstFileIdAsync(IWopiStorageProvider storage)
+    {
+        await foreach (var f in storage.GetWopiFiles(storage.RootContainer.Identifier))
+        {
+            return f.Identifier;
+        }
+        throw new InvalidOperationException("sample/wopi-docs is empty — at least one file is required.");
+    }
+
+    public void Dispose() => _backend.Dispose();
+}

--- a/test/WopiHost.IntegrationTests/WopiHost.IntegrationTests.csproj
+++ b/test/WopiHost.IntegrationTests/WopiHost.IntegrationTests.csproj
@@ -8,6 +8,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\sample\WopiHost.Web.Oidc\WopiHost.Web.Oidc.csproj" />
 		<ProjectReference Include="..\..\sample\WopiHost\WopiHost.csproj" />
+		<ProjectReference Include="..\WopiHost.Abstractions.Testing\WopiHost.Abstractions.Testing.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/test/WopiHost.RedisLockProvider.Tests/RedisLockProviderConformanceTests.cs
+++ b/test/WopiHost.RedisLockProvider.Tests/RedisLockProviderConformanceTests.cs
@@ -15,6 +15,7 @@ namespace WopiHost.RedisLockProvider.Tests;
 /// avoids per-test TCP/handshake churn.
 /// </remarks>
 [Collection(RedisCollection.Name)]
+[Trait("Category", "Integration")]
 public sealed class RedisLockProviderConformanceTests(RedisFixture redis) : LockProviderConformanceTests
 {
     /// <inheritdoc />

--- a/test/WopiHost.RedisLockProvider.Tests/WopiRedisLockProviderEvictionTests.cs
+++ b/test/WopiHost.RedisLockProvider.Tests/WopiRedisLockProviderEvictionTests.cs
@@ -21,6 +21,7 @@ namespace WopiHost.RedisLockProvider.Tests;
 /// here is the provider's own eviction.
 /// </remarks>
 [Collection(RedisCollection.Name)]
+[Trait("Category", "Integration")]
 public sealed class WopiRedisLockProviderEvictionTests(RedisFixture redis)
 {
     private async Task<(WopiRedisLockProvider Sut, IDatabase Db, RedisKey Key)> CreateAsync(

--- a/test/WopiHost.SmokeTests/WebSampleTokenScopingTests.cs
+++ b/test/WopiHost.SmokeTests/WebSampleTokenScopingTests.cs
@@ -1,0 +1,51 @@
+using System.IdentityModel.Tokens.Jwt;
+using WopiHost.Abstractions;
+using WopiHost.Discovery.Enumerations;
+using WopiHost.Web.Services;
+using Xunit;
+
+namespace WopiHost.SmokeTests;
+
+/// <summary>
+/// Covers the anonymous sample's view/edit token scoping
+/// (<see cref="WopiAccessTokenMinter"/> in <c>sample/WopiHost.Web</c>): a token minted for a
+/// non-Edit action must not carry write/rename permissions. Collabora Online uses a single
+/// editor URL for both modes and derives view-vs-edit purely from CheckFileInfo permission
+/// flags, so an over-permissive token silently opens a "view" link in edit mode with no
+/// visible symptom in the URL. Pure-unit; no Playwright/browser required.
+/// </summary>
+public class WebSampleTokenScopingTests
+{
+    private static readonly JwtSecurityTokenHandler s_handler = new();
+
+    private static WopiFilePermissions MintedPermissions(WopiActionEnum action)
+    {
+        var minter = new WopiAccessTokenMinter();
+        var (token, _) = minter.Mint("user-1", "file-42", action);
+        var jwt = s_handler.ReadJwtToken(token);
+        return Enum.Parse<WopiFilePermissions>(jwt.Claims.First(c => c.Type == WopiClaimTypes.FilePermissions).Value);
+    }
+
+    [Fact]
+    public void Mint_EditAction_GrantsWriteAndRename()
+    {
+        var perms = MintedPermissions(WopiActionEnum.Edit);
+
+        Assert.True(perms.HasFlag(WopiFilePermissions.UserCanWrite));
+        Assert.True(perms.HasFlag(WopiFilePermissions.UserCanRename));
+    }
+
+    [Theory]
+    [InlineData(WopiActionEnum.View)]
+    [InlineData(WopiActionEnum.EmbedView)]
+    [InlineData(WopiActionEnum.MobileView)]
+    public void Mint_NonEditAction_OmitsWriteAndRename(WopiActionEnum action)
+    {
+        var perms = MintedPermissions(action);
+
+        Assert.False(perms.HasFlag(WopiFilePermissions.UserCanWrite));
+        Assert.False(perms.HasFlag(WopiFilePermissions.UserCanRename));
+        // Interaction-only flags survive the strip — they don't grant content mutation.
+        Assert.True(perms.HasFlag(WopiFilePermissions.UserCanAttend));
+    }
+}

--- a/test/WopiHost.Url.Tests/WopiUrlSettingsTests.cs
+++ b/test/WopiHost.Url.Tests/WopiUrlSettingsTests.cs
@@ -41,4 +41,44 @@ public class WopiUrlSettingsTests
 
         Assert.Empty(settings);
     }
+
+    [Fact]
+    public void TypedAccessors_UnsetKeys_ReturnDefaultsInsteadOfThrowing()
+    {
+        // The typed accessors are public API on a settings bag; reading a placeholder that was
+        // never set must yield null / a default value, not KeyNotFoundException.
+        var settings = new WopiUrlSettings();
+
+        Assert.Null(settings.UiLlcc);
+        Assert.Null(settings.DcLlcc);
+        Assert.False(settings.Embedded);
+        Assert.False(settings.DisableAsync);
+        Assert.False(settings.DisableBroadcast);
+        Assert.False(settings.Fullscreen);
+        Assert.False(settings.Recording);
+        Assert.Equal(0, settings.ThemeId);
+        Assert.Equal(0, settings.BusinessUser);
+        Assert.Equal(0, settings.DisableChat);
+        Assert.Equal(0, settings.Perfstats);
+        Assert.Null(settings.HostSessionId);
+        Assert.Null(settings.SessionContext);
+        Assert.Equal(default, settings.ValidatorTestCategory);
+    }
+
+    [Fact]
+    public void TypedAccessors_RoundTrip_AfterSet()
+    {
+        var settings = new WopiUrlSettings
+        {
+            UiLlcc = new System.Globalization.CultureInfo("cs-CZ"),
+            Embedded = true,
+            ThemeId = 2,
+            SessionContext = "user-42",
+        };
+
+        Assert.Equal("cs-CZ", settings.UiLlcc?.Name);
+        Assert.True(settings.Embedded);
+        Assert.Equal(2, settings.ThemeId);
+        Assert.Equal("user-42", settings.SessionContext);
+    }
 }

--- a/test/WopiHost.Url.Tests/WopiUrlSettingsTests.cs
+++ b/test/WopiHost.Url.Tests/WopiUrlSettingsTests.cs
@@ -46,8 +46,9 @@ public class WopiUrlSettingsTests
     public void TypedAccessors_UnsetKeys_ReturnDefaultsInsteadOfThrowing()
     {
         // The typed accessors are public API on a settings bag; reading a placeholder that was
-        // never set must yield null / a default value, not KeyNotFoundException.
-        var settings = new WopiUrlSettings();
+        // never set must yield null / a default value, not KeyNotFoundException. The unrelated
+        // raw entry proves the accessors key off their own placeholder, not bag emptiness.
+        var settings = new WopiUrlSettings { ["CUSTOM_RAW_PLACEHOLDER"] = "present" };
 
         Assert.Null(settings.UiLlcc);
         Assert.Null(settings.DcLlcc);


### PR DESCRIPTION
Fixes every finding from the 2026-07 codebase audit (#579) — all severities. The one out-of-repo item (the wiki's Collabora page) can't ride in a PR, so it was fixed by a direct push to the wiki: petrsvihlik/WopiHost.wiki@58248c8. With this PR merged, all 16 checkboxes on the tracker are addressed.

## High — doc samples that didn't compile
- **`WopiHost.Url` README**: both `WopiUrlBuilder` snippets now pass the required `logger` constructor argument.
- **`WopiHost.Discovery` README**: the `FileSystemDiscoveryFileProvider` snippet now passes the required `logger` argument.

## Medium
- **`CheckFileInfo` capability gating**: `SupportsRename` and `SupportsDeleteFile` now track writable-storage presence exactly like `SupportsUpdate`, so a read-only host no longer advertises Rename/Delete it will 501 on. Covered by a new `ReadOnlyHostCheckFileInfoTests` integration test (host booted without `IWopiWritableStorageProvider`) plus a writable-host counterpart in `FileEndpointTests`. `SupportsUserInfo` deliberately untouched per the tracker's note.
- **`WopiUrlSettings` typed accessors** no longer throw `KeyNotFoundException` on unset reads — they use `TryGetValue` and return `null` (`CultureInfo?`/`string?`) or `false`/`0` defaults. New unit tests cover the unset-read and set-then-read paths. `dotnet pack` with package validation against the 9.0.0 baseline passes (nullability-only surface change).
- **Redis lock provider docs**: README and CLAUDE.md now describe the actual `WATCH` + `MULTI`/`EXEC` transaction mechanism (`CreateTransaction` + `Condition.StringEqual`) instead of the Lua/`EVAL` design that was deliberately rejected.
- **CLAUDE.md package-validation note** no longer hardcodes the baseline version; it points at `PackageValidationBaselineVersion` in `Directory.Build.props`, so it can't go stale again on the next release.
- **Wiki `Collabora-Online.md`** (separate repo, direct push — petrsvihlik/WopiHost.wiki@58248c8): the "on by default" section now describes the `Program.cs` code default and why it intentionally isn't a committed `appsettings.Development.json` flag.
- **`WopiHost.Web` token-scoping coverage**: new `WebSampleTokenScopingTests` (in SmokeTests, which already references the sample; pure-unit, no browser) assert the minted JWT's `wopi:fperms` claim includes `UserCanWrite`/`UserCanRename` for Edit and omits both for View/EmbedView/MobileView while keeping `UserCanAttend`.

## Low
- **`Aspire.AppHost.Sdk`** bumped 13.4.3 → 13.4.4 to match the `Aspire.Hosting.*` pins, with a csproj comment noting Dependabot can't see `<Sdk>` elements so it needs a manual bump on every Aspire bump.
- **`WopiHost.Web` download endpoint** switched to `TypedResults.*` with an explicit `Results<NotFound, FileStreamHttpResult>` return type.
- **`WopiHost.Web.Oidc` README** comparison table: `WopiHost.Web` is now correctly described as "Write on Edit action only", not "All-write".
- **`AddWopiDiscovery`** now registers `DiscoveryOptions` via `AddOptions().Configure().Validate(RefreshInterval > 0).ValidateOnStart()`, matching every other provider.
- **`CoauthoringSessionTracker`**: `files_sessions` → `fileSessions`.
- **Redis Docker-backed test classes** now carry `[Trait("Category", "Integration")]` like the Azure suites, so `--filter Category=Integration` (and its inverse) sees them.
- **IntegrationTests README** now names xUnit v3's `Assert.SkipUnless` as the Docker-skip mechanism instead of the nonexistent `Xunit.SkippableFact` reference.
- **Canonical-proof byte builder** hoisted into `WopiHost.Abstractions.Testing` as `WopiProofPayload.Build(...)`; both test copies now call the shared spec-fidelity helper.

## Verification
- `dotnet build WOPI.slnx` — clean (warnings-as-errors on).
- `dotnet pack src/WopiHost.Url -p:Version=9.0.99` — package validation against the 9.0.0 baseline passes.
- Test runs, all green: Url (17), Core (362), Discovery (89), IntegrationTests (144, incl. Docker-backed), SmokeTests (9, incl. Playwright), Cobalt (64), RedisLockProvider (43), MemoryLockProvider (37), FileSystemProvider (138).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Also included (follow-up request)
- **Aspire bumped to 13.4.6 everywhere**: the four `Aspire.Hosting.*` pins in `Directory.Packages.props` plus the `Aspire.AppHost.Sdk` element, in lockstep. Aspire 13.4.6 pulls StreamJsonRpc 2.25.29, whose MessagePack floor (2.5.302) now exceeds the GHSA-hv8m-jj95-wg3x patch threshold — the transitive MessagePack security pin met its documented removal condition and was removed. Clean rebuild with NuGet audit (warnings-as-errors) confirms no vulnerable transitive remains.
