### PR TITLE
refactor: use Path.Join where concatenation is meant, drop no-op Combines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ dotnet run --project sample/WopiHost
   - Keep comments short and concrete; prefer deleting a comment to padding it.
   - Keep the `///` XML doc tags on public APIs (warnings-as-errors require them), but trim their wording to the same bar.
 - .NET analyzers and code style enforcement are on (`EnforceCodeStyleInBuild`).
+- **Path building:** new code uses `Path.Join` for concatenation. `Path.Combine` is reserved for intentional absolute-or-relative resolution and must be paired with an explicit `Path.IsPathRooted` check (its drop-earlier-arguments-on-rooted behavior is otherwise a silent bug — CodeQL `cs/path-combine`). Neither API is a traversal defense (`..` passes through `Path.Join`), so client-controlled names must pass single-segment validation before reaching any path-building call. Note `Path.Join` treats `null` segments as empty where `Path.Combine` throws — guard null inputs explicitly.
 - **Nullable reference types** are enabled solution-wide from the root `Directory.Build.props`. Don't re-declare `<Nullable>` in individual projects — keep the single source of truth.
 - Follow [.NET Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/).
 - Centralized package management via `Directory.Packages.props` — specify versions there, not in individual `.csproj` files.

--- a/sample/WopiHost/ServiceCollectionExtensions.cs
+++ b/sample/WopiHost/ServiceCollectionExtensions.cs
@@ -82,7 +82,7 @@ public static class ServiceCollectionExtensions
 
     public static void AddCobalt(this IServiceCollection services)
     {
-        var assemblyPath = Path.Combine(AppContext.BaseDirectory, "WopiHost.Cobalt.dll");
+        var assemblyPath = Path.Join(AppContext.BaseDirectory, "WopiHost.Cobalt.dll");
         if (!File.Exists(assemblyPath))
         {
             throw new InvalidProgramException($"Cobalt Assembly {assemblyPath} not found.");

--- a/src/WopiHost.Cobalt/README.md
+++ b/src/WopiHost.Cobalt/README.md
@@ -23,7 +23,7 @@ The sample server registers Cobalt by reflection-loading the assembly when `Wopi
 ```csharp
 public static void AddCobalt(this IServiceCollection services)
 {
-    var assemblyPath = Path.Combine(AppContext.BaseDirectory, "WopiHost.Cobalt.dll");
+    var assemblyPath = Path.Join(AppContext.BaseDirectory, "WopiHost.Cobalt.dll");
     if (!File.Exists(assemblyPath))
     {
         throw new InvalidProgramException($"Cobalt Assembly {assemblyPath} not found.");

--- a/src/WopiHost.FileSystemProvider/InMemoryFileIds.cs
+++ b/src/WopiHost.FileSystemProvider/InMemoryFileIds.cs
@@ -34,6 +34,10 @@ public partial class InMemoryFileIds(ILogger<InMemoryFileIds> logger)
     /// </summary>
     public bool WasScanned => !_idToPath.IsEmpty;
 
+    // Test hook: WopiFileSystemProvider enumerates stored paths directly, which is only safe
+    // while every stored path is absolute — tests pin that invariant through this view.
+    internal ICollection<string> StoredPaths => _idToPath.Values;
+
     /// <summary>
     /// Gets the file identifier for the specified path.
     /// </summary>

--- a/src/WopiHost.FileSystemProvider/WopiFileSystemProvider.cs
+++ b/src/WopiHost.FileSystemProvider/WopiFileSystemProvider.cs
@@ -39,9 +39,12 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
         var wopiRootPath = options.Value.RootPath;
+        // Path.Join treats a null segment as empty, so a null RootPath must be rejected up front
+        // or the provider would silently root itself at the content root.
+        ArgumentException.ThrowIfNullOrEmpty(wopiRootPath);
         _wopiAbsolutePath = Path.IsPathRooted(wopiRootPath)
             ? wopiRootPath
-            : new DirectoryInfo(Path.Combine(env.ContentRootPath, wopiRootPath)).FullName;
+            : new DirectoryInfo(Path.Join(env.ContentRootPath, wopiRootPath)).FullName;
 
         if (!_fileIds.WasScanned)
         {
@@ -94,10 +97,9 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(identifier);
+        // The id map only ever stores absolute paths, so folderPath enumerates directly.
         var folderPath = _fileIds.GetPath(identifier)
             ?? throw new DirectoryNotFoundException($"Directory '{identifier}' not found");
-
-        var absolutePath = Path.Combine(_wopiAbsolutePath, folderPath);
 
         // Push the extension filter into the OS-level enumeration: one Directory.EnumerateFiles
         // call per requested extension, each with its own glob. Distinct extensions produce
@@ -109,12 +111,12 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         // case-insensitive extension matching, so it is forced here regardless of host OS.
         var options = new EnumerationOptions { MatchCasing = MatchCasing.CaseInsensitive };
         var enumeration = (fileExtensions is { Count: > 0 })
-            ? fileExtensions.SelectMany(ext => Directory.EnumerateFiles(absolutePath, "*" + ext, options))
-            : Directory.EnumerateFiles(absolutePath, "*", options);
+            ? fileExtensions.SelectMany(ext => Directory.EnumerateFiles(folderPath, "*" + ext, options))
+            : Directory.EnumerateFiles(folderPath, "*", options);
 
         foreach (var path in enumeration)
         {
-            var filePath = Path.Combine(folderPath, Path.GetFileName(path));
+            var filePath = Path.Join(folderPath, Path.GetFileName(path));
             if (_fileIds.TryGetFileId(filePath, out var fileId))
             {
                 var result = await GetWopiFile(fileId, cancellationToken).ConfigureAwait(false)
@@ -130,10 +132,11 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(identifier);
+        // The id map only ever stores absolute paths, so folderPath enumerates directly.
         var folderPath = _fileIds.GetPath(identifier)
             ?? throw new DirectoryNotFoundException($"Directory '{identifier}' not found");
 
-        foreach (var directory in Directory.GetDirectories(Path.Combine(_wopiAbsolutePath, folderPath)))
+        foreach (var directory in Directory.GetDirectories(folderPath))
         {
             if (_fileIds.TryGetFileId(directory, out var folderId))
             {
@@ -193,7 +196,7 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         {
             return null;
         }
-        if (!_fileIds.TryGetFileId(Path.Combine(dirPath, name), out var nameId))
+        if (!_fileIds.TryGetFileId(Path.Join(dirPath, name), out var nameId))
         {
             return null;
         }
@@ -210,7 +213,7 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         {
             return null;
         }
-        if (!_fileIds.TryGetFileId(Path.Combine(dirPath, name), out var nameId))
+        if (!_fileIds.TryGetFileId(Path.Join(dirPath, name), out var nameId))
         {
             return null;
         }
@@ -248,7 +251,7 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
             throw new ArgumentException(message: "Invalid characters in the name.", paramName: nameof(name));
         }
         var fullPath = ResolveContainerPath(containerId);
-        var newPath = Path.Combine(fullPath, name);
+        var newPath = Path.Join(fullPath, name);
         if (!File.Exists(newPath))
         {
             return name;
@@ -257,7 +260,7 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         var ext = Path.GetExtension(name);
         var counter = 1;
         var candidate = name;
-        while (File.Exists(Path.Combine(fullPath, candidate)))
+        while (File.Exists(Path.Join(fullPath, candidate)))
         {
             candidate = $"{stem} ({counter++}){ext}";
         }
@@ -272,14 +275,14 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
             throw new ArgumentException(message: "Invalid characters in the name.", paramName: nameof(name));
         }
         var fullPath = ResolveContainerPath(containerId);
-        var newPath = Path.Combine(fullPath, name);
+        var newPath = Path.Join(fullPath, name);
         if (!Directory.Exists(newPath))
         {
             return name;
         }
         var counter = 1;
         var candidate = name;
-        while (Directory.Exists(Path.Combine(fullPath, candidate)))
+        while (Directory.Exists(Path.Join(fullPath, candidate)))
         {
             candidate = $"{name} ({counter++})";
         }
@@ -293,14 +296,15 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(containerId);
-        // Reject names that aren't a single path segment (separators, '.', '..') before combining —
-        // the name is client-controlled (relative/suggested target), so this is the path-traversal guard.
+        // Reject names that aren't a single path segment (separators, '.', '..') before building
+        // the target path — the name is client-controlled (relative/suggested target) and
+        // Path.Join concatenates ".." as-is, so this guard is the actual traversal defense.
         if (!await CheckValidFileName(name, cancellationToken).ConfigureAwait(false))
         {
             throw new ArgumentException(message: "Invalid characters in the name.", paramName: nameof(name));
         }
         var fullPath = ResolveContainerPath(containerId);
-        var newPath = Path.Combine(fullPath, name);
+        var newPath = Path.Join(fullPath, name);
         if (File.Exists(newPath))
         {
             throw new ArgumentException($"File '{newPath}' already exists.", nameof(name));
@@ -322,14 +326,14 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(containerId);
-        // Reject names that aren't a single path segment (separators, '.', '..') before combining —
-        // the name is client-controlled, so this is the path-traversal guard.
+        // Reject names that aren't a single path segment (separators, '.', '..') before building
+        // the target path — the name is client-controlled, so this guard is the traversal defense.
         if (!await CheckValidContainerName(name, cancellationToken).ConfigureAwait(false))
         {
             throw new ArgumentException(message: "Invalid characters in the name.", paramName: nameof(name));
         }
         var fullPath = ResolveContainerPath(containerId);
-        var newPath = Path.Combine(fullPath, name);
+        var newPath = Path.Join(fullPath, name);
         var dirInfo = new DirectoryInfo(newPath);
         if (dirInfo.Exists)
         {
@@ -389,7 +393,7 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         }
         var parentPath = Path.GetDirectoryName(fullPath)
             ?? throw new DirectoryNotFoundException("Parent directory not found");
-        var newPath = Path.Combine(parentPath, requestedName);
+        var newPath = Path.Join(parentPath, requestedName);
         if (File.Exists(newPath))
         {
             throw new InvalidOperationException($"Target File '{newPath}' already exists.");
@@ -413,7 +417,7 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
         }
         var parentPath = Path.GetDirectoryName(fullPath)
             ?? throw new DirectoryNotFoundException("Parent directory not found");
-        var newPath = Path.Combine(parentPath, requestedName);
+        var newPath = Path.Join(parentPath, requestedName);
         if (Directory.Exists(newPath))
         {
             throw new InvalidOperationException($"Target Directory '{newPath}' already exists.");

--- a/test/WopiHost.Discovery.Tests/FileSystemDiscoveryFileProviderTests.cs
+++ b/test/WopiHost.Discovery.Tests/FileSystemDiscoveryFileProviderTests.cs
@@ -8,7 +8,7 @@ public class FileSystemDiscoveryFileProviderTests
     [Fact]
     public async Task GetDiscoveryXmlAsync_ValidFile_ReturnsXml()
     {
-        var path = Path.Combine(AppContext.BaseDirectory, "OOS2016_discovery.xml");
+        var path = Path.Join(AppContext.BaseDirectory, "OOS2016_discovery.xml");
         var sut = new FileSystemDiscoveryFileProvider(path, NullLogger<FileSystemDiscoveryFileProvider>.Instance);
 
         var xml = await sut.GetDiscoveryXmlAsync();
@@ -20,7 +20,7 @@ public class FileSystemDiscoveryFileProviderTests
     public async Task GetDiscoveryXmlAsync_MissingFile_ThrowsAndIsObservableViaCatchPath()
     {
         var sut = new FileSystemDiscoveryFileProvider(
-            Path.Combine(Path.GetTempPath(), $"does-not-exist-{Guid.NewGuid()}.xml"),
+            Path.Join(Path.GetTempPath(), $"does-not-exist-{Guid.NewGuid()}.xml"),
             NullLogger<FileSystemDiscoveryFileProvider>.Instance);
 
         await Assert.ThrowsAnyAsync<IOException>(() => sut.GetDiscoveryXmlAsync());
@@ -29,7 +29,7 @@ public class FileSystemDiscoveryFileProviderTests
     [Fact]
     public async Task GetDiscoveryXmlAsync_MalformedXml_ThrowsXmlException()
     {
-        var path = Path.Combine(Path.GetTempPath(), $"malformed-{Guid.NewGuid()}.xml");
+        var path = Path.Join(Path.GetTempPath(), $"malformed-{Guid.NewGuid()}.xml");
         await File.WriteAllTextAsync(path, "<not-closed-element>");
         try
         {

--- a/test/WopiHost.Discovery.Tests/HttpDiscoveryFileProviderTests.cs
+++ b/test/WopiHost.Discovery.Tests/HttpDiscoveryFileProviderTests.cs
@@ -43,7 +43,7 @@ public class HttpDiscoveryFileProviderTests
     [Fact]
     public async Task GetDiscoveryXmlAsync_ParsesChildElements()
     {
-        var xml = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "OOS2016_discovery.xml"));
+        var xml = File.ReadAllText(Path.Join(AppContext.BaseDirectory, "OOS2016_discovery.xml"));
         var handler = new FakeHttpMessageHandler(_ => Task.FromResult(XmlResponse(xml)));
         var sut = new HttpDiscoveryFileProvider(CreateHttpClient(handler), NullLogger<HttpDiscoveryFileProvider>.Instance);
 

--- a/test/WopiHost.Discovery.Tests/WopiDiscovererTests.cs
+++ b/test/WopiHost.Discovery.Tests/WopiDiscovererTests.cs
@@ -22,7 +22,7 @@ public class WopiDiscovererTests
     [MemberNotNull(nameof(_wopiDiscoverer))]
     private void InitDiscoverer(string fileName, NetZoneEnum netZone) => 
         _wopiDiscoverer = new WopiDiscoverer(
-            new FileSystemDiscoveryFileProvider(Path.Combine(AppContext.BaseDirectory, fileName), NullLogger<FileSystemDiscoveryFileProvider>.Instance),
+            new FileSystemDiscoveryFileProvider(Path.Join(AppContext.BaseDirectory, fileName), NullLogger<FileSystemDiscoveryFileProvider>.Instance),
             Options.Create(new DiscoveryOptions { NetZone = netZone }),
             NullLogger<WopiDiscoverer>.Instance);
 

--- a/test/WopiHost.E2ETests/Collabora/CollaboraEditDocxTests.cs
+++ b/test/WopiHost.E2ETests/Collabora/CollaboraEditDocxTests.cs
@@ -75,7 +75,7 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
         });
 
         // Snapshot the docx so the save test's mutation can be restored at teardown.
-        var docxPath = Path.Combine(app.WopiDocsPath, SampleDocxName);
+        var docxPath = Path.Join(app.WopiDocsPath, SampleDocxName);
         _originalDocxBytes = await File.ReadAllBytesAsync(docxPath);
         _originalDocxWriteTime = File.GetLastWriteTimeUtc(docxPath);
     }
@@ -92,7 +92,7 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
         // churning the working tree's modified-time for diagnostics.
         if (_originalDocxBytes is not null)
         {
-            var docxPath = Path.Combine(app.WopiDocsPath, SampleDocxName);
+            var docxPath = Path.Join(app.WopiDocsPath, SampleDocxName);
             try
             {
                 var current = await File.ReadAllBytesAsync(docxPath);
@@ -255,7 +255,7 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
     {
         Assert.SkipUnless(app.IsDockerAvailable, "Docker is not available — skipping Collabora e2e.");
 
-        var docxPath = Path.Combine(app.WopiDocsPath, SampleDocxName);
+        var docxPath = Path.Join(app.WopiDocsPath, SampleDocxName);
         var sizeBefore = new FileInfo(docxPath).Length;
         var modifiedBefore = File.GetLastWriteTimeUtc(docxPath);
 

--- a/test/WopiHost.E2ETests/Fixtures/WopiAppFixtureBase.cs
+++ b/test/WopiHost.E2ETests/Fixtures/WopiAppFixtureBase.cs
@@ -223,7 +223,7 @@ public abstract class WopiAppFixtureBase : IAsyncLifetime
         // binary until the repo root (the directory containing WOPI.slnx). Robust to the artifacts/
         // layout (UseArtifactsOutput) which puts test dlls several levels below.
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "WOPI.slnx")))
+        while (dir is not null && !File.Exists(Path.Join(dir.FullName, "WOPI.slnx")))
         {
             dir = dir.Parent;
         }
@@ -232,6 +232,6 @@ public abstract class WopiAppFixtureBase : IAsyncLifetime
             throw new InvalidOperationException(
                 "Could not locate the repository root (looking for WOPI.slnx) from " + AppContext.BaseDirectory + ".");
         }
-        return Path.Combine(dir.FullName, "sample", "wopi-docs");
+        return Path.Join(dir.FullName, "sample", "wopi-docs");
     }
 }

--- a/test/WopiHost.FileSystemProvider.Tests/InMemoryFileIdsTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/InMemoryFileIdsTests.cs
@@ -30,7 +30,7 @@ public class InMemoryFileIdsTests : IDisposable
     [Fact]
     public void AddFile_SamePath_ReturnsSameId()
     {
-        var path = Path.Combine(_tempDir.FullName, "test.docx");
+        var path = Path.Join(_tempDir.FullName, "test.docx");
 
         var id1 = _sut.AddFile(path);
         var id2 = _sut.AddFile(path);
@@ -41,8 +41,8 @@ public class InMemoryFileIdsTests : IDisposable
     [Fact]
     public void AddFile_DifferentPaths_ReturnsDifferentIds()
     {
-        var path1 = Path.Combine(_tempDir.FullName, "file1.docx");
-        var path2 = Path.Combine(_tempDir.FullName, "file2.docx");
+        var path1 = Path.Join(_tempDir.FullName, "file1.docx");
+        var path2 = Path.Join(_tempDir.FullName, "file2.docx");
 
         var id1 = _sut.AddFile(path1);
         var id2 = _sut.AddFile(path2);
@@ -54,7 +54,7 @@ public class InMemoryFileIdsTests : IDisposable
     public void ScanAll_FileInSubdirectory_CanBeFoundById()
     {
         var subDir = _tempDir.CreateSubdirectory("sub");
-        var filePath = Path.Combine(subDir.FullName, "doc.docx");
+        var filePath = Path.Join(subDir.FullName, "doc.docx");
         File.WriteAllText(filePath, string.Empty);
 
         _sut.ScanAll(_tempDir.FullName);
@@ -77,7 +77,7 @@ public class InMemoryFileIdsTests : IDisposable
     [Fact]
     public void GetPath_KnownId_ReturnsPath()
     {
-        var path = Path.Combine(_tempDir.FullName, "doc.docx");
+        var path = Path.Join(_tempDir.FullName, "doc.docx");
         var id = _sut.AddFile(path);
 
         Assert.Equal(path, _sut.GetPath(id));
@@ -99,7 +99,7 @@ public class InMemoryFileIdsTests : IDisposable
     [Fact]
     public void RemoveId_RemovesEntry()
     {
-        var path = Path.Combine(_tempDir.FullName, "doc.docx");
+        var path = Path.Join(_tempDir.FullName, "doc.docx");
         var id = _sut.AddFile(path);
 
         _sut.RemoveId(id);
@@ -110,8 +110,8 @@ public class InMemoryFileIdsTests : IDisposable
     [Fact]
     public void UpdateFile_ChangesPathForExistingId()
     {
-        var oldPath = Path.Combine(_tempDir.FullName, "old.docx");
-        var newPath = Path.Combine(_tempDir.FullName, "new.docx");
+        var oldPath = Path.Join(_tempDir.FullName, "old.docx");
+        var newPath = Path.Join(_tempDir.FullName, "new.docx");
         var id = _sut.AddFile(oldPath);
 
         _sut.UpdateFile(id, newPath);
@@ -123,7 +123,7 @@ public class InMemoryFileIdsTests : IDisposable
     [Fact]
     public void ScanAll_WopiTestFile_GetsWopitestIdentifier()
     {
-        var path = Path.Combine(_tempDir.FullName, "test.wopitest");
+        var path = Path.Join(_tempDir.FullName, "test.wopitest");
         File.WriteAllText(path, string.Empty);
 
         _sut.ScanAll(_tempDir.FullName);
@@ -137,8 +137,8 @@ public class InMemoryFileIdsTests : IDisposable
     {
         // The path→id reverse map must drop the old binding when an id is rebound to a new
         // path, otherwise stale entries pile up unboundedly.
-        var oldPath = Path.Combine(_tempDir.FullName, "old.docx");
-        var newPath = Path.Combine(_tempDir.FullName, "new.docx");
+        var oldPath = Path.Join(_tempDir.FullName, "old.docx");
+        var newPath = Path.Join(_tempDir.FullName, "new.docx");
         var id = _sut.AddFile(oldPath);
 
         _sut.UpdateFile(id, newPath);
@@ -151,7 +151,7 @@ public class InMemoryFileIdsTests : IDisposable
     [Fact]
     public void RemoveId_Path_NoLongerResolvesViaReverseLookup()
     {
-        var path = Path.Combine(_tempDir.FullName, "doc.docx");
+        var path = Path.Join(_tempDir.FullName, "doc.docx");
         var id = _sut.AddFile(path);
 
         _sut.RemoveId(id);
@@ -164,7 +164,7 @@ public class InMemoryFileIdsTests : IDisposable
     {
         // Confirm both maps are reset on rescan — clearing only the forward map would let a
         // parallel reverse-map entry linger.
-        var stalePath = Path.Combine(_tempDir.FullName, "stale.docx");
+        var stalePath = Path.Join(_tempDir.FullName, "stale.docx");
         File.WriteAllText(stalePath, string.Empty);
         _sut.ScanAll(_tempDir.FullName);
         Assert.True(_sut.TryGetFileId(stalePath, out _));
@@ -183,7 +183,7 @@ public class InMemoryFileIdsTests : IDisposable
         // directions.
         const int writers = 64;
         var paths = Enumerable.Range(0, writers)
-            .Select(i => Path.Combine(_tempDir.FullName, $"f{i}.docx"))
+            .Select(i => Path.Join(_tempDir.FullName, $"f{i}.docx"))
             .ToArray();
 
         var ids = await Task.WhenAll(
@@ -205,7 +205,7 @@ public class InMemoryFileIdsTests : IDisposable
         // Stress: half the workers add, the other half remove the same file id. Whatever the
         // interleaving, the forward and reverse maps must agree (no dangling reverse entry).
         const int rounds = 200;
-        var path = Path.Combine(_tempDir.FullName, "shared.docx");
+        var path = Path.Join(_tempDir.FullName, "shared.docx");
 
         var add = Task.Run(() =>
         {

--- a/test/WopiHost.FileSystemProvider.Tests/WopiContainerTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/WopiContainerTests.cs
@@ -36,9 +36,9 @@ public class WopiContainerTests : IDisposable
     public void Size_SumsAllDescendantFiles_Recursive()
     {
         // Root file + nested file under a sub-folder; Size should include both.
-        File.WriteAllBytes(Path.Combine(_tempDir.FullName, "a.bin"), new byte[10]);
+        File.WriteAllBytes(Path.Join(_tempDir.FullName, "a.bin"), new byte[10]);
         var sub = _tempDir.CreateSubdirectory("sub");
-        File.WriteAllBytes(Path.Combine(sub.FullName, "b.bin"), new byte[25]);
+        File.WriteAllBytes(Path.Join(sub.FullName, "b.bin"), new byte[25]);
 
         var sut = new WopiContainer(_tempDir.FullName, "folder-id");
 
@@ -48,7 +48,7 @@ public class WopiContainerTests : IDisposable
     [Fact]
     public void Size_NonExistentFolder_ReturnsZeroRatherThanThrowing()
     {
-        var sut = new WopiContainer(Path.Combine(_tempDir.FullName, "missing"), "folder-id");
+        var sut = new WopiContainer(Path.Join(_tempDir.FullName, "missing"), "folder-id");
         Assert.Equal(0L, sut.Size);
     }
 
@@ -57,10 +57,10 @@ public class WopiContainerTests : IDisposable
     {
         // 2 root files + 1 sub-folder = 3 direct children. The file inside the sub-folder
         // doesn't count — ChildCount is shallow per the IWopiContainer contract.
-        File.WriteAllText(Path.Combine(_tempDir.FullName, "a.txt"), "x");
-        File.WriteAllText(Path.Combine(_tempDir.FullName, "b.txt"), "x");
+        File.WriteAllText(Path.Join(_tempDir.FullName, "a.txt"), "x");
+        File.WriteAllText(Path.Join(_tempDir.FullName, "b.txt"), "x");
         var sub = _tempDir.CreateSubdirectory("sub");
-        File.WriteAllText(Path.Combine(sub.FullName, "nested.txt"), "x");
+        File.WriteAllText(Path.Join(sub.FullName, "nested.txt"), "x");
 
         var sut = new WopiContainer(_tempDir.FullName, "folder-id");
 
@@ -77,7 +77,7 @@ public class WopiContainerTests : IDisposable
     [Fact]
     public void ChildCount_NonExistentFolder_ReturnsZeroRatherThanThrowing()
     {
-        var sut = new WopiContainer(Path.Combine(_tempDir.FullName, "missing"), "folder-id");
+        var sut = new WopiContainer(Path.Join(_tempDir.FullName, "missing"), "folder-id");
         Assert.Equal(0, sut.ChildCount);
     }
 }

--- a/test/WopiHost.FileSystemProvider.Tests/WopiFileSystemProviderTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/WopiFileSystemProviderTests.cs
@@ -29,9 +29,9 @@ public class WopiFileSystemProviderTests : IDisposable
         _root = Directory.CreateTempSubdirectory("WopiFsTest_");
         _sub = _root.CreateSubdirectory("sub");
         _empty = _root.CreateSubdirectory("empty");
-        _rootTxtPath = Path.Combine(_root.FullName, "root.txt");
-        _rootDocxPath = Path.Combine(_root.FullName, "root.docx");
-        _leafTxtPath = Path.Combine(_sub.FullName, "leaf.txt");
+        _rootTxtPath = Path.Join(_root.FullName, "root.txt");
+        _rootDocxPath = Path.Join(_root.FullName, "root.docx");
+        _leafTxtPath = Path.Join(_sub.FullName, "leaf.txt");
         File.WriteAllText(_rootTxtPath, "root-txt");
         File.WriteAllText(_rootDocxPath, "root-docx");
         File.WriteAllText(_leafTxtPath, "leaf");
@@ -121,7 +121,7 @@ public class WopiFileSystemProviderTests : IDisposable
     {
         // A pre-populated InMemoryFileIds that does NOT contain the root path.
         var ids = new InMemoryFileIds(NullLogger<InMemoryFileIds>.Instance);
-        ids.AddFile(Path.Combine(_root.FullName, "unrelated"));
+        ids.AddFile(Path.Join(_root.FullName, "unrelated"));
 
         Assert.Throws<InvalidOperationException>(() =>
             CreateProvider(_root.FullName, ids));
@@ -519,7 +519,7 @@ public class WopiFileSystemProviderTests : IDisposable
         var file = await _sut.CreateWopiChildFile(rootId, "new.txt");
 
         Assert.NotNull(file);
-        Assert.True(File.Exists(Path.Combine(_root.FullName, "new.txt")));
+        Assert.True(File.Exists(Path.Join(_root.FullName, "new.txt")));
     }
 
     [Fact]
@@ -528,7 +528,7 @@ public class WopiFileSystemProviderTests : IDisposable
         var file = await _sut.CreateWopiChildFile(_sut.RootContainer.Identifier, "rootless.txt");
 
         Assert.NotNull(file);
-        Assert.True(File.Exists(Path.Combine(_root.FullName, "rootless.txt")));
+        Assert.True(File.Exists(Path.Join(_root.FullName, "rootless.txt")));
     }
 
     [Fact]
@@ -553,7 +553,8 @@ public class WopiFileSystemProviderTests : IDisposable
     public async Task CreateWopiChildResource_FileWithTraversalName_Throws(string name)
     {
         // The name is client-controlled (relative/suggested target); a name that isn't a single
-        // path segment must be rejected before Path.Combine so it can't escape the root.
+        // path segment must be rejected before it is joined to the container path so it can't
+        // escape the root.
         var rootId = _sut.RootContainer.Identifier;
         await Assert.ThrowsAsync<ArgumentException>(() => _sut.CreateWopiChildFile(rootId, name));
     }
@@ -566,7 +567,7 @@ public class WopiFileSystemProviderTests : IDisposable
         var folder = await _sut.CreateWopiChildContainer(rootId, "new-folder");
 
         Assert.NotNull(folder);
-        Assert.True(Directory.Exists(Path.Combine(_root.FullName, "new-folder")));
+        Assert.True(Directory.Exists(Path.Join(_root.FullName, "new-folder")));
     }
 
     [Fact]
@@ -691,7 +692,7 @@ public class WopiFileSystemProviderTests : IDisposable
 
         Assert.True(ok);
         Assert.False(File.Exists(_rootTxtPath));
-        Assert.True(File.Exists(Path.Combine(_root.FullName, "renamed.txt")));
+        Assert.True(File.Exists(Path.Join(_root.FullName, "renamed.txt")));
     }
 
     [Fact]
@@ -720,7 +721,7 @@ public class WopiFileSystemProviderTests : IDisposable
 
         Assert.True(ok);
         Assert.False(Directory.Exists(_empty.FullName));
-        Assert.True(Directory.Exists(Path.Combine(_root.FullName, "renamed")));
+        Assert.True(Directory.Exists(Path.Join(_root.FullName, "renamed")));
     }
 
     [Fact]
@@ -790,5 +791,30 @@ public class WopiFileSystemProviderTests : IDisposable
         var result = await _sut.GetWopiContainerByName(rootId, "does-not-exist");
 
         Assert.Null(result);
+    }
+
+    // ---------- Stored-path invariant ----------
+
+    [Fact]
+    public async Task StoredPaths_AfterScanCreateAndRenameFlows_AreAllRooted()
+    {
+        // GetWopiFiles/GetWopiContainers enumerate the stored path directly, so every path the
+        // provider records must be absolute — a relative entry would silently resolve against
+        // the process working directory. Exercises every map-mutating flow (initial scan,
+        // create, rename) starting from a relative root path, the input most likely to leak
+        // relativeness into the map.
+        var ids = new InMemoryFileIds(NullLogger<InMemoryFileIds>.Instance);
+        var provider = CreateProvider(rootPath: "sub", ids);
+
+        var containerId = provider.RootContainer.Identifier;
+        var file = await provider.CreateWopiChildFile(containerId, "invariant.txt");
+        var folder = await provider.CreateWopiChildContainer(containerId, "invariant-folder");
+        Assert.NotNull(file);
+        Assert.NotNull(folder);
+        await provider.RenameWopiFile(file.Identifier, "invariant-renamed.txt");
+        await provider.RenameWopiContainer(folder.Identifier, "invariant-folder-renamed");
+
+        Assert.All(ids.StoredPaths, path =>
+            Assert.True(Path.IsPathRooted(path), $"Stored path '{path}' is not rooted."));
     }
 }

--- a/test/WopiHost.FileSystemProvider.Tests/WopiFileTests.cs
+++ b/test/WopiHost.FileSystemProvider.Tests/WopiFileTests.cs
@@ -8,7 +8,7 @@ public class WopiFileTests : IDisposable
 
     public WopiFileTests()
     {
-        _filePath = Path.Combine(_tempDir.FullName, "doc.docx");
+        _filePath = Path.Join(_tempDir.FullName, "doc.docx");
         File.WriteAllText(_filePath, "hello world");
         _sut = new WopiFile(_filePath, "id-1");
     }
@@ -113,7 +113,7 @@ public class WopiFileTests : IDisposable
         // FileNotFoundException for missing paths on Unix), then remove it so
         // stat/statx fails with ENOENT. The owner helper surfaces that as IOException,
         // which the Owner getter swallows to honour the best-effort contract.
-        var transient = Path.Combine(_tempDir.FullName, "transient.docx");
+        var transient = Path.Join(_tempDir.FullName, "transient.docx");
         File.WriteAllText(transient, "x");
         var sut = new WopiFile(transient, "id-transient");
         File.Delete(transient);

--- a/test/WopiHost.IntegrationTests/Fixtures/MutatingEndpointsFixture.cs
+++ b/test/WopiHost.IntegrationTests/Fixtures/MutatingEndpointsFixture.cs
@@ -30,7 +30,7 @@ public sealed class MutatingEndpointsFixture : IDisposable
 
     public MutatingEndpointsFixture()
     {
-        _tempRoot = Path.Combine(Path.GetTempPath(), $"wopi-mut-{Guid.NewGuid():N}");
+        _tempRoot = Path.Join(Path.GetTempPath(), $"wopi-mut-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempRoot);
         CopyDirectory(TestPaths.WopiDocsRoot, _tempRoot);
 

--- a/test/WopiHost.IntegrationTests/Fixtures/TestPaths.cs
+++ b/test/WopiHost.IntegrationTests/Fixtures/TestPaths.cs
@@ -13,7 +13,7 @@ internal static class TestPaths
         // Walk up from the test bin directory to the repo root, then into sample/wopi-docs.
         var assemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
         var dir = new DirectoryInfo(assemblyDir);
-        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "WOPI.slnx")))
+        while (dir is not null && !File.Exists(Path.Join(dir.FullName, "WOPI.slnx")))
         {
             dir = dir.Parent;
         }
@@ -21,6 +21,6 @@ internal static class TestPaths
         {
             throw new InvalidOperationException("Could not locate repo root (WOPI.slnx) walking up from test bin.");
         }
-        return Path.Combine(dir.FullName, "sample", "wopi-docs");
+        return Path.Join(dir.FullName, "sample", "wopi-docs");
     }
 }

--- a/test/WopiHost.IntegrationTests/PutRelativeFileOverwrite501Tests.cs
+++ b/test/WopiHost.IntegrationTests/PutRelativeFileOverwrite501Tests.cs
@@ -107,7 +107,7 @@ public sealed class PutRelativeFileOverwrite501Tests : IClassFixture<PutRelative
 
         public Fixture()
         {
-            _tempRoot = Path.Combine(Path.GetTempPath(), $"wopi-pr501-{Guid.NewGuid():N}");
+            _tempRoot = Path.Join(Path.GetTempPath(), $"wopi-pr501-{Guid.NewGuid():N}");
             Directory.CreateDirectory(_tempRoot);
 
             WopiBackend = new WopiBackendFactory(

--- a/test/WopiHost.SmokeTests/Fixtures/TestPaths.cs
+++ b/test/WopiHost.SmokeTests/Fixtures/TestPaths.cs
@@ -12,7 +12,7 @@ internal static class TestPaths
     {
         var assemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
         var dir = new DirectoryInfo(assemblyDir);
-        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "WOPI.slnx")))
+        while (dir is not null && !File.Exists(Path.Join(dir.FullName, "WOPI.slnx")))
         {
             dir = dir.Parent;
         }
@@ -20,6 +20,6 @@ internal static class TestPaths
         {
             throw new InvalidOperationException("Could not locate repo root (WOPI.slnx) walking up from test bin.");
         }
-        return Path.Combine(dir.FullName, "sample", "wopi-docs");
+        return Path.Join(dir.FullName, "sample", "wopi-docs");
     }
 }


### PR DESCRIPTION
Closes #586

Converts every path-building call site to the API that matches its intent, so CodeQL's `cs/path-combine` has nothing left to flag — no query exclusion needed.

## What changed

- **Group A — no-op Combines removed.** `GetWopiFiles`/`GetWopiContainers` combined `_wopiAbsolutePath` with a `folderPath` that is always absolute, so the Combine only "worked" because it silently dropped the first argument. The folder path is now used directly, and the load-bearing invariant ("every path stored in `InMemoryFileIds` is rooted") is pinned by a new test (`StoredPaths_AfterScanCreateAndRenameFlows_AreAllRooted`) that exercises scan, create, and rename flows from a relative root path. A small `internal StoredPaths` view on `InMemoryFileIds` supports it (`InternalsVisibleTo` is already wired for test assemblies).
- **Group B — validated-leaf concatenation → `Path.Join`** across the FS provider (by-name lookups, suggested names, create, rename). Semantics-preserving for valid names and defense-in-depth: a rooted name now degrades to a confined invalid subpath instead of replacing the base. Validation guards are untouched — `Path.Join` passes `..` through, so single-segment validation remains the actual traversal defense.
- **Group C — ctor root resolution** keeps the explicit `IsPathRooted` branch and switches the relative branch to `Join`. Since `Join` treats `null` as empty where `Combine` threw, the ctor now rejects a null/empty `RootPath` up front (`ArgumentException.ThrowIfNullOrEmpty`) instead of silently rooting at the content root.
- **Group D** — sample Cobalt loader (+ the matching snippet in `src/WopiHost.Cobalt/README.md`).
- **Group E** — mechanical sweep over ~50 test-fixture sites; second arguments are literals or test-generated leaf names, so behavior-identical.
- **Convention documented** in `CLAUDE.md` (Code Style section), including the `Join`-treats-null-as-empty gotcha.

`grep -rn 'Path.Combine' src sample test infra` now returns nothing.

## Verification

- `dotnet build WOPI.slnx` — clean (warnings-as-errors).
- Test runs: FileSystemProvider.Tests 139 ✅, Discovery.Tests 89 ✅, Core.Tests 362 ✅, IntegrationTests 144 ✅. E2E/Smoke fixture changes are literal leaf-name conversions, compile-verified via the solution build.

## Notes for review

- **Overlap with #581:** the issue was written against the post-#581 code state (its by-name single-segment guards from b7924c1 aren't on `master` yet). This PR touches the same `Path.Combine(dirPath, name)` lines in the by-name lookups, so whichever merges second has a trivial conflict to resolve — the end state is guard (from #581) + `Path.Join` (from here). On `master` today, the `Join` conversion already closes the rooted-name lookup hole on its own.
- **Post-merge:** re-check the code-scanning dashboard — new scans should report no `cs/path-combine` hits; alerts 270, 273–282 stay dismissed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
