### PR TITLE
refactor(fs-provider): map enumerated paths to ids via Select

### DIFF
--- a/src/WopiHost.FileSystemProvider/WopiFileSystemProvider.cs
+++ b/src/WopiHost.FileSystemProvider/WopiFileSystemProvider.cs
@@ -134,12 +134,11 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
             ? fileExtensions.SelectMany(ext => Directory.EnumerateFiles(folderPath, "*" + ext, options))
             : Directory.EnumerateFiles(folderPath, "*", options);
 
-        foreach (var path in enumeration)
+        // The startup scan can't have seen entries created or renamed by another process
+        // sharing the tree; ids derive deterministically from paths, so each enumerated path
+        // registers lazily instead of hiding the file from the listing.
+        foreach (var fileId in enumeration.Select(_fileIds.GetOrAddFileId))
         {
-            // The startup scan can't have seen entries created or renamed by another process
-            // sharing the tree; ids derive deterministically from paths, so register such a path
-            // lazily instead of hiding the file from the listing.
-            var fileId = _fileIds.GetOrAddFileId(path);
             var result = await GetWopiFile(fileId, cancellationToken).ConfigureAwait(false)
                 ?? throw new FileNotFoundException($"File '{fileId}' not found");
             yield return result;
@@ -158,11 +157,10 @@ public partial class WopiFileSystemProvider : IWopiStorageProvider, IWopiWritabl
             throw new DirectoryNotFoundException($"Directory '{identifier}' not found");
         }
 
-        foreach (var directory in Directory.GetDirectories(folderPath))
+        // Same lazy registration as GetWopiFiles — a folder created or renamed by another
+        // process must still show up in the listing.
+        foreach (var folderId in Directory.GetDirectories(folderPath).Select(_fileIds.GetOrAddFileId))
         {
-            // Same lazy registration as GetWopiFiles — a folder created or renamed by another
-            // process must still show up in the listing.
-            var folderId = _fileIds.GetOrAddFileId(directory);
             var result = await GetWopiContainer(folderId, cancellationToken).ConfigureAwait(false)
                 ?? throw new DirectoryNotFoundException($"Directory '{folderId}' not found");
             yield return result;


### PR DESCRIPTION
## Summary

Resolves CodeQL quality alerts [#290](https://github.com/petrsvihlik/WopiHost/security/code-scanning/290) and [#294](https://github.com/petrsvihlik/WopiHost/security/code-scanning/294) (`cs/linq/missed-select`, precision: high).

Both flagged loops in `WopiFileSystemProvider` — `GetWopiFiles` and `GetWopiContainers` — immediately mapped their iteration variable through `_fileIds.GetOrAddFileId` and never touched it again, which is exactly the pattern the rule targets. The mapping now lives in a `.Select(_fileIds.GetOrAddFileId)` on the sequence itself, and the lazy-registration comments moved above the loops.

Semantics are unchanged: `Select` is lazy, so `GetOrAddFileId` still runs per item as the async iterator advances, same as before.

Verified against the query source ([`Linq/Helpers.qll`](https://github.com/github/codeql/blob/main/csharp/ql/lib/Linq/Helpers.qll)) that the alert won't just shift to the next statement — `missedSelectOpportunity` explicitly excludes first statements whose initializer contains an `await`, which is what remains in both loop bodies.

## Testing

- `dotnet build src/WopiHost.FileSystemProvider` — clean, 0 warnings
- `dotnet test test/WopiHost.FileSystemProvider.Tests` — 182/182 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)