### PR TITLE
ci: harden workflows per Semgrep findings (SHA pins, Dependabot cooldown, shell-injection defense)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,12 @@ updates:
       - cobalt-github-packages
     schedule:
       interval: daily
+    # Wait out the window in which a freshly published (possibly compromised) version
+    # is most likely to be yanked — this repo auto-merges Dependabot PRs, so the
+    # cooldown is the only human-latency between a new package and master.
+    # Security-advisory updates are a separate flow and are not delayed by this.
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 20
     commit-message:
       prefix: "chore(deps)"
@@ -38,6 +44,10 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    # Same rationale as the nuget cooldown; actions are SHA-pinned, so this delays
+    # the pin bump until a new action release has had a week of public scrutiny.
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore(ci)"
     groups:

--- a/.github/workflows/bump-baseline.yml
+++ b/.github/workflows/bump-baseline.yml
@@ -37,7 +37,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || (!github.event.release.prerelease && !github.event.release.draft) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: master
           fetch-depth: 0
@@ -45,15 +45,19 @@ jobs:
       - name: Determine target version
         id: target
         shell: bash
+        # Event data enters the script through env vars rather than ${{ }} interpolation
+        # into the script body, so a crafted tag or dispatch input can't inject shell syntax.
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
           set -euo pipefail
           if [[ "${{ github.event_name }}" == "release" ]]; then
             # Strip a leading "v" so both "v8.0.0" and "8.0.0" tag styles work.
-            TARGET="${{ github.event.release.tag_name }}"
-            TARGET="${TARGET#v}"
+            TARGET="${RELEASE_TAG#v}"
             echo "Source: release tag → $TARGET"
           else
-            TARGET="${{ github.event.inputs.version }}"
+            TARGET="$INPUT_VERSION"
             if [[ -z "$TARGET" ]]; then
               # No explicit target — query NuGet.org for the latest stable WopiHost.Core
               # version. WopiHost.Core is the canonical packable assembly (every other
@@ -72,14 +76,23 @@ jobs:
             echo "::error::Could not determine a target version."
             exit 1
           fi
+          # Everything downstream (sed replacement, branch name, PR text) assumes a plain
+          # version string; refuse anything shaped differently at the boundary.
+          if [[ ! "$TARGET" =~ ^[0-9]+(\.[0-9]+){1,3}(-[0-9A-Za-z.]+)?$ ]]; then
+            echo "::error::Target '$TARGET' is not a version string."
+            exit 1
+          fi
           echo "version=$TARGET" >> "$GITHUB_OUTPUT"
 
       - name: Update Directory.Build.props
         id: update
         shell: bash
+        # env indirection for the same reason as the previous step: the output derives from
+        # event data, so interpolating it into the script would reintroduce the injection here.
+        env:
+          NEW: ${{ steps.target.outputs.version }}
         run: |
           set -euo pipefail
-          NEW="${{ steps.target.outputs.version }}"
           FILE="Directory.Build.props"
           CURRENT="$(sed -n 's:.*<PackageValidationBaselineVersion>\([^<]*\)</PackageValidationBaselineVersion>.*:\1:p' "$FILE" | head -n 1)"
           echo "Current baseline: ${CURRENT:-<unset>}"
@@ -136,7 +149,7 @@ jobs:
         # exited early), it logs "no changes" and creates no PR. The action also re-uses the
         # named branch — re-running this workflow updates the existing PR in place rather than
         # spawning duplicates.
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore/bump-package-validation-baseline-${{ steps.target.outputs.version }}

--- a/.github/workflows/ci-failure-diagnosis.yml
+++ b/.github/workflows/ci-failure-diagnosis.yml
@@ -23,13 +23,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
 
       - name: Diagnose the failure
         continue-on-error: true
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@558b1d6cab4085c7753fe402c10bef0fbb92ac7a # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
 
@@ -33,7 +33,7 @@ jobs:
         id: claude-review
         # Informational: a reviewer hiccup never fails the PR's checks.
         continue-on-error: true
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@558b1d6cab4085c7753fe402c10bef0fbb92ac7a # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # The code-review plugin owns the structured review + posting (buffered inline

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@558b1d6cab4085c7753fe402c10bef0fbb92ac7a # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/codebase-audit.yml
+++ b/.github/workflows/codebase-audit.yml
@@ -25,12 +25,12 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0   # the audit may inspect history
 
       - name: Run codebase audit
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@558b1d6cab4085c7753fe402c10bef0fbb92ac7a # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup .NET 10.0
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: '10.0.x'
 
@@ -42,7 +42,7 @@ jobs:
         run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> $GITHUB_ENV
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           languages: csharp
           config-file: ./.github/codeql/codeql-config.yml
@@ -54,6 +54,6 @@ jobs:
         run: dotnet build WOPI.slnx --no-restore --configuration Release /p:ContinuousIntegrationBuild=true
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           category: "/language:csharp"

--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -24,13 +24,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0   # need the merge-base to diff the PR
 
       - name: Check for documentation drift
         continue-on-error: true
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@558b1d6cab4085c7753fe402c10bef0fbb92ac7a # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: '--allowed-tools "Bash,Read,Grep,Glob"'

--- a/.github/workflows/e2e-collabora.yml
+++ b/.github/workflows/e2e-collabora.yml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30 # Generous: Collabora image pull on a clean cache + Playwright install.
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup .NET 10.0
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: '10.0.x'
 
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload Playwright traces on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-traces
           path: |

--- a/.github/workflows/e2e-onlyoffice.yml
+++ b/.github/workflows/e2e-onlyoffice.yml
@@ -30,10 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40 # Generous: the ~4.3 GB ONLYOFFICE image pull on a clean cache + engine warmup.
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup .NET 10.0
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: '10.0.x'
 
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload Playwright traces on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-traces-onlyoffice
           path: |

--- a/.github/workflows/infersharp.yml
+++ b/.github/workflows/infersharp.yml
@@ -39,13 +39,13 @@ jobs:
     environment:
       name: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'Integrate Pull Request' || '' }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 2
 
       - name: Setup .NET 10.0
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: '10.0.x'
 
@@ -83,14 +83,14 @@ jobs:
 
       - name: Upload SARIF to GitHub code scanning
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           sarif_file: infer-out/report.sarif
           category: infersharp
 
       - name: Upload Infer# output as artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: infer-output
           path: |

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
     - name: Setup .NET 10.0
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: '10.0.x'
     - name: Set Cobalt packages token
@@ -40,12 +40,12 @@ jobs:
     - name: Upload test results to Codecov
       # Runs even when the Test step failed — reporting the failed tests is the whole point.
       if: ${{ !cancelled() }}
-      uses: codecov/test-results-action@v1
+      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ${{ github.workspace }}/test-results/*.junit.xml
     - name: Upload coverage to Qlty
-      uses: qltysh/qlty-action/coverage@v2
+      uses: qltysh/qlty-action/coverage@fd52dc852530a708d68c3b7342f8d33d1df4cd55 # v2
       with:
         oidc: true
         # Coverlet's MSBuild integration emits `coverage.info` per project at
@@ -58,11 +58,11 @@ jobs:
         # .qlty/qlty.toml.
         skip-missing-files: true
     - name: Codecov
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
     - name: FOSSA scan + policy gate
-      uses: fossa-contrib/fossa-action@v4
+      uses: fossa-contrib/fossa-action@d28f0c947e7406706981a62a91ecc009bcc39fd7 # v4
       with:
         fossa-api-key: ${{ secrets.FOSSA_API_KEY }}
         skip-test: false
@@ -81,9 +81,9 @@ jobs:
         # macos-latest: Apple Silicon (arm64) -> plain `stat` symbol.
         os: [windows-latest, macos-latest]
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
     - name: Setup .NET 10.0
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: '10.0.x'
     - name: Set Cobalt packages token

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -19,13 +19,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
 
       - name: Triage the issue
         continue-on-error: true   # a triage hiccup must never block anything
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@558b1d6cab4085c7753fe402c10bef0fbb92ac7a # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: '--allowed-tools "Bash,Read,Grep,Glob"'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v6
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,12 +30,12 @@ jobs:
     environment:
       name: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'Integrate Pull Request' || '' }}
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 2
     - name: Setup .NET 10.0
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: '10.0.x'
     - name: Set Cobalt packages token
@@ -55,24 +55,24 @@ jobs:
     - name: Upload test results to Codecov
       # Runs even when the Test step failed — reporting the failed tests is the whole point.
       if: ${{ !cancelled() }}
-      uses: codecov/test-results-action@v1
+      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ${{ github.workspace }}/test-results/*.junit.xml
     - name: Upload coverage to Qlty
-      uses: qltysh/qlty-action/coverage@v2
+      uses: qltysh/qlty-action/coverage@fd52dc852530a708d68c3b7342f8d33d1df4cd55 # v2
       with:
         oidc: true
         files: "test/**/coverage.info"
         # See integrate.yml for the rationale.
         skip-missing-files: true
     - name: Codecov
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: FOSSA scan + policy gate
-      uses: fossa-contrib/fossa-action@v4
+      uses: fossa-contrib/fossa-action@d28f0c947e7406706981a62a91ecc009bcc39fd7 # v4
       with:
         fossa-api-key: ${{ secrets.FOSSA_API_KEY }}
         skip-test: false
@@ -94,12 +94,12 @@ jobs:
     environment:
       name: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'Integrate Pull Request' || '' }}
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 1
     - name: Setup .NET 10.0
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: '10.0.x'
     - name: Set Cobalt packages token
@@ -117,12 +117,12 @@ jobs:
     environment:
       name: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'Integrate Pull Request' || '' }}
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 1
     - name: Setup .NET 10.0
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: '10.0.x'
     - name: Set Cobalt packages token
@@ -262,7 +262,7 @@ jobs:
         fi
     - name: Post sticky PR comment
       if: always()
-      uses: marocchino/sticky-pull-request-comment@v3
+      uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3
       with:
         header: apicompat-report
         path: apicompat-report.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
     - name: Setup .NET 10.0
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: '10.0.x'
     - name: Extract version from tag
@@ -33,14 +33,14 @@ jobs:
     - name: Test
       run: dotnet test --no-build --verbosity normal --configuration Release /p:CollectCoverage=true /p:CoverletOutputFormat=lcov
     - name: Upload coverage to Qlty
-      uses: qltysh/qlty-action/coverage@v2
+      uses: qltysh/qlty-action/coverage@fd52dc852530a708d68c3b7342f8d33d1df4cd55 # v2
       with:
         oidc: true
         files: "**/coverage.*.info"
         # See integrate.yml for the rationale.
         skip-missing-files: true
     - name: Codecov
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
     - name: Pack
@@ -48,7 +48,7 @@ jobs:
       # nupkg/snupkg files land in artifacts/package/release/.
       run: dotnet pack --no-build --include-symbols --verbosity normal --configuration Release /p:PackageVersion="${{ steps.get_version.outputs.version-without-v }}"
     - name: Upload artifacts
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: "NuGet packages"
         path: artifacts/package/release
@@ -57,7 +57,7 @@ jobs:
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
     - name: Upload artifacts to the GitHub release
-      uses: Roang-zero1/github-upload-release-artifacts-action@v3
+      uses: Roang-zero1/github-upload-release-artifacts-action@87271b3f8dca9feb9e9d44381fddd2db7f09d6e1 # v3
       with:
         args: artifacts/package/release
       env:

--- a/.github/workflows/semgrep-guardrails.yml
+++ b/.github/workflows/semgrep-guardrails.yml
@@ -1,0 +1,45 @@
+name: Semgrep guardrails
+
+# Enforces the repo-local rules in .semgrep/ — CLAUDE.md conventions codified as
+# executable PR checks. Deliberately separate from the Semgrep AppSec Platform
+# integration: the platform's managed scans run the org's security policy on every
+# push and PR through the GitHub App (no workflow needed for that), but managed
+# scans never read rule files from the repository, so repo-specific guardrails run
+# here. This job uses no token and sends no telemetry — rules and scan stay in-repo.
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore:
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/FUNDING.yml'
+      - 'LICENSE'
+      - '.claude/**'
+  push:
+    branches: [master]
+    paths-ignore:
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/FUNDING.yml'
+      - 'LICENSE'
+      - '.claude/**'
+
+permissions:
+  contents: read
+
+jobs:
+  guardrails:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Install Semgrep
+        # Pinned like every other CI dependency. Dependabot doesn't manage pipx
+        # run-lines, so bump the version manually now and then.
+        run: pipx install semgrep==1.168.0
+
+      - name: Run guardrail rules
+        # --error fails the check on any finding. The rules start from a clean
+        # baseline, so a finding is always a newly introduced violation.
+        run: semgrep scan --config .semgrep/ --error --metrics=off

--- a/.github/workflows/wopi-validator.yml
+++ b/.github/workflows/wopi-validator.yml
@@ -50,12 +50,12 @@ jobs:
       name: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'Integrate Pull Request' || '' }}
     steps:
       - name: Checkout WopiHost
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: |
             8.0.x
@@ -65,7 +65,7 @@ jobs:
         run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> $GITHUB_ENV
 
       - name: Cache validator package
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.nuget/packages/wopivalidator
           key: wopivalidator-${{ hashFiles('tools/wopi-validator/wopi-validator.csproj') }}
@@ -271,7 +271,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: wopi-validator-output
           path: |
@@ -281,7 +281,7 @@ jobs:
 
       - name: Post results to PR
         if: always() && github.event_name == 'pull_request_target'
-        uses: marocchino/sticky-pull-request-comment@v3
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3
         with:
           header: wopi-validator
           message: |

--- a/.semgrep/guardrails.yaml
+++ b/.semgrep/guardrails.yaml
@@ -1,0 +1,48 @@
+# Repo-specific guardrails: CLAUDE.md conventions the type system can't enforce,
+# codified as executable PR checks. Run by .github/workflows/semgrep-guardrails.yml.
+# The Semgrep AppSec Platform's managed scans run the org policy only and never read
+# rule files from the repository — these rules exist solely for that workflow.
+rules:
+  - id: wopihost-no-path-combine
+    languages: [csharp]
+    severity: WARNING
+    message: >-
+      Path.Combine silently drops every earlier segment when a later one is rooted,
+      which turns concatenation intent into a traversal bug (CodeQL cs/path-combine).
+      Use Path.Join for concatenation. When absolute-or-relative resolution is the
+      point, pair the call with an explicit Path.IsPathRooted check and suppress this
+      finding inline with `// nosemgrep: wopihost-no-path-combine` plus a short
+      justification. See CLAUDE.md, "Path building".
+    pattern-either:
+      - pattern: Path.Combine(...)
+      - pattern: System.IO.Path.Combine(...)
+
+  - id: wopihost-no-nullable-in-csproj
+    languages: [generic]
+    severity: ERROR
+    paths:
+      include:
+        - "**/*.csproj"
+    pattern: "<Nullable>"
+    message: >-
+      Nullable reference types are enabled solution-wide in the root
+      Directory.Build.props. A per-project <Nullable> forks that single source of
+      truth and drifts silently. Remove it. See CLAUDE.md, "Code Style & Build Rules".
+
+  - id: wopihost-use-central-package-versions
+    languages: [generic]
+    severity: ERROR
+    paths:
+      include:
+        - "**/*.csproj"
+      exclude:
+        # The wopi-validator helper opts out of central package management
+        # (ManagePackageVersionsCentrally=false) so Dependabot can pin the upstream
+        # net8-era validator package independently of the solution.
+        - "/tools/**"
+    pattern: "<PackageReference ... Version="
+    message: >-
+      Package versions are managed centrally in Directory.Packages.props; a Version
+      attribute on a PackageReference bypasses central package management (or fails
+      restore with NU1008). Declare the version in Directory.Packages.props and keep
+      the PackageReference version-less. See CLAUDE.md, "Code Style & Build Rules".

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,6 @@
+# Semgrep skips .gitignored files only when git metadata is reachable; container
+# mounts of a worktree or exported archives degrade to crawling everything —
+# including the multi-gigabyte artifacts/ build output. Mirror .gitignore so
+# git-less runs stay scoped to source.
+:include .gitignore
+.git/


### PR DESCRIPTION
Completes the Semgrep adoption tracked in #567 — fixes the actionable findings from the AppSec Platform scan (61 of 68; scoping note at the bottom for the other 7) and adds the one repo-side piece the platform cannot provide: repo-local guardrail rules with a minimal CI job to run them.

## Why no `semgrep ci` workflow is needed for the security scanning

The platform integration runs as **Semgrep Managed Scans** via the GitHub App: it clones the repo on Semgrep's ephemeral infrastructure, scans every push and PR diff-aware, and reports a `semgrep-cloud-platform/scan` status check (already visible on this PR). No CLI or action in the pipeline — the org policy's security rules are fully wired. The only thing managed scans deliberately do **not** do is read rule files from the repository, which is what part 4 below is for.

## 1. Pin all actions to full commit SHAs — `github-actions-mutable-action-tag`, 53 findings

Every `uses:` reference across all workflows is now pinned to a 40-character commit SHA, with the previous tag kept as a trailing comment:

```yaml
- uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
```

**Why it matters here specifically:** a repointed release tag on a third-party action (`codecov/*`, `fossa-contrib/*`, `qltysh/*`, `marocchino/*`, …) executes inside jobs that hold `COBALT_PACKAGES_TOKEN`, `CODECOV_TOKEN`, and `FOSSA_API_KEY` — and on same-repo PRs those jobs run with **no approval gate**. That's the same blast radius as a pwn-request, minus the human in the loop. This class of attack is not hypothetical (tj-actions/changed-files, trivy-action, kics-github-action compromises).

**Update automation is unaffected:** Dependabot's `github-actions` ecosystem natively supports SHA pins — it bumps the hash on new releases and rewrites the version comment, and the existing minor/patch grouping keeps working because the comment tells it which semver each pin corresponds to.

## 2. Dependabot cooldown — `dependabot-missing-cooldown`, 2 findings

Both ecosystems now wait 7 days before proposing a newly published version:

```yaml
cooldown:
  default-days: 7
```

This repo runs **daily Dependabot with auto-merge**, so before this change a freshly published (possibly compromised) package version could reach `master` with near-zero human latency. Most package compromises are detected and yanked within days — the cooldown makes the pipeline wait out exactly that window. Advisory-driven security updates are a separate Dependabot flow and are not delayed.

## 3. No event data interpolated into shell — `run-shell-injection`, 1 finding (+1 latent)

`bump-baseline.yml` interpolated `github.event.release.tag_name` and `github.event.inputs.version` directly into a `run:` script. Fixed with the standard `env:` indirection — and taken one step further than the finding:

- the **derived step output** (`steps.target.outputs.version`) was interpolated into the *second* script, which would have reintroduced the exact same injection one step later; it now travels via `env:` too;
- the resolved target must match a **version-string shape** before it flows into `sed`, the PR branch name, or the PR body — anything else fails the run at the boundary.

Honest severity note: both inputs are only settable by users with write access (creating releases / dispatching workflows), so this was defense-in-depth, not a live vulnerability. Semgrep's "High" is inflated for this repo's threat model; fixed anyway because the fix is three lines and tag names with shell metacharacters would have broken the script regardless.

## 4. Repo-local guardrails: `.semgrep/` rules + `semgrep-guardrails.yml`

The durable-value half of the #567 research: CLAUDE.md conventions the type system can't enforce, codified as executable PR checks. Managed scans run the org policy only and never consume repo rule files (per Semgrep's docs, custom rules require Semgrep in CI) — so a minimal, platform-independent job runs exactly the rules in [.semgrep/guardrails.yaml](../blob/claude/semgrep-ci-hardening/.semgrep/guardrails.yaml): no token, no telemetry, `--error` so any finding blocks.

| Rule | Convention it enforces |
|---|---|
| `wopihost-no-path-combine` | `Path.Join` for concatenation; a justified `Path.IsPathRooted`-paired `Path.Combine` suppresses inline with `nosemgrep` (CLAUDE.md "Path building", follow-up to #588) |
| `wopihost-no-nullable-in-csproj` | `<Nullable>` lives once in `Directory.Build.props` |
| `wopihost-use-central-package-versions` | no `Version=` on `PackageReference` (CPM via `Directory.Packages.props`); the CPM-opted-out `tools/wopi-validator` helper is excluded |

Verified both ways: **0 findings** on the current tree (3 rules × 387 files — clean baseline, so any future finding is a real regression), and all rules fire on a deliberate-violations fixture. A `.semgrepignore` mirroring `.gitignore` keeps git-less local runs (container mounts of a worktree) from crawling `artifacts/`.

## Deliberately out of scope

The 7 remaining findings (5× `pull-request-target-code-checkout` + 2 duplicate mutable-tag hits on the same lines) are **not** addressed here. That design is intentional: fork PRs are routed into the `Integrate Pull Request` environment before any code runs, which is the documented mitigation for fork-PRs-that-need-secrets. Follow-ups tracked separately: verifying the environment's required-reviewers protection, narrowing workflow-level `permissions:` to job level, then triaging those findings as acknowledged in the platform.

## Verification

- `actionlint` over all workflows (including the new one): no errors; the only remaining output is pre-existing shellcheck style/info notices in scripts this PR doesn't touch.
- Every pinned SHA was resolved directly from the tag it replaces via the GitHub API (`repos/{action}/commits/{tag}`).
- Guardrail rules validated against the repo (clean) and against a violations fixture (all rules fire).

With this, everything from the #567 evaluation is in place: platform-managed security scanning on pushes + PRs (no pipeline changes needed), findings from the first scan fixed, and repo-specific guardrails enforced in CI.

Closes #567.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
