### PR TITLE
chore: pin collabora/code to 26.04.2.4.1 + Dependabot docker tracking via docker-compose.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,15 @@ updates:
           - "minor"
           - "patch"
 
+  - package-ecosystem: docker
+    directory: "/infra/WopiHost.AppHost"
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps)"
+
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/infra/WopiHost.AppHost/Program.cs
+++ b/infra/WopiHost.AppHost/Program.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Configuration;
 
 var builder = DistributedApplication.CreateBuilder(args);

--- a/infra/WopiHost.AppHost/Program.cs
+++ b/infra/WopiHost.AppHost/Program.cs
@@ -124,6 +124,20 @@ IResourceBuilder<ProjectResource> AddWebFrontend(string name, IResourceBuilder<P
         .WithExternalHttpEndpoints();
 }
 
+// tag is null when the image line carries no tag qualifier.
+static (string Image, string? Tag) ReadContainerImage(string composePath, string service)
+{
+    var content = File.ReadAllText(composePath);
+    var m = Regex.Match(content,
+        $@"(?m)^[ \t]+{Regex.Escape(service)}:[ \t]*\n[ \t]+image:[ \t]*(\S+)");
+    if (!m.Success)
+        throw new InvalidOperationException(
+            $"No 'image:' declaration found for service '{service}' in {composePath}.");
+    var imageRef = m.Groups[1].Value;
+    var sep = imageRef.LastIndexOf(':');
+    return sep < 0 ? (imageRef, null) : (imageRef[..sep], imageRef[(sep + 1)..]);
+}
+
 // Every backend lane accumulates here so the shared lock + storage backends below wire to all of
 // them in one pass: a single Redis instance coordinates locks across every backend (a lock taken
 // while editing in one client is visible to the other), and a single Azurite blob container backs
@@ -257,9 +271,13 @@ if (builder.Configuration.GetValue("AppHost:IncludeOidcSample", defaultValue: fa
 // WaitFor on both backend and frontend blocks them until Collabora's /hosting/discovery returns 200 —
 // otherwise Polly's Standard-Retry pipeline logs noisy "ResponseEnded" / 10s timeouts on first load
 // while loolwsd is still binding.
+var composePath = Path.Join(AppContext.BaseDirectory, "docker-compose.yml");
 if (useCollabora)
 {
-    var collabora = builder.AddContainer("collabora", "collabora/code", "26.04.2.4.1")
+    var (collaboraImage, collaboraTag) = ReadContainerImage(composePath, "collabora");
+    var collabora = (collaboraTag is { Length: > 0 }
+        ? builder.AddContainer("collabora", collaboraImage, collaboraTag)
+        : builder.AddContainer("collabora", collaboraImage))
            // host.docker.internal needs an explicit --add-host=host.docker.internal:host-gateway on
            // Linux Docker Engine — Docker Desktop on Mac/Windows wires it implicitly, but the Linux
            // daemon doesn't. Without this, Collabora's WOPI callbacks from inside the container can't
@@ -320,7 +338,10 @@ if (useCollabora)
 // dependents until /hosting/discovery answers. Opt-in via "AppHost:UseOnlyOffice"=true.
 if (useOnlyOffice)
 {
-    var onlyoffice = builder.AddContainer("onlyoffice", "onlyoffice/documentserver")
+    var (ooImage, ooTag) = ReadContainerImage(composePath, "onlyoffice");
+    var onlyoffice = (ooTag is { Length: > 0 }
+        ? builder.AddContainer("onlyoffice", ooImage, ooTag)
+        : builder.AddContainer("onlyoffice", ooImage))
            // Same host-gateway reasoning as Collabora — ONLYOFFICE's WOPI callbacks reach the backend
            // at host.docker.internal:5051.
            .WithContainerRuntimeArgs("--add-host", "host.docker.internal:host-gateway")

--- a/infra/WopiHost.AppHost/Program.cs
+++ b/infra/WopiHost.AppHost/Program.cs
@@ -259,7 +259,7 @@ if (builder.Configuration.GetValue("AppHost:IncludeOidcSample", defaultValue: fa
 // while loolwsd is still binding.
 if (useCollabora)
 {
-    var collabora = builder.AddContainer("collabora", "collabora/code")
+    var collabora = builder.AddContainer("collabora", "collabora/code", "26.04.2.4.1")
            // host.docker.internal needs an explicit --add-host=host.docker.internal:host-gateway on
            // Linux Docker Engine — Docker Desktop on Mac/Windows wires it implicitly, but the Linux
            // daemon doesn't. Without this, Collabora's WOPI callbacks from inside the container can't

--- a/infra/WopiHost.AppHost/WopiHost.AppHost.csproj
+++ b/infra/WopiHost.AppHost/WopiHost.AppHost.csproj
@@ -13,6 +13,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Update="docker-compose.yml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Aspire.Hosting.AppHost" />
     <PackageReference Include="Aspire.Hosting.Azure.Storage" />
     <PackageReference Include="Aspire.Hosting.Redis" />

--- a/infra/WopiHost.AppHost/docker-compose.yml
+++ b/infra/WopiHost.AppHost/docker-compose.yml
@@ -1,0 +1,8 @@
+# Container image versions — Dependabot (docker ecosystem) tracks these image: lines
+# and opens bump PRs when new stable tags are published.
+# WopiHost.AppHost reads this file at startup; do not rename or remove it.
+services:
+  collabora:
+    image: collabora/code:26.04.2.4.1
+  onlyoffice:
+    image: onlyoffice/documentserver


### PR DESCRIPTION
## Summary

- Pins the `collabora/code` image from unpinned (`latest`) to `26.04.2.4.1` — the current latest stable as of 2026-08-01.
- Moves both container image tags (`collabora/code`, `onlyoffice/documentserver`) to `infra/WopiHost.AppHost/docker-compose.yml` so Dependabot's docker ecosystem owns future bumps. `Program.cs` is not touched by future bumps — only `docker-compose.yml` is.
- No breaking changes flagged in upstream Collabora release notes (the upstream releases page only publishes Helm chart releases; no CODE-specific notes are available there).

## What changed

**`infra/WopiHost.AppHost/docker-compose.yml`** (new)
The single source of truth for container image versions. Not used to run containers — exists so Dependabot can track `image:` lines and open bump PRs.

**`.github/dependabot.yml`**
Added a `docker` ecosystem entry pointed at `/infra/WopiHost.AppHost` (monthly schedule, 7-day cooldown, matching the nuget/github-actions entries). Dependabot will open future bump PRs that touch only `docker-compose.yml`.

**`infra/WopiHost.AppHost/Program.cs`**
Added `ReadContainerImage` helper that parses `image:` from a docker-compose service block and returns `(image, tag)`. Both `AddContainer` call sites now read from `docker-compose.yml` instead of hardcoding the strings. `onlyoffice/documentserver` was also unpinned — it's now in the manifest and Dependabot will open the first pin PR for it too.

**`infra/WopiHost.AppHost/WopiHost.AppHost.csproj`**
Added `<None Update="docker-compose.yml" CopyToOutputDirectory="PreserveNewest">` so the file is available alongside the AppHost binary at runtime.

## Test plan

- [ ] `dotnet build infra/WopiHost.AppHost`
- [ ] `dotnet run --project infra/WopiHost.AppHost` with `AppHost:UseCollabora=true`, open the Aspire dashboard, confirm the `collabora` container starts healthy and a document loads in the iframe.
- [ ] Confirm Dependabot opens a PR touching only `docker-compose.yml` on the next monthly cycle (or trigger manually via the Dependabot UI).