### PR TITLE
chore: pin AppHost container images + Renovate custom-manager tracking (alternative to #623)

### DIFF
--- a/infra/WopiHost.AppHost/Program.cs
+++ b/infra/WopiHost.AppHost/Program.cs
@@ -259,7 +259,7 @@ if (builder.Configuration.GetValue("AppHost:IncludeOidcSample", defaultValue: fa
 // while loolwsd is still binding.
 if (useCollabora)
 {
-    var collabora = builder.AddContainer("collabora", "collabora/code")
+    var collabora = builder.AddContainer("collabora", "collabora/code", "26.04.2.4.1")
            // host.docker.internal needs an explicit --add-host=host.docker.internal:host-gateway on
            // Linux Docker Engine — Docker Desktop on Mac/Windows wires it implicitly, but the Linux
            // daemon doesn't. Without this, Collabora's WOPI callbacks from inside the container can't
@@ -320,7 +320,7 @@ if (useCollabora)
 // dependents until /hosting/discovery answers. Opt-in via "AppHost:UseOnlyOffice"=true.
 if (useOnlyOffice)
 {
-    var onlyoffice = builder.AddContainer("onlyoffice", "onlyoffice/documentserver")
+    var onlyoffice = builder.AddContainer("onlyoffice", "onlyoffice/documentserver", "9.4.0.1")
            // Same host-gateway reasoning as Collabora — ONLYOFFICE's WOPI callbacks reach the backend
            // at host.docker.internal:5051.
            .WithContainerRuntimeArgs("--add-host", "host.docker.internal:host-gateway")

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabledManagers": ["custom.regex"],
+  "dependencyDashboard": false,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Tracks container image tags passed as C# string literals to Aspire's builder.AddContainer(name, image, tag) calls in the AppHost. Dependabot's docker ecosystems only parse Dockerfile/docker-compose files and never see a reference embedded in source, so Renovate patches these literals in place. enabledManagers keeps Renovate scoped to this manager only — NuGet and GitHub Actions stay owned by Dependabot to avoid duplicate PRs for the same dependency.",
+      "managerFilePatterns": ["/^infra/WopiHost\\.AppHost/Program\\.cs$/"],
+      "matchStrings": [
+        "AddContainer\\(\"[^\"]+\", \"(?<depName>[^\"]+)\", \"(?<currentValue>[^\"]+)\"\\)"
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Waits out the window in which a freshly published (possibly compromised) image tag is most likely to be yanked — the same rationale as the 7-day Dependabot cooldown in .github/dependabot.yml.",
+      "matchManagers": ["custom.regex"],
+      "minimumReleaseAge": "7 days",
+      "commitMessagePrefix": "chore(deps)",
+      "labels": ["dependencies"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Competing implementation to #623 — same goal (pin the AppHost container images and automate future tag bumps), different mechanism. This is the Renovate `customManagers` approach: the image tags stay as C# string literals in `Program.cs`, and Renovate is taught to patch them in place. Pick one PR and close the other.

- Pins `collabora/code` to `26.04.2.4.1` (current latest stable, same pin as #623).
- Pins `onlyoffice/documentserver` to `9.4.0.1` (current latest stable on Docker Hub) — a bot can only bump an existing version literal, so the pin is a prerequisite for tracking in either approach.
- Adds `renovate.json` with a single custom regex manager that matches both `builder.AddContainer(name, image, tag)` call sites and resolves new tags via the `docker` datasource.

## How this differs from #623

| | #623 (Dependabot + compose manifest) | This PR (Renovate custom manager) |
|---|---|---|
| Source of truth | New `docker-compose.yml`, read at startup via a regex parser in `Program.cs` | The `AddContainer` literals in `Program.cs` — no indirection |
| Future bump PRs touch | `docker-compose.yml` only | `Program.cs` (one string literal) |
| New runtime moving parts | Compose file must ship beside the binary; parse failure breaks AppHost startup | None — runtime behavior is unchanged |
| Bots involved | Dependabot only | Renovate (scoped via `enabledManagers` to just this manager; NuGet + Actions stay with Dependabot) |
| Config bug status | `package-ecosystem: docker` doesn't parse compose files — needs `docker-compose` to function | `renovate-config-validator` passes |

## Prerequisites & caveats

- **The Renovate GitHub App must be installed** on this repo (or a self-hosted runner configured) — `renovate.json` alone activates nothing.
- `dependencyDashboard` is off to keep issue noise down alongside Dependabot; delete that line if the dashboard is wanted.
- `minimumReleaseAge: 7 days` mirrors the Dependabot cooldown rationale (wait out the yank window for freshly published tags).
- `.github/workflows/dependabot-auto-merge.yml` gates on `dependabot[bot]`, so Renovate's bump PRs will **not** auto-merge. Extending that trust to `renovate[bot]` is a separate security decision, deliberately not part of this PR.

## Test plan

- [x] `renovate-config-validator renovate.json` — passes ("Config validated successfully").
- [x] `dotnet build infra/WopiHost.AppHost` — 0 warnings, 0 errors.
- [ ] `dotnet run --project infra/WopiHost.AppHost` — confirm both containers start healthy on the pinned tags and a document loads in each editor.
- [ ] After installing the Renovate app: confirm the first run detects both dependencies (Renovate log lists `collabora/code` and `onlyoffice/documentserver`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
