### PR TITLE
Pin the toolchain and add a nightly .NET 11 preview lane

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
 FROM mcr.microsoft.com/devcontainers/dotnet
 
-# Install .NET 9 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:9.0 /usr/share/dotnet /usr/share/dotnet
+# Install .NET 10 SDK. Must satisfy the global.json pin, which admits only 10.0.x.
+COPY --from=mcr.microsoft.com/dotnet/sdk:10.0 /usr/share/dotnet /usr/share/dotnet

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,6 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS sdk
+
 FROM mcr.microsoft.com/devcontainers/dotnet
 
 # Install .NET 10 SDK. Must satisfy the global.json pin, which admits only 10.0.x.
-COPY --from=mcr.microsoft.com/dotnet/sdk:10.0 /usr/share/dotnet /usr/share/dotnet
+COPY --from=sdk /usr/share/dotnet /usr/share/dotnet

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,3 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS sdk
-
-FROM mcr.microsoft.com/devcontainers/dotnet
-
-# Install .NET 10 SDK. Must satisfy the global.json pin, which admits only 10.0.x.
-COPY --from=sdk /usr/share/dotnet /usr/share/dotnet
+# Ships the .NET 10 SDK, satisfying the global.json pin (10.0.x). The tag is explicit
+# rather than `latest` so the image can't drift onto a major the pin would reject.
+FROM mcr.microsoft.com/devcontainers/dotnet:2-10.0

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "C# (.NET 9)",
+  "name": "C# (.NET 10)",
   "build": {
     "dockerfile": "./Dockerfile",
     "context": "."

--- a/.github/workflows/net11-preview.yml
+++ b/.github/workflows/net11-preview.yml
@@ -1,0 +1,166 @@
+name: .NET 11 Preview
+
+# Early-warning lane for the next major. Nothing here gates a pull request: the workflow has no
+# `pull_request` trigger at all, so it is structurally incapable of blocking a merge. That is also
+# why the jobs are NOT marked continue-on-error — a lane that always reports green is worse than
+# no lane, and visibility is the entire point.
+#
+# Two independent questions, one job each:
+#   preview-runtime — do the net10.0 binaries still behave when executed on the .NET 11 runtime?
+#   preview-sdk     — does the repo still compile when the .NET 11 SDK's Roslyn + analyzers build it?
+#
+# Neither job changes a TargetFramework. Retargeting is a separate, later exercise; this only
+# surfaces the breakage early, while there is still time to react to it.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 04:53 UTC nightly. Off-the-hour, and clear of the heavy container lanes
+    # (e2e-collabora 03:17, e2e-onlyoffice 03:37) so they don't contend for runner capacity.
+    - cron: '53 4 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  preview-runtime:
+    name: net10.0 binaries on the .NET 11 runtime
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # Two separate setup-dotnet steps on purpose: dotnet-quality applies to every version listed
+      # in the step, so a combined `10.0.x` + `11.0.x` list would drag the .NET 10 install onto a
+      # preview build too, and the "build exactly like a PR does" property below would be lost.
+      - name: Setup .NET 10 SDK (builds the code)
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Setup .NET 11 SDK (supplies the runtime under test)
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Set Cobalt packages token
+        run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> $GITHUB_ENV
+
+      # global.json still pins the .NET 10 SDK here, so this build is byte-for-byte the PR build.
+      # Only the runtime the tests execute on differs, which keeps the blame surface to the runtime.
+      - name: Build
+        run: |
+          dotnet restore
+          dotnet build --no-restore /p:ContinuousIntegrationBuild=true
+
+      - name: Install Playwright browsers (for sample-app smoke tests)
+        run: pwsh artifacts/bin/WopiHost.SmokeTests/debug/playwright.ps1 install --with-deps chromium
+
+      # Roll-forward policies below LatestMajor only engage when the requested runtime is ABSENT,
+      # and .NET 10 is installed on this runner — so DOTNET_ROLL_FORWARD=Major would quietly keep
+      # the tests on .NET 10 and this lane would pass without having tested anything. Prove the
+      # mechanism against a throwaway net10.0 app before trusting the run below.
+      #
+      # The probe lives in RUNNER_TEMP, outside the repo, so neither global.json nor the root
+      # Directory.Build.props applies to it.
+      - name: Verify roll-forward reaches .NET 11
+        run: |
+          set -euo pipefail
+          dotnet --list-runtimes
+          probe="$RUNNER_TEMP/rollforward-probe"
+          mkdir -p "$probe"
+          cat > "$probe/probe.csproj" <<'CSPROJ'
+          <Project Sdk="Microsoft.NET.Sdk">
+            <PropertyGroup>
+              <OutputType>Exe</OutputType>
+              <TargetFramework>net10.0</TargetFramework>
+            </PropertyGroup>
+          </Project>
+          CSPROJ
+          cat > "$probe/Program.cs" <<'PROGRAM'
+          System.Console.WriteLine(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);
+          PROGRAM
+          dotnet build "$probe/probe.csproj" -c Release -o "$probe/out"
+          actual=$(DOTNET_ROLL_FORWARD=LatestMajor DOTNET_ROLL_FORWARD_TO_PRERELEASE=1 dotnet "$probe/out/probe.dll")
+          echo "Probe reports: $actual"
+          case "$actual" in
+            '.NET 11.'*)
+              echo "Roll-forward reaches .NET 11." ;;
+            *)
+              echo "::error::Roll-forward did not reach .NET 11 (got '$actual'). The test run would silently exercise .NET 10 instead."
+              exit 1 ;;
+          esac
+
+      - name: Test on the .NET 11 runtime
+        run: dotnet test --no-build --verbosity normal
+        env:
+          DOTNET_ROLL_FORWARD: LatestMajor
+          DOTNET_ROLL_FORWARD_TO_PRERELEASE: '1'
+
+  preview-sdk:
+    name: Build with the .NET 11 SDK (still targeting net10.0)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup .NET 10 SDK
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Setup .NET 11 SDK (preview)
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Set Cobalt packages token
+        run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> $GITHUB_ENV
+
+      # Widens the committed pin for this job only. The version floor deliberately stays at
+      # 10.0.100: a preview such as 11.0.100-preview.x sorts BELOW 11.0.100 under semver, so
+      # raising the floor to 11 would make the resolver reject the very SDK under test.
+      - name: Unpin the SDK (this job only)
+        run: |
+          set -euo pipefail
+          jq '.sdk.rollForward = "latestMajor" | .sdk.allowPrerelease = true' global.json > global.json.tmp
+          mv global.json.tmp global.json
+          cat global.json
+
+      # Same failure mode as the roll-forward probe above: if resolution fell back to .NET 10 this
+      # job would just re-run the ordinary build and report a meaningless green.
+      - name: Verify the .NET 11 SDK is selected
+        run: |
+          set -euo pipefail
+          selected=$(dotnet --version)
+          echo "Selected SDK: $selected"
+          case "$selected" in
+            11.*)
+              echo "Building with the .NET 11 SDK." ;;
+            *)
+              echo "::error::Expected an 11.x SDK, got '$selected'. This job would only repeat the .NET 10 build."
+              exit 1 ;;
+          esac
+
+      # The packaged libraries are the signal that matters — they are what ships to NuGet. Kept as
+      # its own step so that an Aspire break in the full-solution step below cannot mask the result.
+      # Expect new-analyzer-wave failures here: TreatWarningsAsErrors is on globally, so every
+      # newly-default-on diagnostic lands as a build error. That is the point of the lane.
+      - name: Build packaged libraries
+        run: |
+          set -euo pipefail
+          for proj in src/*/*.csproj; do
+            echo "::group::$proj"
+            dotnet build "$proj" /p:ContinuousIntegrationBuild=true
+            echo "::endgroup::"
+          done
+
+      # infra/WopiHost.AppHost pins Aspire.AppHost.Sdk as an MSBuild SDK, which couples it to SDK
+      # internals far more tightly than a PackageReference does — it is the likeliest first break,
+      # and the fix is upstream in Aspire rather than in this repo. Non-fatal so a red AppHost
+      # doesn't bury the src/ result above.
+      - name: Build the full solution
+        continue-on-error: true
+        run: dotnet build WOPI.slnx /p:ContinuousIntegrationBuild=true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,16 @@ All contributions are welcome:
 - Feel free to submit a PR, just make sure your code adheres the existing codestyle, and to [.NET's Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/)
 
 ## Toolchain
-The SDK is pinned in [`global.json`](global.json): any .NET 10 SDK satisfies it, and `allowPrerelease: false` keeps preview SDKs out of ordinary builds. `LangVersion` is pinned in `Directory.Build.props` for the same reason — left at `latest` it would track whatever compiler happens to be installed.
 
-Together that means **.NET 11 previews can be installed side by side without affecting this repo**. Builds keep selecting the .NET 10 SDK and C# 14 no matter what else is on the machine.
+The SDK is pinned in [`global.json`](global.json): any .NET 10 SDK satisfies
+it, and `allowPrerelease: false` keeps preview SDKs out of ordinary builds.
+`LangVersion` is pinned in `Directory.Build.props` for the same reason — left
+at `latest` it would track whatever compiler happens to be installed.
 
-Preview SDKs and runtimes are exercised nightly by [`.github/workflows/net11-preview.yml`](.github/workflows/net11-preview.yml). It is informational, gates nothing, and changes no target framework.
+Together that means **.NET 11 previews can be installed side by side without
+affecting this repo**. Builds keep selecting the .NET 10 SDK and C# 14 no
+matter what else is on the machine.
+
+Preview SDKs and runtimes are exercised nightly by
+[`.github/workflows/net11-preview.yml`](.github/workflows/net11-preview.yml).
+It is informational, gates nothing, and changes no target framework.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,3 +15,10 @@ All contributions are welcome:
 
 ## Pull requests
 - Feel free to submit a PR, just make sure your code adheres the existing codestyle, and to [.NET's Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/)
+
+## Toolchain
+The SDK is pinned in [`global.json`](global.json): any .NET 10 SDK satisfies it, and `allowPrerelease: false` keeps preview SDKs out of ordinary builds. `LangVersion` is pinned in `Directory.Build.props` for the same reason — left at `latest` it would track whatever compiler happens to be installed.
+
+Together that means **.NET 11 previews can be installed side by side without affecting this repo**. Builds keep selecting the .NET 10 SDK and C# 14 no matter what else is on the machine.
+
+Preview SDKs and runtimes are exercised nightly by [`.github/workflows/net11-preview.yml`](.github/workflows/net11-preview.yml). It is informational, gates nothing, and changes no target framework.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,11 @@
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
 		<ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-		<LangVersion>latest</LangVersion>
+		<!-- Pinned rather than `latest`. `latest` resolves to whatever the installed SDK's compiler
+		     supports, so a side-by-side preview SDK silently raises the language version and its
+		     analyzer defaults — and with TreatWarningsAsErrors that breaks the build on one
+		     machine and not another. Raise deliberately, together with the global.json pin. -->
+		<LangVersion>14.0</LangVersion>
 		<!-- Centralize bin/obj/package/publish output under repo-root artifacts/.
 		     ArtifactsPath is pinned here so that test projects (which have their
 		     own Directory.Build.props) don't end up with a separate test/artifacts/. -->

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
### Motivation

Phases 0–2 of #633 — start exercising .NET 11 previews without retargeting anything. **No `TargetFramework` changes; nothing here can gate a PR.**

**Phase 0 — pin the toolchain.** This part isn't really .NET 11 work; it fixes a hazard that exists today. There was no `global.json`, so SDK selection was "highest installed" — anyone installing a newer SDK for an unrelated project silently switched this repo to a different Roslyn, analyzer wave and MSBuild. With `TreatWarningsAsErrors` on globally, that shows up as build breaks reproducing on one machine and not another. `LangVersion` had the same shape of problem: `latest` tracks the installed compiler rather than naming a version.

Both are now pinned. Any 10.0.x SDK satisfies `global.json` (`rollForward: latestFeature`), and `allowPrerelease: false` keeps previews out of ordinary builds — so a preview SDK can be installed side by side with no effect here. That's what makes local experimentation safe.

**Phases 1–2 — the preview lane** (`.github/workflows/net11-preview.yml`, nightly + `workflow_dispatch`), two independent questions:

| Job | Question | How |
|---|---|---|
| `preview-runtime` | Do the `net10.0` binaries still behave on the .NET 11 runtime? | Builds with the pinned .NET 10 SDK — byte-for-byte the PR build — then runs the suite under roll-forward, so drift is attributable to the runtime alone. |
| `preview-sdk` | Does the repo still compile under the .NET 11 SDK's Roslyn/analyzers? | Widens the pin for that job only, builds `src/**` still targeting `net10.0`. |

Two deliberate deviations from the plan in #633, both worth calling out:

- **The jobs are not `continue-on-error`.** The issue proposed it, but the workflow has no `pull_request` trigger, so it's already structurally incapable of blocking a merge — and `continue-on-error` would make it report green forever, which is the exact failure mode the lane exists to avoid.
- **Both jobs assert the toolchain they claim to test was actually selected.** Roll-forward policies below `LatestMajor` only engage when the requested runtime is *absent*, and CI installs .NET 10 alongside — so the more obvious `DOTNET_ROLL_FORWARD=Major` would have kept tests on .NET 10 and passed without testing anything. `preview-sdk` has the same trap, and both now fail loudly instead.

**Unplanned but necessary:** the devcontainer installed the 9.0 SDK while the repo targets `net10.0` — already unable to build, and the `global.json` pin would have turned that into a hard SDK-resolution failure. Bumped to 10.0.

Also note `preview-sdk` keeps the version floor at `10.0.100` when widening the pin: a preview like `11.0.100-preview.x` sorts *below* `11.0.100` under semver, so raising the floor to 11 would make the resolver reject the very SDK under test.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added — n/a, no product code changed; the workflow *is* the test surface
- [ ] Tests are passing — **not verified locally** (see below)
- [x] Docs have been updated (if applicable) — new *Toolchain* section in `CONTRIBUTING.md`
- [x] Temporary settings have been reverted to defaults
- [x] Adheres to [.NET Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/)

### How to test

⚠️ **No .NET SDK was available in the authoring environment, so none of this was built locally.** CI on this PR is the first real execution. What *was* verified mechanically:

- `global.json` and `devcontainer.json` parse as JSON; the workflow parses as YAML.
- The `jq` rewrite in `preview-sdk` produces the intended `latestMajor` / `allowPrerelease: true` document.
- The probe heredocs survive YAML block-scalar de-indentation (delimiters land at column 0), and generate a well-formed csproj + `Program.cs`.
- Both version guards were exercised against representative strings — `.NET 11.0.0-preview.1.…` and `11.0.100-preview.1.…` pass; `.NET 10.0.10` and `10.0.203` correctly fail the job.

To verify for real:

1. **Phase 0 is the load-bearing risk** — ordinary CI on this PR should be completely unchanged. C# 14 is what `latest` already resolved to under the .NET 10 SDK, so the `LangVersion` pin should be a no-op. Any new diagnostic appearing in the normal build means that assumption was wrong.
2. Run the new lane manually: **Actions → .NET 11 Preview → Run workflow**. Expect the two verification steps to confirm `.NET 11.x` / `11.x` before any real work happens.
3. If .NET 11 previews aren't published under `dotnet-quality: preview` yet, the `setup-dotnet` steps fail — that's a legible failure, not a silent pass.
4. Expect `preview-sdk` to find real work eventually; with `TreatWarningsAsErrors` global, every newly-default-on analyzer diagnostic lands as a build error. That's the lane doing its job, not a regression.

Worth saying plainly: per the discussion on #633, my recommendation was Phase 0 now and the CI lane at RC, when analyzer waves are frozen and findings are actionable rather than churn. Merging Phases 1–2 now means accepting some months of preview noise on a nightly job — the risk being that a lane which is red for unactionable reasons stops getting read. Easy to mitigate by leaving the workflow on `workflow_dispatch` only and adding the `schedule:` block back at RC.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAjzSoFNvJLN6CeXaFawWa)_