### PR TITLE
Pin SSH.NET past GHSA-q939-rpr3-3284 to unblock restore

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -57,6 +57,10 @@
          flags as a high-severity stack overflow on circular schema references; 2.7.5 is the
          first patched 2.x release. -->
     <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
+    <!-- Testcontainers pulls SSH.NET 2025.1.0, which GHSA-q939-rpr3-3284 flags as a
+         high-severity path traversal in ScpClient.Download() on recursive downloads;
+         2026.0.0 is the first patched release. -->
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
### Motivation

**master is currently red through no change of its own.** A NuGet audit advisory for `SSH.NET` 2025.1.0 was published between the last green build (`integrate.yml` #374, Aug 12 13:44) and the next scheduled run, so `dotnet restore` now fails:

```
error NU1903: Warning As Error: Package 'SSH.NET' 2025.1.0 has a known high severity
vulnerability, https://github.com/advisories/GHSA-q939-rpr3-3284
```

[GHSA-q939-rpr3-3284](https://github.com/advisories/GHSA-q939-rpr3-3284) is a high-severity (CVSS 7.1) path traversal in `ScpClient.Download()` on recursive downloads: a malicious SCP server can supply `../` filenames and write outside the target directory. Affected `≤ 2025.1.0`, patched in `2026.0.0`.

This affects **every** solution-level restore, so `pull_request.yml` and `integrate.yml` will fail on the next PR or push. It surfaced first on the nightly [.NET 11 Preview run](https://github.com/petrsvihlik/WopiHost/actions/runs/31672718892) only because that was the first workflow to run after the advisory landed — it is not a .NET 11 issue.

**Why a pin rather than a bump:** `SSH.NET` is transitive via `Testcontainers` (used by the Redis, Integration, AzureStorage and AzureLock test projects). Testcontainers **4.13.0 is already its own latest release**, and its nuspec declares `SSH.NET >= 2025.1.0` — so there is no parent version to upgrade to, and Dependabot cannot fix this on its own. `2026.0.0` satisfies that range.

**Why this shape:** it follows the existing `Transitive security pins` convention in `Directory.Packages.props` rather than introducing a competing one. `CentralPackageTransitivePinningEnabled` is already `true`, so the `PackageVersion` entry alone force-upgrades the transitive reference — no `PackageReference` is needed in the consuming projects, matching the `Microsoft.OpenApi` 2.7.5 precedent directly above it. The comment names the parent and the first patched release, per the section's documented policy.

Exit condition is the one the section describes: drop the entry once Testcontainers ships a release referencing `SSH.NET >= 2026.0.0`.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added — n/a, dependency-version change only
- [ ] Tests are passing — see below; CI on this PR is the verification
- [ ] Docs have been updated (if applicable) — n/a
- [x] Temporary settings have been reverted to defaults
- [x] Adheres to [.NET Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/)

### How to test

No .NET SDK is available in the authoring environment, so this was not built locally. Verified mechanically: the file still parses as XML, and Testcontainers 4.13.0's nuspec was read directly from nuget.org to confirm the `SSH.NET >= 2025.1.0` range that `2026.0.0` must satisfy.

CI on this PR is the real check — a green `build` job means restore now succeeds.

⚠️ **The one risk worth a reviewer's eye:** `2025.1.0 → 2026.0.0` is a major-version bump of a library Testcontainers was compiled against, so there is some chance of a runtime binding or behaviour change. The Testcontainers-based suites (`WopiHost.IntegrationTests`, `WopiHost.RedisLockProvider.Tests`, `WopiHost.AzureStorageProvider.Tests`, `WopiHost.AzureLockProvider.Tests`) all exercise real containers and run in the `build` job, so a genuine incompatibility should fail here rather than reach master.

### Not included

The same run showed the `preview-sdk` job reporting **success** despite hitting this identical restore failure — its `Build the full solution` step is `continue-on-error: true`, which was meant to stop an Aspire break from burying the `src/**` result but masks any solution-wide breakage. Left out of this PR to keep an urgent CI unblock focused; happy to tighten it separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAjzSoFNvJLN6CeXaFawWa)_