### PR TITLE
Retire the Microsoft.OpenApi pin and stop the preview lane tolerating restore failures

### DIFF
--- a/.github/workflows/net11-preview.yml
+++ b/.github/workflows/net11-preview.yml
@@ -144,6 +144,14 @@ jobs:
               exit 1 ;;
           esac
 
+      # Restore is deliberately its own fatal step, ahead of both builds. The full-solution build
+      # below tolerates failures, and without a separate restore that tolerance extends to the
+      # dependency graph as well: a solution-wide NU1903 audit failure once let this job report
+      # green on a commit whose restore was broken for every other workflow in the repo. Only
+      # compilation is meant to be tolerated here, never resolution.
+      - name: Restore
+        run: dotnet restore WOPI.slnx
+
       # The packaged libraries are the signal that matters — they are what ships to NuGet. Kept as
       # its own step so that an Aspire break in the full-solution step below cannot mask the result.
       # Expect new-analyzer-wave failures here: TreatWarningsAsErrors is on globally, so every
@@ -153,14 +161,14 @@ jobs:
           set -euo pipefail
           for proj in src/*/*.csproj; do
             echo "::group::$proj"
-            dotnet build "$proj" /p:ContinuousIntegrationBuild=true
+            dotnet build "$proj" --no-restore /p:ContinuousIntegrationBuild=true
             echo "::endgroup::"
           done
 
       # infra/WopiHost.AppHost pins Aspire.AppHost.Sdk as an MSBuild SDK, which couples it to SDK
       # internals far more tightly than a PackageReference does — it is the likeliest first break,
       # and the fix is upstream in Aspire rather than in this repo. Non-fatal so a red AppHost
-      # doesn't bury the src/ result above.
+      # doesn't bury the src/ result above; the restore step above bounds what that can hide.
       - name: Build the full solution
         continue-on-error: true
-        run: dotnet build WOPI.slnx /p:ContinuousIntegrationBuild=true
+        run: dotnet build WOPI.slnx --no-restore /p:ContinuousIntegrationBuild=true

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="StackExchange.Redis" Version="3.1.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
@@ -53,10 +53,6 @@
     patched release to watch for.
   -->
   <ItemGroup Label="Transitive security pins">
-    <!-- Microsoft.AspNetCore.OpenApi pulls Microsoft.OpenApi 2.0.0, which GHSA-v5pm-xwqc-g5wc
-         flags as a high-severity stack overflow on circular schema references; 2.7.5 is the
-         first patched 2.x release. -->
-    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <!-- Testcontainers pulls SSH.NET 2025.1.0, which GHSA-q939-rpr3-3284 flags as a
          high-severity path traversal in ScpClient.Download() on recursive downloads;
          2026.0.0 is the first patched release. -->


### PR DESCRIPTION
### Motivation

Two follow-ups from the SSH.NET incident (#637), one commit each.

**1. Retire the `Microsoft.OpenApi` security pin.**

`Microsoft.AspNetCore.OpenApi` 10.0.10 declared `Microsoft.OpenApi -> 2.0.0`, inside the range [GHSA-v5pm-xwqc-g5wc](https://github.com/advisories/GHSA-v5pm-xwqc-g5wc) flags (`>= 2.0.0-preview.11, <= 2.7.4`), so the version had to be force-upgraded to keep NuGet audit from breaking restore.

**10.0.11 declares `[2.7.5, 3.0.0)`** — the patched release is now its floor, so the pin no longer changes resolution. That's exactly the removal condition the section's own comment states: *"Remove an entry once its parent package ships a patched version transitively."*

Worth doing deliberately rather than waiting: the pin would otherwise sit there forever. `2.7.5` still satisfies the new range, so once Dependabot bumps the parent nothing fails and nothing signals that the entry has become dead weight.

Verified `Microsoft.AspNetCore.OpenApi` is the only path to `Microsoft.OpenApi` here — no project references it directly, and `Scalar.AspNetCore` 2.16.17 declares no dependencies at all. `CentralPackageTransitivePinningEnabled` stays, since the SSH.NET entry still needs it.

**2. Stop `preview-sdk` tolerating restore failures.**

The full-solution build is `continue-on-error: true` so an Aspire break can't bury the `src/**` result. But with restore folded into that step, the tolerance covered dependency resolution as well — so when the SSH.NET advisory landed, [that job reported green](https://github.com/petrsvihlik/WopiHost/actions/runs/31672718892) on a commit no other workflow in the repo could restore. Only `preview-runtime` caught it, because its build step is fatal.

Restore is now its own fatal step and both builds pass `--no-restore`:

| Failure | Before | After |
|---|---|---|
| Broken dependency graph / audit advisory | tolerated ❌ | **fatal** ✅ |
| AppHost won't compile under a preview SDK | tolerated ✅ | tolerated ✅ |

It runs after the SDK unpin, so resolution still happens under the .NET 11 SDK being exercised. Side benefit: one solution-level restore instead of a per-project restore in the `src/**` loop.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added — n/a, dependency-version and CI-config change only
- [ ] Tests are passing — CI on this PR is the verification (see below)
- [ ] Docs have been updated (if applicable) — n/a
- [x] Temporary settings have been reverted to defaults
- [x] Adheres to [.NET Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/)

### How to test

No .NET SDK in the authoring environment, so nothing was built locally. Verified mechanically: `Directory.Packages.props` still parses as XML, the workflow still parses as YAML with `Restore` correctly ordered after the SDK unpin and before both builds, and `continue-on-error` now on the final step only. The `10.0.11 -> [2.7.5, 3.0.0)` dependency range was read from the package's nuspec on nuget.org rather than inferred.

**The load-bearing check is `build` on this PR.** A green restore proves the transitive resolution lands on a patched `Microsoft.OpenApi` without the pin. If the parent bump were wrong, restore would fail with the same NU1903 the pin was suppressing — so this is self-verifying in the direction that matters.

Change 2 only affects `.github/workflows/net11-preview.yml`, which has no `pull_request` trigger, so **it cannot be exercised by this PR's CI**. It runs on the next nightly or a manual dispatch after merge. The change is small and its failure mode is conservative — the worst case is the lane going red for something it previously ignored, which is the intent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAjzSoFNvJLN6CeXaFawWa)_