### PR TITLE
chore(ci): Harden CI against transient flakes — image-pull retries, Renovate fixture-tag tracking, Cobalt probe race fix

### DIFF
--- a/.github/actions/prepull-testcontainers-images/action.yml
+++ b/.github/actions/prepull-testcontainers-images/action.yml
@@ -1,0 +1,35 @@
+name: Pre-pull Testcontainers images
+description: >
+  Pulls the container images the Testcontainers-backed test fixtures use, retrying transient
+  registry failures. Without this, a single reset connection during an image pull surfaces as
+  dozens of unrelated test failures at fixture-init time (every test in the Azurite/Redis
+  collections fails with DockerImageNotFoundException) instead of one clearly-named failed step.
+runs:
+  using: composite
+  steps:
+    - name: Pull fixture images with retries
+      shell: bash
+      run: |
+        # The images are pinned as C# string constants inside the fixtures (AzuriteFixture,
+        # RedisFixture), so they are extracted from source rather than listed a second time
+        # here. The pattern requires a quoted "name:tag" whose tag starts with a digit, which
+        # matches image pins ("mcr.microsoft.com/azure-storage/azurite:3.35.0", "redis:7-alpine")
+        # and no other string literal in fixture code.
+        mapfile -t images < <(grep -rhoE '"[a-z0-9.-]+(/[a-z0-9._-]+)*:[0-9][A-Za-z0-9._-]*"' test --include='*Fixture.cs' | tr -d '"' | sort -u)
+        if [ "${#images[@]}" -eq 0 ]; then
+          echo "::warning::No fixture container images found under test/**/*Fixture.cs — the extraction pattern has likely drifted from the fixtures. Testcontainers will pull at test time without retries."
+          exit 0
+        fi
+        for image in "${images[@]}"; do
+          for attempt in 1 2 3 4 5; do
+            if docker pull "$image"; then
+              continue 2
+            fi
+            echo "Pull of $image failed (attempt $attempt/5)."
+            if [ "$attempt" -lt 5 ]; then
+              sleep $((attempt * 10))
+            fi
+          done
+          echo "::error::Could not pull $image after 5 attempts — registry unreachable."
+          exit 1
+        done

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -33,6 +33,8 @@ jobs:
       run: dotnet build --no-restore /p:ContinuousIntegrationBuild=true
     - name: Install Playwright browsers (for sample-app smoke tests)
       run: pwsh artifacts/bin/WopiHost.SmokeTests/debug/playwright.ps1 install --with-deps chromium
+    - name: Pre-pull Testcontainers images
+      uses: ./.github/actions/prepull-testcontainers-images
     - name: Test
       # Emit JUnit XML alongside lcov coverage so Codecov Test Analytics can ingest run
       # times / failures. {assembly} keeps each test project's results in a distinct file.

--- a/.github/workflows/net11-preview.yml
+++ b/.github/workflows/net11-preview.yml
@@ -92,6 +92,8 @@ jobs:
               exit 1 ;;
           esac
 
+      - name: Pre-pull Testcontainers images
+        uses: ./.github/actions/prepull-testcontainers-images
       - name: Test on the .NET 11 runtime
         run: dotnet test --no-build --verbosity normal
         env:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,6 +48,8 @@ jobs:
       # The build emits playwright.ps1 next to the SmokeTests assembly; run it with --with-deps
       # so Linux runners get the apt packages Chromium needs. Idempotent — caches in ~/.cache.
       run: pwsh artifacts/bin/WopiHost.SmokeTests/debug/playwright.ps1 install --with-deps chromium
+    - name: Pre-pull Testcontainers images
+      uses: ./.github/actions/prepull-testcontainers-images
     - name: Test
       # Emit JUnit XML alongside lcov coverage so Codecov Test Analytics can ingest run
       # times / failures. {assembly} keeps each test project's results in a distinct file.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore --configuration Release /p:ContinuousIntegrationBuild=true /p:Version="${{ steps.get_version.outputs.version-without-v }}"
+    - name: Pre-pull Testcontainers images
+      uses: ./.github/actions/prepull-testcontainers-images
     - name: Test
       run: dotnet test --no-build --verbosity normal --configuration Release /p:CollectCoverage=true /p:CoverletOutputFormat=lcov
     - name: Upload coverage to Qlty

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,11 +43,17 @@
 		<_NuGetUserConfigNix Condition="'$(HOME)' != ''">$(HOME)/.nuget/NuGet/NuGet.Config</_NuGetUserConfigNix>
 		<_NuGetUserConfigXdg Condition="'$(XDG_CONFIG_HOME)' != ''">$(XDG_CONFIG_HOME)/NuGet/NuGet.Config</_NuGetUserConfigXdg>
 		<_NuGetUserConfigXdg Condition="'$(_NuGetUserConfigXdg)' == '' and '$(HOME)' != ''">$(HOME)/.config/NuGet/NuGet.Config</_NuGetUserConfigXdg>
-		<!-- Read each existing candidate once; the Exists() guard short-circuits so a missing file is never read. -->
-		<_NuGetUserConfigTextWin Condition="'$(_NuGetUserConfigWin)' != '' and Exists('$(_NuGetUserConfigWin)')">$([System.IO.File]::ReadAllText('$(_NuGetUserConfigWin)'))</_NuGetUserConfigTextWin>
-		<_NuGetUserConfigTextNix Condition="'$(_NuGetUserConfigNix)' != '' and Exists('$(_NuGetUserConfigNix)')">$([System.IO.File]::ReadAllText('$(_NuGetUserConfigNix)'))</_NuGetUserConfigTextNix>
-		<_NuGetUserConfigTextXdg Condition="'$(_NuGetUserConfigXdg)' != '' and Exists('$(_NuGetUserConfigXdg)')">$([System.IO.File]::ReadAllText('$(_NuGetUserConfigXdg)'))</_NuGetUserConfigTextXdg>
 		<IncludeCobalt Condition="'$(IncludeCobalt)' == '' and '$(COBALT_PACKAGES_TOKEN)' != ''">true</IncludeCobalt>
+		<!-- The user-config probe is a dev-machine convenience; on CI the token above is the only
+		     signal, so the probe is skipped there ('CI' is set on GitHub runners) and whenever the
+		     token has already decided. On a fresh runner the first restore creates the default user
+		     NuGet.Config concurrently with property evaluation, and ReadAllText racing that write
+		     fails the build with MSB4184 (sharing violation). The Exists() guard short-circuits so
+		     a missing file is never read. -->
+		<_ProbeNuGetUserConfig Condition="'$(IncludeCobalt)' == '' and '$(CI)' != 'true'">true</_ProbeNuGetUserConfig>
+		<_NuGetUserConfigTextWin Condition="'$(_ProbeNuGetUserConfig)' == 'true' and '$(_NuGetUserConfigWin)' != '' and Exists('$(_NuGetUserConfigWin)')">$([System.IO.File]::ReadAllText('$(_NuGetUserConfigWin)'))</_NuGetUserConfigTextWin>
+		<_NuGetUserConfigTextNix Condition="'$(_ProbeNuGetUserConfig)' == 'true' and '$(_NuGetUserConfigNix)' != '' and Exists('$(_NuGetUserConfigNix)')">$([System.IO.File]::ReadAllText('$(_NuGetUserConfigNix)'))</_NuGetUserConfigTextNix>
+		<_NuGetUserConfigTextXdg Condition="'$(_ProbeNuGetUserConfig)' == 'true' and '$(_NuGetUserConfigXdg)' != '' and Exists('$(_NuGetUserConfigXdg)')">$([System.IO.File]::ReadAllText('$(_NuGetUserConfigXdg)'))</_NuGetUserConfigTextXdg>
 		<IncludeCobalt Condition="'$(IncludeCobalt)' == '' and $(_NuGetUserConfigTextWin.Contains('$(_CobaltFeedMarker)'))">true</IncludeCobalt>
 		<IncludeCobalt Condition="'$(IncludeCobalt)' == '' and $(_NuGetUserConfigTextNix.Contains('$(_CobaltFeedMarker)'))">true</IncludeCobalt>
 		<IncludeCobalt Condition="'$(IncludeCobalt)' == '' and $(_NuGetUserConfigTextXdg.Contains('$(_CobaltFeedMarker)'))">true</IncludeCobalt>

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,15 @@
         "AddContainer\\(\"[^\"]+\", \"(?<depName>[^\"]+)\", \"(?<currentValue>[^\"]+)\"\\)"
       ],
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Tracks container image tags pinned as C# string constants in the Testcontainers test fixtures (AzuriteFixture, RedisFixture) — same rationale as the AppHost manager above. The pattern requires the tag to start with a digit so only image pins match, mirroring the extraction in .github/actions/prepull-testcontainers-images.",
+      "managerFilePatterns": ["/^test/.+Fixture\\.cs$/"],
+      "matchStrings": [
+        "\"(?<depName>[a-z0-9.-]+(?:/[a-z0-9._-]+)*):(?<currentValue>[0-9][A-Za-z0-9._-]*)\""
+      ],
+      "datasourceTemplate": "docker"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
### Motivation

Two unrelated transient failures hit PR #635 in consecutive runs, each surfacing as a wall of confusing errors on a diff that never touched the code:

1. **Registry flake → 145 test failures.** A reset connection while pulling `mcr.microsoft.com/azure-storage/azurite:3.35.0` left the image out of the local Docker cache, so every Testcontainers-backed test in both Azure test projects failed at fixture-init with `DockerImageNotFoundException`. Testcontainers does not retry a failed pull.
2. **NuGet.Config race → MSB4184 before anything compiles.** On a fresh macOS runner, the `IncludeCobalt` gate's `ReadAllText` of the user-level `NuGet.Config` raced NuGet's first-run creation of that very file and died on a sharing violation.

This PR makes both failure modes either self-heal or impossible, and closes the automation gap that left fixture-pinned image tags invisible to update tooling:

- **`.github/actions/prepull-testcontainers-images`** — composite action that extracts the image pins from `test/**/*Fixture.cs` (single source of truth, nothing to drift) and pulls each with 5 attempts + backoff. Wired into the four workflows running the Docker-gated suites (`pull_request`, `integrate`, `release`, `net11-preview`). A genuine registry outage now fails fast in one clearly-named step instead of as mass test failures.
- **`renovate.json`** — a second custom-manager entry tracks the image tags pinned as C# string constants in the test fixtures (Azurite ×2, Redis, mock-oauth2-server). Dependabot's docker ecosystem only parses Dockerfile/compose files and never sees these; the existing manager only covered the AppHost's `AddContainer` calls.
- **`Directory.Build.props`** — the Cobalt gate decides from `COBALT_PACKAGES_TOKEN` first and skips the user-config file probe on CI entirely (`CI` is set on hosted runners). The probe is a dev-machine convenience for maintainers who registered the private feed locally; on CI it only ever raced NuGet for a file that can't contain the feed marker anyway.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added — n/a: CI workflow + build-property changes; see "How to test" for how each piece was verified
- [x] Tests are passing
- [x] Docs have been updated (if applicable) — comments in the action, `renovate.json`, and `Directory.Build.props` carry the rationale
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
- [x] Adheres to [.NET Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/)

### How to test

- **Caveat:** the affected workflows run on `pull_request_target` / `push`, so the workflow definition (and the new step) comes from the *base* branch — this PR's own `build` job does **not** show the `Pre-pull Testcontainers images` step yet. It first runs for real on the post-merge `integrate` run on `master`; that run's `build` job log should show the step pulling `azurite:3.35.0`, `redis:7-alpine`, and `mock-oauth2-server:2.1.10` before `Test`.
- The action's script was executed verbatim outside CI on both paths: with a stubbed `docker` (extraction finds exactly the three fixture images; a transient failure retries and then succeeds) and against an unreachable Docker daemon (five attempts with backoff, then a single `::error::` annotation and exit 1).
- The `Directory.Build.props` fix *is* exercised by this PR's own CI (checkout uses the PR merge ref): the macOS and Windows `FS owner lookup` jobs and the full `build` job all restore successfully with the token present.
- Local dev behavior is unchanged: with no `CI` var and no token, `dotnet build` still probes the user-level `NuGet.Config` locations and flips `IncludeCobalt` when the feed registration is found.
- For the Renovate entry: the regex was validated against every `*Fixture.cs` under `test/` — matches are exactly `redis:7-alpine`, `mcr.microsoft.com/azure-storage/azurite:3.35.0` (×2), and `ghcr.io/navikt/mock-oauth2-server:2.1.10`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsgvpWAmZfAUrNQZxz5Q6X