### PR TITLE
docs: Pin the Redis-floor guidance to 9.1.x and link the upstream mock-oauth2-server issue

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,7 +41,7 @@
       "labels": ["dependencies"]
     },
     {
-      "description": "mock-oauth2-server 6.0.0's userinfo endpoint returns nbf/exp/iat as ISO-8601 strings — a side effect of its Jackson 2→3 migration — instead of the NumericDate values OIDC requires, so ASP.NET's OIDC handler rejects the response and the OidcSignInTests fail. The negated regex excludes exactly that release, keeping 6.0.1+/6.x+ flowing for re-evaluation once upstream fixes the serialization; remove the rule (and the pin comment in MockOidcServerFixture) when it does.",
+      "description": "mock-oauth2-server 6.0.0's userinfo endpoint returns nbf/exp/iat as ISO-8601 strings — a side effect of its Jackson 2→3 migration — instead of the NumericDate values OIDC requires, so ASP.NET's OIDC handler rejects the response and the OidcSignInTests fail. Reported upstream as https://github.com/navikt/mock-oauth2-server/issues/1006. The negated regex excludes exactly that release, keeping 6.0.1+/6.x+ flowing for re-evaluation once upstream fixes the serialization; remove the rule (and the pin comment in MockOidcServerFixture) when it does.",
       "matchDepNames": ["ghcr.io/navikt/mock-oauth2-server"],
       "allowedVersions": "!/^6\\.0\\.0$/"
     }

--- a/src/WopiHost.RedisLockProvider/README.md
+++ b/src/WopiHost.RedisLockProvider/README.md
@@ -2,7 +2,7 @@
 
 `IWopiLockProvider` implementation backed by Redis, with atomic compare-and-swap via server-side conditional commands (`SET IFEQ`/`DELIFEQ`) and TTL-driven WOPI expiry.
 
-> **Requires Redis 8.4 or later.** The compare-and-swap paths use the conditional commands introduced in Redis 8.4; older servers reject them at runtime. Deployments on older Redis (including managed offerings that lag upstream) should stay on WopiHost.RedisLockProvider v9.x, whose CAS ran as `WATCH`-based transactions.
+> **Requires Redis 8.4 or later.** The compare-and-swap paths use the conditional commands introduced in Redis 8.4; older servers reject them at runtime. Deployments on older Redis (including managed offerings that lag upstream) should stay on WopiHost.RedisLockProvider 9.1.x or earlier, whose CAS ran as `WATCH`-based transactions.
 
 ## When to pick this over the other lock providers
 


### PR DESCRIPTION
### Motivation

Two release-prep corrections ahead of tagging 9.2.0:

- The RedisLockProvider README pointed older-Redis deployments at "v9.x", but with 9.2.0 shipping the Redis 8.4+ CAS as a **minor**, the last release with `WATCH`-based transactions is **9.1.x** — the guidance now says exactly that.
- The mock-oauth2-server 6.0.0 exclusion in `renovate.json` now cites the upstream report ([navikt/mock-oauth2-server#1006](https://github.com/navikt/mock-oauth2-server/issues/1006)), so the rule's removal condition is traceable.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added — n/a: docs/config-comment wording only
- [x] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
- [x] Adheres to [.NET Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/)

### How to test

Wording-only change: `renovate.json` still parses (validated), no code touched. Should merge before the 9.2.0 release is published so the packaged README carries the correct stay-on version.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsgvpWAmZfAUrNQZxz5Q6X

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsgvpWAmZfAUrNQZxz5Q6X)_