### PR TITLE
fix(ci): Use the working coverage glob in release.yml's Qlty upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,9 @@ jobs:
       uses: qltysh/qlty-action/coverage@08a0a862c159eae9b9003081da6663d96efef637 # v2
       with:
         oidc: true
-        files: "**/coverage.*.info"
+        # Coverlet emits `coverage.info` per project at `test/<Project>/coverage.info`;
+        # see integrate.yml for the glob rationale.
+        files: "test/**/coverage.info"
         # See integrate.yml for the rationale.
         skip-missing-files: true
     - name: Codecov


### PR DESCRIPTION
## Summary

The 9.2.0 release run ([job log](https://github.com/petrsvihlik/WopiHost/actions/runs/31802216539/job/94772608995)) errored in the **Upload coverage to Qlty** step:

> Error: No code coverage data files were found. Please check the action's inputs.

`release.yml` still globbed `**/coverage.*.info` — a pattern that matches nothing, because coverlet emits plain `coverage.info` per test project (`test/<Project>/coverage.info`) now that the solution is single-targeted; the `.*.` form required a TFM label between the dots. `integrate.yml` and `pull_request.yml` were already switched to `test/**/coverage.info` (f5d9c94), but `release.yml` was missed — and since it only runs on releases, the gap stayed invisible until 9.2.0 shipped.

This aligns `release.yml` with the other two workflows. The Qlty action logs the error without failing the job, which is why the release itself still succeeded — coverage from release runs just never reached Qlty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)