### PR TITLE
chore(deps): Take mock-oauth2-server 6.0.1 and drop the 6.0.0 exclusion

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,11 +39,6 @@
       "minimumReleaseAge": "7 days",
       "commitMessagePrefix": "chore(deps)",
       "labels": ["dependencies"]
-    },
-    {
-      "description": "mock-oauth2-server 6.0.0's userinfo endpoint returns nbf/exp/iat as ISO-8601 strings — a side effect of its Jackson 2→3 migration — instead of the NumericDate values OIDC requires, so ASP.NET's OIDC handler rejects the response and the OidcSignInTests fail. Reported upstream as https://github.com/navikt/mock-oauth2-server/issues/1006. The negated regex excludes exactly that release, keeping 6.0.1+/6.x+ flowing for re-evaluation once upstream fixes the serialization; remove the rule (and the pin comment in MockOidcServerFixture) when it does.",
-      "matchDepNames": ["ghcr.io/navikt/mock-oauth2-server"],
-      "allowedVersions": "!/^6\\.0\\.0$/"
     }
   ]
 }

--- a/test/WopiHost.IntegrationTests/Fixtures/MockOidcServerFixture.cs
+++ b/test/WopiHost.IntegrationTests/Fixtures/MockOidcServerFixture.cs
@@ -19,11 +19,7 @@ public sealed class MockOidcServerFixture : IAsyncLifetime
     /// <summary>Issuer name used by the mock server. Discovery URL is <c>{BaseUrl}/{Issuer}/.well-known/openid-configuration</c>.</summary>
     public const string Issuer = "default";
 
-    // 6.0.0 is deliberately skipped: its Jackson 2->3 migration made the userinfo endpoint
-    // serialize nbf/exp/iat as ISO-8601 strings instead of the NumericDate values OIDC requires,
-    // so ASP.NET's OIDC handler rejects the response mid-handshake. The renovate.json rule for
-    // this image excludes that one release; drop both once a fixed 6.x ships.
-    private const string Image = "ghcr.io/navikt/mock-oauth2-server:5.0.2";
+    private const string Image = "ghcr.io/navikt/mock-oauth2-server:6.0.1";
     private const ushort ContainerPort = 8080;
 
     private IContainer? _container;


### PR DESCRIPTION
### Motivation

Upstream fixed the regression that kept the OIDC test fixture on 5.0.2.

[navikt/mock-oauth2-server#1006](https://github.com/navikt/mock-oauth2-server/issues/1006) (filed from this repo when #643 went red) is closed, fixed by [#1007](https://github.com/navikt/mock-oauth2-server/pull/1007) and released as **6.0.1**. The fix is exactly the suggested one — the userinfo route serializes through Nimbus instead of handing Jackson a map of `Date` values:

```diff
- val claims = it.verifyBearerToken(tokenProvider).claims
- json(claims)
+ val claims = it.verifyBearerToken(tokenProvider)
+ json(claims.toJSONObject())
```

…plus a regression test asserting `iat`/`nbf`/`exp` come back as epoch seconds. So `nbf`/`exp`/`iat` are NumericDate again and ASP.NET's OIDC handler stops rejecting the userinfo response mid-handshake.

That removes both workarounds: the fixture takes 6.0.1, and the `renovate.json` rule that excluded exactly 6.0.0 goes away (with its pin comment), so the image tracks 6.x normally again.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added — n/a: the existing `OidcSignInTests` are the regression test; they're what caught 6.0.0 and what must stay green here
- [x] Tests are passing
- [x] Docs have been updated (if applicable) — the obsolete pin comment is removed
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
- [x] Adheres to [.NET Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/)

### How to test

CI is the proof: `OidcSignInTests.SignIn_FullFlow_AuthenticatesUserAndAllowsAccessToProtectedPage` and `SignOut_AfterSignIn_ClearsCookieAndProtectedAccessIs401` drive the full authorization-code handshake including the userinfo call, against the 6.0.1 container. Both failed on 6.0.0 with `IDX21343`/`IDX11020`; they must pass here.

Nothing else in the 6.0.0 majors' documented breaks touches this fixture — the dropped `logback`/`kotlinx-serialization-json` bundling and the Jackson 3 API change affect JVM library consumers (the Docker image still ships logback), the debugger restriction is unused, and the new 1 MiB request-body cap is far above these form posts.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsgvpWAmZfAUrNQZxz5Q6X

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsgvpWAmZfAUrNQZxz5Q6X)_