### PR TITLE
feat: cover the remaining CheckFileInfo properties and discovery actions

### DIFF
--- a/src/WopiHost.Abstractions/WopiCheckFileInfo.cs
+++ b/src/WopiHost.Abstractions/WopiCheckFileInfo.cs
@@ -488,6 +488,201 @@ public class WopiCheckFileInfo : IWopiHostCapabilities
     /// </summary>
     [JsonIgnore]
     public bool WebEditingDisabled { get; set; }
+
+    /// <summary>
+    /// The Microsoft Entra ID (formerly Azure AD) object ID of the current user, as a string.
+    /// </summary>
+    [JsonPropertyName("AADUserObjectId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AadUserObjectId { get; set; }
+
+    /// <summary>
+    /// A Boolean value that indicates the host supports batching of <see href="https://learn.microsoft.com/microsoft-365/cloud-storage-partner-program/rest/files/addactivities">AddActivities</see> calls for a user.
+    /// </summary>
+    public bool AllowAddActivitiesUserBatching { get; set; }
+
+    /// <summary>
+    /// A Boolean value that indicates the WOPI client may enable features that have not yet reached general availability.
+    /// </summary>
+    public bool AllowEarlyFeatures { get; set; }
+
+    /// <summary>
+    /// A URI to the app catalog the WOPI client should use when offering add-ins to the user.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Uri? AppCatalogUrl { get; set; }
+
+    /// <summary>
+    /// A string identifying the policy the host applied to this file, used by the WOPI client for policy reporting.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AppliedPolicyId { get; set; }
+
+    /// <summary>
+    /// A string value indicating how aggressively the WOPI client should protect itself against host throttling.
+    /// <para>Possible values: <c>MostProtected</c>, <c>Protected</c>, <c>Normal</c>, <c>LessProtected</c>, <c>LeastProtected</c>.</para>
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ClientThrottlingProtection { get; set; }
+
+    /// <summary>
+    /// A string prefix identifying the compliance domain the file belongs to.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ComplianceDomainPrefix { get; set; }
+
+    /// <summary>
+    /// A string value restricting what the user may copy out of the document.
+    /// <para>Possible values: <c>BlockAll</c>, <c>CurrentDocumentOnly</c>.</para>
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CopyPasteRestrictions { get; set; }
+
+    /// <summary>
+    /// A URI to a WebDAV endpoint for the file, used to open it in the desktop client via Direct Invoke.
+    /// </summary>
+    [JsonPropertyName("DirectInvokeDAVUrl")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Uri? DirectInvokeDavUrl { get; set; }
+
+    /// <summary>
+    /// A Boolean value that indicates the user may edit the file but the host cannot persist the changes.
+    /// </summary>
+    public bool EditingCannotSave { get; set; }
+
+    /// <summary>
+    /// A URI identifying the origin of the page the WOPI client is embedded in.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Uri? EmbeddingPageOrigin { get; set; }
+
+    /// <summary>
+    /// A string the host passes through to the embedding page for the duration of the session.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? EmbeddingPageSessionInfo { get; set; }
+
+    /// <summary>
+    /// A collection of application feature names the WOPI client should enable for this session.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IEnumerable<string>? EnabledApplicationFeatures { get; set; }
+
+    /// <summary>
+    /// A string describing the kind of identifier carried in <see cref="HostAuthenticationId"/>.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? HostAuthenticationIdType { get; set; }
+
+    /// <summary>
+    /// A URI to a page that renders the file for syndication in an HTML <c>div</c>.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Uri? HostDivSyndicationViewUrl { get; set; }
+
+    /// <summary>
+    /// A Boolean value that indicates Yammer integration is available for this file.
+    /// </summary>
+    public bool IsYammerEnabled { get; set; }
+
+    /// <summary>
+    /// A string naming the organization that licensed the current user.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? LicensedOrganization { get; set; }
+
+    /// <summary>
+    /// A URI the WOPI client invokes to open the file in the corresponding desktop client.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Uri? OpenInClientCommandUrl { get; set; }
+
+    /// <summary>
+    /// A Boolean value that indicates the file is protected by an information-protection policy.
+    /// </summary>
+    public bool ProtectedFile { get; set; }
+
+    /// <summary>
+    /// A URI to a page where the user can report the file as abusive.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Uri? ReportAbuseUrl { get; set; }
+
+    /// <summary>
+    /// A string describing the Safe Links scanning state that applies to links in the file.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SafeLinksStatus { get; set; }
+
+    /// <summary>
+    /// A Boolean value that indicates the host supports policy checks for the current user and file.
+    /// </summary>
+    public bool SupportsCheckPolicy { get; set; }
+
+    /// <summary>
+    /// A Boolean value that indicates the host supports checking whether a user has access to the file.
+    /// </summary>
+    public bool SupportsCheckUserAccess { get; set; }
+
+    /// <summary>
+    /// A Boolean value that indicates the host can resolve contacts on behalf of the WOPI client.
+    /// </summary>
+    public bool SupportsContactsResolution { get; set; }
+
+    /// <summary>
+    /// A Boolean value that indicates the host supports storing per-user values against the file.
+    /// </summary>
+    public bool SupportsFileUserValue { get; set; }
+
+    /// <summary>
+    /// A Boolean value that indicates the host supports retrieving the file's activity feed.
+    /// </summary>
+    public bool SupportsGetActivities { get; set; }
+
+    /// <summary>
+    /// A Boolean value that indicates the host supports granting a user access to the file.
+    /// </summary>
+    public bool SupportsGrantUserAccess { get; set; }
+
+    /// <summary>
+    /// A Boolean value that indicates the host supports returning information-protection policies for the file.
+    /// </summary>
+    public bool SupportsPolicies { get; set; }
+
+    /// <summary>
+    /// A Boolean value that indicates the host supports the reviewing mode of the WOPI client.
+    /// </summary>
+    public bool SupportsReviewing { get; set; }
+
+    /// <summary>
+    /// A Boolean value that indicates the file is writable in principle but cannot be written right now.
+    /// </summary>
+    public bool TemporarilyNotWritable { get; set; }
+
+    /// <summary>
+    /// A URI to a page explaining the host's terms of use.
+    /// </summary>
+    /// <remarks>Deprecated since WOPI version 2015.06.01.</remarks>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Uri? TermsOfUseUrl { get; set; }
+
+    /// <summary>
+    /// A Boolean value that indicates the user may review the file, that is, add and resolve comments and tracked changes.
+    /// </summary>
+    public bool UserCanReview { get; set; }
+
+    /// <summary>
+    /// The workflow types available for this file. Must be set whenever <see cref="WorkflowUrl"/> or <see cref="WorkflowPostMessage"/> is provided, otherwise the WOPI client ignores both.
+    /// <para>Possible values: <c>Assign</c>, <c>Submit</c>.</para>
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IEnumerable<string>? WorkflowType { get; set; }
+
+    /// <summary>
+    /// A URI the WOPI client navigates to when the user starts a workflow named in <see cref="WorkflowType"/>.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Uri? WorkflowUrl { get; set; }
     #endregion
 
     #region "PostMessage properties"
@@ -544,6 +739,31 @@ public class WopiCheckFileInfo : IWopiHostCapabilities
     /// </summary>
     /// <remarks>Pre-release property - not yet used by any WOPI client</remarks>
     public bool WorkflowPostMessage { get; set; }
+
+    /// <summary>
+    /// A Boolean value that, when set to true, indicates the host expects to receive the UI_InsertImage PostMessage when the Insert Image UI in Microsoft 365 for the web is activated.
+    /// </summary>
+    public bool InsertImagePostMessage { get; set; }
+
+    /// <summary>
+    /// A Boolean value that, when set to true, indicates the host expects to receive the UI_OpenInClient PostMessage when the Open in Client UI in Microsoft 365 for the web is activated.
+    /// </summary>
+    public bool OpenInClientPostMessage { get; set; }
+
+    /// <summary>
+    /// A Boolean value that, when set to true, indicates the host expects to receive the Permissions PostMessage when the file's permissions change during the session.
+    /// </summary>
+    public bool PermissionsPostMessage { get; set; }
+
+    /// <summary>
+    /// A Boolean value that, when set to true, indicates the host expects to receive the PolicyCheck PostMessage when the WOPI client evaluates a policy.
+    /// </summary>
+    public bool PolicyCheckPostMessage { get; set; }
+
+    /// <summary>
+    /// A Boolean value that, when set to true, indicates the host expects to receive the UI_ReportAbuse PostMessage when the Report Abuse UI in Microsoft 365 for the web is activated.
+    /// </summary>
+    public bool ReportAbusePostMessage { get; set; }
     #endregion
 
     #region "IWopiHostCapabilities"

--- a/src/WopiHost.Discovery/Enumerations/WopiActionEnum.cs
+++ b/src/WopiHost.Discovery/Enumerations/WopiActionEnum.cs
@@ -128,5 +128,35 @@ public enum WopiActionEnum
     /// <summary>
     /// Not supported within the Office 365 - Cloud Storage Partner Program.
     /// </summary>
-    DocumentChat
+    DocumentChat,
+
+    /// <summary>
+    /// An action that opens the file, letting the WOPI client pick the view or edit experience itself.
+    /// </summary>
+    Open,
+
+    /// <summary>
+    /// An action that allows users to edit a document in a mode optimized for embedding in a web page.
+    /// </summary>
+    EmbedEdit,
+
+    /// <summary>
+    /// An action that renders a preview of the file optimized for embedding in a web page.
+    /// </summary>
+    EmbedPreview,
+
+    /// <summary>
+    /// An action that renders a UI for configuring how the file is embedded in a web page.
+    /// </summary>
+    EmbedConfigurator,
+
+    /// <summary>
+    /// An action that previews the file as it appears to a user filling in a form.
+    /// </summary>
+    FormPreview,
+
+    /// <summary>
+    /// An action used to preload static content for the Office for the web unified application.
+    /// </summary>
+    PreloadUnifiedApp
 }

--- a/test/WopiHost.Discovery.Tests/WopiDiscovererTests.cs
+++ b/test/WopiHost.Discovery.Tests/WopiDiscovererTests.cs
@@ -125,6 +125,22 @@ public class WopiDiscovererTests
     }
 
     [Theory]
+    [InlineData(NetZoneEnum.ExternalHttps, "xlsx", WopiActionEnum.Open, XmlOo2019)]
+    [InlineData(NetZoneEnum.InternalHttp, "onetoc2", WopiActionEnum.EmbedEdit, XmlOo2019)]
+    [InlineData(NetZoneEnum.InternalHttp, "onetoc2", WopiActionEnum.EmbedEdit, XmlOos2016)]
+    [InlineData(NetZoneEnum.ExternalHttps, "xlsx", WopiActionEnum.EmbedPreview, XmlOo2019)]
+    [InlineData(NetZoneEnum.ExternalHttps, "xlsx", WopiActionEnum.EmbedConfigurator, XmlOo2019)]
+    [InlineData(NetZoneEnum.InternalHttp, "xlsx", WopiActionEnum.FormPreview, XmlOo2019)]
+    public async Task SupportsActionAsync_ActionOnlyInDiscoveryXml_ReturnsTrue(NetZoneEnum netZone, string extension, WopiActionEnum action, string fileName)
+    {
+        InitDiscoverer(fileName, netZone);
+
+        var result = await _wopiDiscoverer.SupportsActionAsync(extension, action);
+
+        Assert.True(result, $"{action} should be supported for {extension}!");
+    }
+
+    [Theory]
     [InlineData(NetZoneEnum.InternalHttp, "html", XmlOos2016)]
     [InlineData(NetZoneEnum.InternalHttp, "txt", XmlOos2016)]
     public async Task RequiresCobaltAsync_UnknownExtension_ReturnsFalse(NetZoneEnum netZone, string extension, string fileName)


### PR DESCRIPTION
### Motivation

No single issue — this came out of exploring #604 (Microsoft Office Inspectors for Fiddler). Comparing this repo's models against Microsoft's own spec-derived ones surfaced two concrete coverage gaps. The Fiddler inspector itself is not integrable here (see the writeup on #604); these are the parts of that exploration worth landing.

Both gaps were verified against authoritative sources rather than the inspector, which turned out to be dated:

**1. `WopiCheckFileInfo` was missing 46 of the 138 properties in the official CheckFileInfo JSON schema.**

The source of truth is `src/WopiValidator.Core/JsonSchemas/CsppCheckFileInfoSchema.json` in [microsoft/wopi-validator-core](https://github.com/microsoft/wopi-validator-core) — the same validator this repo already pins at `WopiValidator 2.0.5` in `tools/wopi-validator`, so the host is already judged against it in CI.

Of the 46, eight are marked `"not": {}` in the CSPP schema, which forbids them; they are permitted only under the CSPP+ profile. This PR adds the **39 the CSPP profile allows** and leaves those eight out. Property types come from the schema (`boolean` → `bool`, `format: uri` → `Uri?`, `array` → `IEnumerable<string>?`, string enums → `string?` with the permitted values listed in the doc comment).

Nothing already on the model is invalid: every pre-existing property appears in the schema. The one CSPP-forbidden property present, `SupportsCoauth`, is untouched and correct — it is CSPP+, which is the right profile for a Cobalt-capable host.

`AadUserObjectId` and `DirectInvokeDavUrl` follow the existing `Sha256` pattern — an identifier without consecutive capitals, with the wire name pinned by `JsonPropertyName` — rather than introducing `AADUserObjectId`/`DirectInvokeDAVUrl` against the convention already used for `Sha256` and `IrmPolicy*`.

**2. `WopiActionEnum` could not express six action names that appear in this repo's own discovery fixtures.**

`open`, `embededit`, `embedpreview`, `embedconfigurator`, `formpreview`, and `preloadunifiedapp` all occur in `OO2019_discovery.xml` and/or `OOS2016_discovery.xml` under `test/WopiHost.Discovery.Tests/`. Because `WopiDiscoverer` only maps enum → string when looking actions up, this was never a parse failure — those actions were simply unreachable to a host. New members are **appended** so existing ordinals are unchanged.

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing — via CI; see the note below
- [x] Docs have been updated (if applicable) — XML docs on all new members; no prose docs affected
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
- [x] Adheres to [.NET Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/)

> [!NOTE]
> **This was authored in an environment with no .NET SDK** (its egress proxy blocks the .NET distribution hosts), so `dotnet build` / `dotnet test` never ran locally and CI was the first real compile. That has now happened and is green:
> - `build` ✅ — compiles under `TreatWarningsAsErrors` and the test suite passes (Codecov: "All tests successful", coverage 93.30% → 93.33%)
> - `API Compatibility` ✅ — no public-API breaks in any of the eight packages against `9.2.0`
> - `validate` ✅ — WOPI validator 115 pass / 3 fail, the 3 being the pinned `ProofKeys.*` baseline documented in `NoOpProofValidator.cs`, unchanged by this PR
>
> Before CI, both changes were checked mechanically instead: parsing the modified `WopiCheckFileInfo.cs` and diffing its effective JSON property names (respecting `JsonPropertyName`) against the schema — 131 properties, no duplicates, every CSPP-allowed property present, nothing absent from the schema; and re-implementing `SupportsActionAsync`'s matching rules (net-zone normalisation, case-insensitive `ext`/`name` comparison) against the fixture XML to confirm all six new test rows resolve.

### How to test

```bash
dotnet build WOPI.slnx
dotnet test test/WopiHost.Discovery.Tests
```

The new `SupportsActionAsync_ActionOnlyInDiscoveryXml_ReturnsTrue` theory is the meaningful one: each row asserts a newly-added enum member resolves against a real Office Online / OOS discovery document already checked into the repo. It fails on `master` because the enum members do not exist.

`preloadunifiedapp` has no test — it appears in `OO2019_discovery.xml` without an `ext` attribute, so it is not reachable through the extension-keyed lookups. It is added to the enum for completeness only.

The CheckFileInfo change is additive and has no behavioural test: nothing populates the new properties, and `DefaultCheckFileInfoBuilder` is unchanged. It widens what a host *can* set. Worth a look on two points:

1. Whether the eight CSPP+-only properties (`AccessTokenExpiry`, `FileGeoLocationCode`, `OfficeCollaborationServiceEndpointUrl`, `RealTimeChannelEndpointUrl`, `SequenceNumber`, `ServerTime`, `SharingStatus`, plus the already-present `SupportsCoauth`) should follow in a separate PR — the repo already emits one of them, so excluding the rest is a judgement call I made conservatively rather than an obvious rule.
2. Whether the eight new `Supports*` properties belong on `IWopiHostCapabilities`. They are deliberately **not** there: adding members to a published interface is a binary-breaking change that package validation would reject against the 9.2.0 baseline. That would need a major version.

Unrelated and left alone: several existing XML docs in `WopiCheckFileInfo.cs` are copy-paste artefacts describing the wrong property (`UserPrincipalName`, `WebEditingDisabled`, `AppStateHistoryPostMessage`, `WorkflowPostMessage`). Happy to fix them in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fop6FTEoHMucrmAHUR5d1G