### PR TITLE
fix(ci): Restore Codecov coverage uploads broken by the MTP migration

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -62,10 +62,24 @@ jobs:
         # publish time. Without this flag Qlty counts them as 0% covered. See also
         # .qlty/qlty.toml.
         skip-missing-files: true
+    - name: Rename coverage reports for Codecov auto-discovery
+      # The Codecov CLI only auto-detects coverage files whose names contain "coverage"
+      # or match a fixed list (literal `cobertura.xml`, `lcov.info`, ...), and it does
+      # not expand globs passed via the action's `files:` input. MTP code coverage
+      # writes `<guid>.cobertura.xml`, which matches neither, so the upload silently
+      # finds zero reports and the codecov/* commit statuses are never posted.
+      run: |
+        shopt -s nullglob
+        for f in "${{ github.workspace }}"/test-results/*.cobertura.xml; do
+          mv "$f" "${f%.cobertura.xml}.coverage.cobertura.xml"
+        done
     - name: Codecov
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        # A silent upload failure leaves the codecov/patch and codecov/project statuses
+        # pending forever on PRs, blocking the merge with no visible error.
+        fail_ci_if_error: true
     - name: FOSSA scan + policy gate
       uses: fossa-contrib/fossa-action@d28f0c947e7406706981a62a91ecc009bcc39fd7 # v4
       with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -71,10 +71,24 @@ jobs:
         files: "test-results/**/*.cobertura.xml"
         # See integrate.yml for the rationale.
         skip-missing-files: true
+    - name: Rename coverage reports for Codecov auto-discovery
+      # The Codecov CLI only auto-detects coverage files whose names contain "coverage"
+      # or match a fixed list (literal `cobertura.xml`, `lcov.info`, ...), and it does
+      # not expand globs passed via the action's `files:` input. MTP code coverage
+      # writes `<guid>.cobertura.xml`, which matches neither, so the upload silently
+      # finds zero reports and the codecov/* commit statuses are never posted.
+      run: |
+        shopt -s nullglob
+        for f in "${{ github.workspace }}"/test-results/*.cobertura.xml; do
+          mv "$f" "${f%.cobertura.xml}.coverage.cobertura.xml"
+        done
     - name: Codecov
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        # A silent upload failure leaves the required codecov/patch and codecov/project
+        # statuses pending forever, blocking the merge with no visible error.
+        fail_ci_if_error: true
 
     - name: FOSSA scan + policy gate
       uses: fossa-contrib/fossa-action@d28f0c947e7406706981a62a91ecc009bcc39fd7 # v4


### PR DESCRIPTION
### Motivation

No issue exists — this fixes the `codecov/patch` and `codecov/project` required statuses hanging on "waiting for status to be reported" on every PR since #654 (e.g. #658), which blocks merging.

Root cause: #654 switched coverage output from coverlet's `coverage.info` (lcov) to MTP code coverage's `<guid>.cobertura.xml` under `test-results/`. The Codecov CLI auto-detects coverage files only by names containing `coverage` or a fixed list of exact names (`cobertura.xml`, `lcov.info`, …), and it does not expand globs passed via the action's `files:` input — so since #654 the upload step logs

```
info -- Found 0 coverage files to report
Error: No coverage reports found. Please make sure you're generating reports successfully.
```

and, because `fail_ci_if_error` defaults to false, the job still goes green while Codecov never receives a report and never posts the two statuses.

The fix, applied to both `pull_request.yml` and `integrate.yml`:

- A step before the Codecov upload renames `test-results/*.cobertura.xml` → `*.coverage.cobertura.xml` so the CLI's auto-discovery finds the reports. It runs after the Qlty upload, whose own `@actions/glob`-based `files:` matching is unaffected.
- `fail_ci_if_error: true` on the Codecov step so a zero-reports upload turns the job red instead of silently leaving the required statuses pending.

**Merge note:** `pull_request_target` runs the workflow definition from `master`, so this PR's own checks still use the broken workflow — the codecov statuses will hang here too and it needs an admin merge (or temporarily un-requiring the two checks). Stuck PRs like #658 then need a fresh run (`·@·d·ependabot r·ebase` or re-running the "Pull Request" workflow). The first post-fix uploads compare against the last pre-#654 baseline; the 3%/10% thresholds in `codecov.yml` absorb the drift, and the first `master` push re-establishes the baseline.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added (n/a — workflow-only change)
- [x] Tests are passing
- [ ] Docs have been updated (if applicable) (n/a)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
- [x] Adheres to [.NET Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/) (n/a — no .NET code touched)

### How to test

After merging to `master`, trigger a fresh "Pull Request" workflow run on any open PR (e.g. `·@·d·ependabot r·ebase` on #658) and check the run's "Codecov" step: it should log `Found 12 coverage files to report` and a successful upload, and `codecov/patch` / `codecov/project` should appear on the PR within a few minutes. The `master` push itself exercises the same steps in `integrate.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2xC4ZGP6o6QSLF7RtwJQK

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2xC4ZGP6o6QSLF7RtwJQK)_