### PR TITLE
fix(ci): Restore the Codecov coverage upload in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,16 @@ jobs:
         files: "test-results/**/*.cobertura.xml"
         # See integrate.yml for the rationale.
         skip-missing-files: true
+    - name: Rename coverage reports for Codecov auto-discovery
+      # See integrate.yml for the rationale.
+      run: |
+        shopt -s nullglob
+        for f in "${{ github.workspace }}"/test-results/*.cobertura.xml; do
+          mv "$f" "${f%.cobertura.xml}.coverage.cobertura.xml"
+        done
     - name: Codecov
+      # Unlike the CI workflows, deliberately no fail_ci_if_error: a Codecov outage
+      # must not block publishing the release.
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Motivation

No issue exists — companion to #659, applying the same fix to `release.yml`. The release workflow uploads coverage to Codecov the same way as the CI workflows, so it has been silently uploading nothing since #654: the Codecov CLI's auto-discovery doesn't recognize MTP code coverage's `<guid>.cobertura.xml` filenames (it only matches names containing `coverage` or a fixed list of exact names), so the upload step logs `Found 0 coverage files to report` and release-tag coverage never reaches Codecov.

Same remedy as #659: rename `test-results/*.cobertura.xml` → `*.coverage.cobertura.xml` before the Codecov step (after the Qlty upload, which is unaffected).

One deliberate difference from #659: **no `fail_ci_if_error` here** — no required statuses hang on a tag build, and a Codecov outage must not block publishing a release.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added (n/a — workflow-only change)
- [x] Tests are passing
- [ ] Docs have been updated (if applicable) (n/a)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
- [x] Adheres to [.NET Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/) (n/a — no .NET code touched)

### How to test

On the next release tag, check the release run's "Codecov" step log: it should list the discovered `*.coverage.cobertura.xml` files and report a successful upload instead of `Found 0 coverage files to report`, and the tagged commit should show coverage on Codecov.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2xC4ZGP6o6QSLF7RtwJQK

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2xC4ZGP6o6QSLF7RtwJQK)_