### PR TITLE
feat(ci): Auto-rebase stale Dependabot PRs one at a time

### DIFF
--- a/.github/workflows/dependabot-rebase-queue.yml
+++ b/.github/workflows/dependabot-rebase-queue.yml
@@ -1,0 +1,65 @@
+name: Dependabot Rebase Queue
+
+# Branch protection requires PR branches to be up to date with master, but Dependabot
+# only rebases its PRs when they conflict — a PR that is merely behind stays unmergeable
+# until someone updates it. Each master push (typically a just-merged Dependabot PR)
+# asks Dependabot to rebase the oldest auto-merging PR that has fallen behind, one PR
+# per run: rebasing them all at once would burn CI on branches the next merge
+# immediately invalidates again. The just-rebased PR re-runs CI, auto-merges, and that
+# merge push triggers this workflow again — draining the queue serially, hands-free.
+#
+# The rebase is requested via an `@dependabot rebase` comment rather than the
+# update-branch API: pushes made with GITHUB_TOKEN don't trigger other workflows, so an
+# API-updated branch would sit with its checks never re-running. Dependabot's own
+# force-push retriggers CI normally.
+
+on:
+  push:
+    branches: [ master ]
+  schedule:
+    # Fallback for a missed push event or a queue that stalled overnight.
+    - cron: '17 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: dependabot-rebase-queue
+  cancel-in-progress: true
+
+jobs:
+  rebase-next:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Ask Dependabot to rebase the oldest stale auto-merging PR
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+
+        # Only PRs with auto-merge enabled: a PR being held back on purpose shouldn't
+        # burn CI on rebases, and (merging nothing) it would stall the serial drain.
+        prs=$(gh pr list --repo "$REPO" --author "app/dependabot" --state open \
+          --json number,baseRefName,headRefName,autoMergeRequest,createdAt \
+          --jq 'sort_by(.createdAt) | .[] | select(.autoMergeRequest != null)
+                | [.number, .baseRefName, .headRefName] | @tsv')
+
+        if [ -z "$prs" ]; then
+          echo "No open auto-merging Dependabot PRs."
+          exit 0
+        fi
+
+        while IFS=$'\t' read -r number base head; do
+          behind=$(gh api "repos/$REPO/compare/$base...$head" --jq '.behind_by')
+          if [ "$behind" -gt 0 ]; then
+            echo "PR #$number ($head) is $behind commit(s) behind $base — requesting a rebase."
+            gh pr comment "$number" --repo "$REPO" --body "@dependabot rebase"
+            exit 0
+          fi
+          echo "PR #$number ($head) is up to date with $base."
+        done <<< "$prs"
+
+        echo "No stale Dependabot PRs to rebase."


### PR DESCRIPTION
### Motivation

No issue exists — this removes the manual Dependabot treadmill: with several green Dependabot PRs open, merging one makes the rest "out of date" (branch protection requires branches to be up to date), so each needs a manual update + full CI re-run, one by one. Dependabot itself only rebases its PRs **on conflict** (`rebase-strategy: auto`), not when they're merely behind, and GitHub's merge queue isn't available on user-owned repositories — hence a small workflow:

- On every `master` push (typically a just-merged Dependabot PR), plus a daily cron fallback and `workflow_dispatch`, it finds open Dependabot PRs **with auto-merge enabled**, oldest first, and comments `·@·d·ependabot r·ebase` on the first one that is behind its base.
- **One PR per run, deliberately**: rebasing all stale PRs at once would burn CI on branches the very next merge invalidates again. The rebased PR re-runs CI, auto-merges (via the existing Dependabot Auto-Merge workflow), and that merge push triggers this workflow again — the queue drains serially with no human involvement.
- The rebase is requested via comment rather than the update-branch API because pushes made with `GITHUB_TOKEN` don't trigger other workflows — an API-updated branch would sit with its checks never re-running. Dependabot's own force-push retriggers CI normally.
- PRs with auto-merge disabled are skipped: a PR being held back on purpose shouldn't burn CI, and (merging nothing) it would stall the drain.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added (n/a — workflow-only change)
- [x] Tests are passing
- [ ] Docs have been updated (if applicable) (n/a)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
- [x] Adheres to [.NET Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/) (n/a — no .NET code touched)

### How to test

With ≥2 auto-merging Dependabot PRs open, merge (or let auto-merge land) one of them. The "Dependabot Rebase Queue" run triggered by that push should comment `·@·d·ependabot r·ebase` on the oldest remaining PR; Dependabot reacts with 👍 and force-pushes the rebase, CI re-runs, the PR auto-merges, and the next run picks up the following PR. `workflow_dispatch` allows kicking the drain manually at any time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2xC4ZGP6o6QSLF7RtwJQK

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2xC4ZGP6o6QSLF7RtwJQK)_