### PR TITLE
fix(ci): Make the Dependabot rebase queue actually able to drain

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,12 +1,12 @@
 name: Dependabot Auto-Merge
 
-# Auto-merge is enabled with GITHUB_TOKEN, so the eventual squash-merge is performed
-# by github-actions[bot] and its push to master emits no workflow events — the
-# on-master-push workflows (Integrate, CodeQL, InferSharp, the rebase queue) do not
-# run for these merge commits. The rebase queue compensates by chaining off PR CI
-# completion; the others simply catch up on the next human push or scheduled run.
-# Enabling auto-merge with a PAT or GitHub App token instead would lift the
-# suppression for all of them at once.
+# Prefers DEPENDABOT_AUTOMATION_PAT (a fine-grained PAT — contents: write,
+# pull requests: write — belonging to a user with push access, shared with
+# dependabot-rebase-queue.yml) over GITHUB_TOKEN. When auto-merge is enabled with
+# GITHUB_TOKEN the eventual squash-merge is performed by github-actions[bot], and its
+# push to master emits no workflow events — the on-master-push workflows (Integrate,
+# CodeQL, InferSharp, the rebase queue) silently skip those merge commits. A merge
+# attributed to the PAT's owner triggers them all normally.
 
 on:
   pull_request_target:
@@ -25,4 +25,4 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMATION_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,13 @@
 name: Dependabot Auto-Merge
 
+# Auto-merge is enabled with GITHUB_TOKEN, so the eventual squash-merge is performed
+# by github-actions[bot] and its push to master emits no workflow events — the
+# on-master-push workflows (Integrate, CodeQL, InferSharp, the rebase queue) do not
+# run for these merge commits. The rebase queue compensates by chaining off PR CI
+# completion; the others simply catch up on the next human push or scheduled run.
+# Enabling auto-merge with a PAT or GitHub App token instead would lift the
+# suppression for all of them at once.
+
 on:
   pull_request_target:
     types: [opened, reopened]

--- a/.github/workflows/dependabot-rebase-queue.yml
+++ b/.github/workflows/dependabot-rebase-queue.yml
@@ -11,16 +11,21 @@ name: Dependabot Rebase Queue
 # The rebase is requested via an `@dependabot rebase` comment rather than the
 # update-branch API: pushes made with GITHUB_TOKEN don't trigger other workflows, so an
 # API-updated branch would sit with its checks never re-running. Dependabot's own
-# force-push retriggers CI normally.
+# force-push retriggers CI normally. Dependabot refuses commands from
+# github-actions[bot] ("only users with push access can use that command"), so the
+# comment must be posted with DEPENDABOT_AUTOMATION_PAT — a fine-grained PAT
+# (contents: write, pull requests: write) belonging to a user with push access, shared
+# with dependabot-auto-merge.yml. Without the secret the job exits with a warning
+# instead of posting comments Dependabot will bounce.
 #
-# The same GITHUB_TOKEN event suppression cuts the other way on the trigger side:
-# auto-merge is enabled with GITHUB_TOKEN (dependabot-auto-merge.yml), so the resulting
-# squash-merge push to master emits no push event — a `push` trigger alone only ever
-# fires for human merges and the queue never drains on its own. The dependabot lane is
-# instead chained off the PR CI workflow completing: `workflow_run` fires regardless of
-# what caused the underlying event. CI completion precedes the auto-merge by a little
-# (GitHub merges once the last required check goes green), so the job waits for the
-# triggering PR to actually leave the open state before looking for stale PRs.
+# The same GITHUB_TOKEN event suppression cuts the other way on the trigger side: when
+# auto-merge was enabled with GITHUB_TOKEN, the squash-merge push to master emits no
+# push event, so a `push` trigger alone only fires for human merges (and for auto-merges
+# enabled with the PAT). The dependabot lane is therefore also chained off the PR CI
+# workflow completing: `workflow_run` fires regardless of what caused the underlying
+# event. CI completion slightly precedes the auto-merge (GitHub merges once the last
+# required check goes green), so the job waits for the triggering PR to actually leave
+# the open state before looking for stale PRs.
 
 on:
   push:
@@ -47,12 +52,18 @@ jobs:
     steps:
     - name: Ask Dependabot to rebase the oldest stale auto-merging PR
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        AUTOMATION_PAT: ${{ secrets.DEPENDABOT_AUTOMATION_PAT }}
+        GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMATION_PAT || secrets.GITHUB_TOKEN }}
         REPO: ${{ github.repository }}
         EVENT_NAME: ${{ github.event_name }}
         HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
       run: |
         set -euo pipefail
+
+        if [ -z "$AUTOMATION_PAT" ]; then
+          echo "::warning::DEPENDABOT_AUTOMATION_PAT is not set. Dependabot rejects @dependabot commands from github-actions[bot], so there is no point posting one — stale Dependabot PRs will sit until someone comments '@dependabot rebase' or updates the branch by hand."
+          exit 0
+        fi
 
         if [ "$EVENT_NAME" = "workflow_run" ]; then
           case "$HEAD_BRANCH" in

--- a/.github/workflows/dependabot-rebase-queue.yml
+++ b/.github/workflows/dependabot-rebase-queue.yml
@@ -2,22 +2,34 @@ name: Dependabot Rebase Queue
 
 # Branch protection requires PR branches to be up to date with master, but Dependabot
 # only rebases its PRs when they conflict — a PR that is merely behind stays unmergeable
-# until someone updates it. Each master push (typically a just-merged Dependabot PR)
-# asks Dependabot to rebase the oldest auto-merging PR that has fallen behind, one PR
-# per run: rebasing them all at once would burn CI on branches the next merge
-# immediately invalidates again. The just-rebased PR re-runs CI, auto-merges, and that
-# merge push triggers this workflow again — draining the queue serially, hands-free.
+# until someone updates it. Each time master moves (typically a just-merged Dependabot
+# PR), this workflow asks Dependabot to rebase the oldest auto-merging PR that has
+# fallen behind, one PR per run: rebasing them all at once would burn CI on branches the
+# next merge immediately invalidates again. The just-rebased PR re-runs CI, auto-merges,
+# and that triggers this workflow again — draining the queue serially, hands-free.
 #
 # The rebase is requested via an `@dependabot rebase` comment rather than the
 # update-branch API: pushes made with GITHUB_TOKEN don't trigger other workflows, so an
 # API-updated branch would sit with its checks never re-running. Dependabot's own
 # force-push retriggers CI normally.
+#
+# The same GITHUB_TOKEN event suppression cuts the other way on the trigger side:
+# auto-merge is enabled with GITHUB_TOKEN (dependabot-auto-merge.yml), so the resulting
+# squash-merge push to master emits no push event — a `push` trigger alone only ever
+# fires for human merges and the queue never drains on its own. The dependabot lane is
+# instead chained off the PR CI workflow completing: `workflow_run` fires regardless of
+# what caused the underlying event. CI completion precedes the auto-merge by a little
+# (GitHub merges once the last required check goes green), so the job waits for the
+# triggering PR to actually leave the open state before looking for stale PRs.
 
 on:
   push:
     branches: [ master ]
+  workflow_run:
+    workflows: [ "Pull Request" ]
+    types: [ completed ]
   schedule:
-    # Fallback for a missed push event or a queue that stalled overnight.
+    # Fallback for a missed event or a queue that stalled overnight.
     - cron: '17 5 * * *'
   workflow_dispatch:
 
@@ -37,8 +49,28 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         REPO: ${{ github.repository }}
+        EVENT_NAME: ${{ github.event_name }}
+        HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
       run: |
         set -euo pipefail
+
+        if [ "$EVENT_NAME" = "workflow_run" ]; then
+          case "$HEAD_BRANCH" in
+            dependabot/*) ;;
+            *) echo "CI completion for '$HEAD_BRANCH' is not a Dependabot PR."; exit 0 ;;
+          esac
+          # CI completing is the cue that auto-merge is imminent, not that it happened.
+          # Wait for the PR to merge (or close) so the compare below sees the moved
+          # master; a PR still open after the timeout means a failed or missing check,
+          # in which case master didn't move and the drain below no-ops.
+          for _ in $(seq 1 30); do
+            state=$(gh pr view "$HEAD_BRANCH" --repo "$REPO" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+            if [ "$state" != "OPEN" ]; then
+              break
+            fi
+            sleep 20
+          done
+        fi
 
         # Only PRs with auto-merge enabled: a PR being held back on purpose shouldn't
         # burn CI on rebases, and (merging nothing) it would stall the serial drain.


### PR DESCRIPTION
### Motivation

Live testing (triggered by #663 sitting unmergeable this morning) showed the auto-rebase flow merged in #661 was inert in two independent ways:

1. **The `push` trigger never fires for auto-merged PRs.** Auto-merge is enabled with `GITHUB_TOKEN`, so the squash-merge push to master is attributed to `github-actions[bot]` and GitHub suppresses workflow events from `GITHUB_TOKEN` pushes. The queue only ever ran on human merges and the daily cron. (The same suppression also skips Integrate/CodeQL/InferSharp for those merge commits — master has no runs for #657, #658, or #662.)
2. **Dependabot rejects the command anyway.** A manually dispatched run posted `·@·d·ependabot r·ebase` on #663 and Dependabot replied *"Sorry, only users with push access can use that command"* — it refuses commands from `github-actions[bot]`.

The fix:

- Both workflows route through the new `DEPENDABOT_AUTOMATION_PAT` secret (fine-grained PAT, contents + pull-requests write, falling back to `GITHUB_TOKEN`), so the rebase command is accepted and auto-merge pushes emit normal events.
- The rebase queue is additionally chained off the "Pull Request" CI workflow completing (`workflow_run` fires regardless of the triggering actor); the job waits for the triggering Dependabot PR to leave the open state so the staleness compare sees post-merge master.
- Without the secret the queue exits with a visible warning instead of posting comments Dependabot will bounce.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added — n/a, workflow-only change
- [x] Tests are passing
- [x] Docs have been updated (if applicable) — behavior documented in the workflow headers
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
- [x] Adheres to [.NET Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/) — n/a, no .NET code

### How to test

The `DEPENDABOT_AUTOMATION_PAT` secret is already configured. After merging, wait for the next morning with two grouped Dependabot PRs (or dispatch the "Dependabot Rebase Queue" workflow while a stale auto-merging Dependabot PR exists) and verify: the queue posts `·@·d·ependabot r·ebase`, Dependabot accepts it and force-pushes, CI re-runs, the PR auto-merges, and the following master push (now attributed to the PAT owner) triggers Integrate/CodeQL and the next drain round.

---
_Generated by [Claude Code](https://claude.ai/code/session_013fkTwG3rGBSiaCc9ymCkcb)_