### PR TITLE
Fix Collabora E2E save test on CODE 26.04 + CI coverage errors and build warnings

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -44,11 +44,25 @@ jobs:
       run: dotnet test --no-build --results-directory ${{ github.workspace }}/test-results --coverage --coverage-output-format cobertura --report-xunit-junit
     - name: Upload test results to Codecov
       # Runs even when the Test step failed — reporting the failed tests is the whole point.
+      # codecov/test-results-action is deprecated in favor of codecov-action with
+      # report_type: test_results; in that mode the CLI's own search patterns pick up the
+      # *.junit.xml files in the directory (the `files:` input does not expand globs).
       if: ${{ !cancelled() }}
-      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: ${{ github.workspace }}/test-results/**/*.junit.xml
+        report_type: test_results
+        directory: ${{ github.workspace }}/test-results
+    - name: Prune empty coverage reports
+      # A test assembly whose tests are all filtered out (the E2E project under the CI-wide
+      # Category!=E2E filter) still writes a cobertura file with no <package> element; qlty's
+      # parser rejects such a file outright and aborts the whole upload. A zero-data report
+      # carries nothing worth uploading — drop them before the coverage steps.
+      run: |
+        shopt -s nullglob
+        for f in "${{ github.workspace }}"/test-results/*.cobertura.xml; do
+          grep -q "<package" "$f" || { echo "Pruning empty coverage report: $f"; rm "$f"; }
+        done
     - name: Upload coverage to Qlty
       uses: qltysh/qlty-action/coverage@08a0a862c159eae9b9003081da6663d96efef637 # v2
       with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -59,11 +59,25 @@ jobs:
       run: dotnet test --no-build --results-directory ${{ github.workspace }}/test-results --coverage --coverage-output-format cobertura --report-xunit-junit
     - name: Upload test results to Codecov
       # Runs even when the Test step failed — reporting the failed tests is the whole point.
+      # codecov/test-results-action is deprecated in favor of codecov-action with
+      # report_type: test_results; in that mode the CLI's own search patterns pick up the
+      # *.junit.xml files in the directory (the `files:` input does not expand globs).
       if: ${{ !cancelled() }}
-      uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: ${{ github.workspace }}/test-results/**/*.junit.xml
+        report_type: test_results
+        directory: ${{ github.workspace }}/test-results
+    - name: Prune empty coverage reports
+      # A test assembly whose tests are all filtered out (the E2E project under the CI-wide
+      # Category!=E2E filter) still writes a cobertura file with no <package> element; qlty's
+      # parser rejects such a file outright and aborts the whole upload. A zero-data report
+      # carries nothing worth uploading — drop them before the coverage steps.
+      run: |
+        shopt -s nullglob
+        for f in "${{ github.workspace }}"/test-results/*.cobertura.xml; do
+          grep -q "<package" "$f" || { echo "Pruning empty coverage report: $f"; rm "$f"; }
+        done
     - name: Upload coverage to Qlty
       uses: qltysh/qlty-action/coverage@08a0a862c159eae9b9003081da6663d96efef637 # v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,13 @@ jobs:
       uses: ./.github/actions/prepull-testcontainers-images
     - name: Test
       run: dotnet test --no-build --configuration Release --results-directory ${{ github.workspace }}/test-results --coverage --coverage-output-format cobertura
+    - name: Prune empty coverage reports
+      # See pull_request.yml for the rationale (qlty rejects package-less cobertura files).
+      run: |
+        shopt -s nullglob
+        for f in "${{ github.workspace }}"/test-results/*.cobertura.xml; do
+          grep -q "<package" "$f" || { echo "Pruning empty coverage report: $f"; rm "$f"; }
+        done
     - name: Upload coverage to Qlty
       uses: qltysh/qlty-action/coverage@08a0a862c159eae9b9003081da6663d96efef637 # v2
       with:

--- a/infra/WopiHost.AppHost/WopiHost.AppHost.csproj
+++ b/infra/WopiHost.AppHost/WopiHost.AppHost.csproj
@@ -2,7 +2,7 @@
 <!-- Keep in lockstep with the Aspire.Hosting.* versions in Directory.Packages.props.
      Dependabot's nuget ecosystem scans PackageReference/PackageVersion elements only,
      so this Sdk element needs a manual bump alongside every Aspire.Hosting.* bump. -->
-<Sdk Name="Aspire.AppHost.Sdk" Version="13.4.6" />
+<Sdk Name="Aspire.AppHost.Sdk" Version="13.5.2" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -10,6 +10,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <IsAspireHost>true</IsAspireHost>
     <UserSecretsId>bd8828e6-c0a3-44b0-af52-51332580a612</UserSecretsId>
+    <!-- This AppHost is driven via `dotnet run` (VS F5, the E2E test fixtures, CI) and uses
+         no feature that needs the bundled Aspire CLI; opting in would only add download
+         weight to every build lane. ASPIRE010 is the nudge to opt in — suppressed because
+         the opt-out is deliberate, not an oversight. -->
+    <AspireUseCliBundle>false</AspireUseCliBundle>
+    <NoWarn>$(NoWarn);ASPIRE010</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/WopiHost.E2ETests/Collabora/CollaboraEditDocxTests.cs
+++ b/test/WopiHost.E2ETests/Collabora/CollaboraEditDocxTests.cs
@@ -328,59 +328,67 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
             } catch (_) { /* same-origin policy or no wrap — both fine, fall through */ }
         }");
 
-        // Step 2: Collabora opens the doc in "Viewing" mode by default even when the WOPI host
-        // sends UserCanWrite=true (#document-container carries class="readonly"). The view-mode
-        // dropdown in the notebookbar has the toggle; clicking it once and then picking the
-        // "Editing" entry switches the doc into edit mode so subsequent typing actually
-        // mutates content. Wrapped to swallow any failure (selector drift, leftover overlay,
-        // timeout) because the save assertion below is the real test — if Collabora kept the
-        // doc read-only, the write won't happen and the diagnostic dump explains it.
-        // Catches the broad Exception bucket because Playwright's timeout surfaces as
-        // System.TimeoutException (from WrapApiCallAsync), NOT as a PlaywrightException.
-        try
+        // Step 2: get the document out of read-only mode — and prove it before typing.
+        // Whether a UserCanWrite doc starts in Collabora's "Viewing" mode has shifted across
+        // CODE releases (26.04 ignores the notebookbar toggle this test used to click, so the
+        // keystrokes went nowhere and only the save oracle caught it), so no single affordance
+        // is trusted: the loop retries the known ones until #document-container drops its
+        // "readonly" class.
+        //   - #mobile-edit-button: the entry point Permission.js wires precisely for documents
+        //     that START read-only; the id has been stable across CODE versions.
+        //   - the notebookbar view-mode dropdown + "Editing" entry (works on CODE 25.04).
+        // postMessage cannot substitute here: in read-only mode Send_UNO_Command filters
+        // commands to an allowlist that does not include .uno:EditDoc (Toolbar.js).
+        // Failing fast with the live container class beats typing into a read-only canvas and
+        // leaving the diagnosis to the downstream save oracle.
+        var editDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+        var containerClass = await GetContainerClassAsync();
+        while (HasReadOnlyClass(containerClass) && DateTime.UtcNow < editDeadline)
         {
-            await officeFrame.Locator("#viewModeDropdownButton-button").ClickAsync(new() { Timeout = 5_000 });
-            await officeFrame.Locator("text=Editing").First.ClickAsync(new() { Timeout = 5_000 });
+            await TryDismissAsync(officeFrame.Locator("#mobile-edit-button"), timeoutMs: 1_500);
+            await TryDismissAsync(officeFrame.Locator("#viewModeDropdownButton-button"), timeoutMs: 1_500);
+            await TryDismissAsync(officeFrame.Locator("text=Editing").First, timeoutMs: 1_500);
+            await Task.Delay(500);
+            containerClass = await GetContainerClassAsync();
         }
-        catch (Exception ex) when (ex is PlaywrightException or TimeoutException)
+        if (HasReadOnlyClass(containerClass))
         {
-            // View-mode dropdown not where expected, or the click was intercepted. Fall
-            // through — the save assertion below will catch any resulting no-op write.
+            throw await FailWithDiagnosticsAsync(
+                "The document never left Collabora's read-only mode within 30s — every known " +
+                "edit-mode affordance (#mobile-edit-button, the view-mode dropdown) missed. " +
+                "Typing would silently go nowhere, so the test stops here.");
         }
 
-        // Step 3: focus the document area. The actual document tiles are rendered to internal
-        // canvas / <div> elements that swallow pointer events; clicking the container is
-        // enough to put input focus on the editor (Collabora intercepts the synthetic mouse
-        // event and routes it through loolwsd's tile pipeline).
-        // Force=true skips the visible/enabled/stable check so a *second* modal popping up
-        // mid-click (e.g. the "Welcome" dialog on a fresh session) doesn't make the click
-        // retry-loop and time out. Pointer-event semantics aren't needed here — only focus +
-        // subsequent keyboard input, both of which work under Force.
-        await officeFrame.Locator("#document-container").ClickAsync(new() { Force = true });
-
-        // Step 2: type a marker into the document. The marker doubles as the save oracle: it
+        // Step 3: focus the document area and type the marker. Clicking the container routes
+        // input focus to Collabora's hidden input; the marker doubles as the save oracle — it
         // must come back in the saved file's word/document.xml, proving the keystrokes
         // round-tripped keystroke → loolwsd → tile invalidate → write-on-save → PutFile.
+        // Force=true skips the visible/enabled/stable check so a late modal popping up
+        // mid-click doesn't make the click retry-loop and time out.
+        await officeFrame.Locator("#document-container").ClickAsync(new() { Force = true });
         await page.Keyboard.TypeAsync(EditMarker, new KeyboardTypeOptions { Delay = 30 });
 
-        // Wait for Collabora to mark the document model dirty (Doc_ModifiedStatus
-        // Modified:true) before requesting the save; a fixed sleep either wastes time or —
-        // on a slow runner — lets Action_Save race the keystrokes and save a clean model.
-        // Falls through on deadline rather than failing: some CODE builds may not emit the
-        // event, and the marker assertion below is the authoritative oracle either way.
-        var dirtyDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(15);
-        while (DateTime.UtcNow < dirtyDeadline)
+        // The typing must observably reach the document model before a save is worth
+        // requesting: Collabora emits Doc_ModifiedStatus Modified:true on the clean→dirty
+        // transition (the capture already recorded the initial Modified:false, so the channel
+        // itself is proven). One re-click + re-type covers a transient focus steal by a late
+        // modal; a model that stays clean after that is the real failure this test exists to
+        // surface — with DontSaveIfUnmodified:false the save would otherwise "succeed" on
+        // unchanged content.
+        if (!await WaitForModelDirtyAsync(TimeSpan.FromSeconds(10)))
         {
-            var modelDirty = await page.EvaluateAsync<bool>(
-                "() => (window.__collaboraMessages || []).some(m => m.messageId === 'Doc_ModifiedStatus' && m.modified === true)");
-            if (modelDirty)
+            await officeFrame.Locator("#document-container").ClickAsync(new() { Timeout = 5_000 });
+            await page.Keyboard.TypeAsync(EditMarker, new KeyboardTypeOptions { Delay = 30 });
+            if (!await WaitForModelDirtyAsync(TimeSpan.FromSeconds(10)))
             {
-                break;
+                throw await FailWithDiagnosticsAsync(
+                    "The document is in edit mode, but the typed keystrokes never marked the " +
+                    "model dirty (no Doc_ModifiedStatus Modified:true) — input focus is not " +
+                    "reaching Collabora's editor.");
             }
-            await Task.Delay(250);
         }
 
-        // Step 3: trigger save via the host-postMessage API. Collabora documents this as a
+        // Step 4: trigger save via the host-postMessage API. Collabora documents this as a
         // first-class integration channel (https://sdk.collaboraonline.com/docs/postmessage_api.html#Action_Save),
         // so it's much more stable than poking the toolbar Save icon — that icon's DOM id
         // has changed at least once between CODE majors. Action_Save with default options
@@ -396,7 +404,7 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
             }), '*');
         }");
 
-        // Step 4: poll for the on-disk write. The PutFile request travels Collabora → host
+        // Step 5: poll for the on-disk write. The PutFile request travels Collabora → host
         // backend → file-system provider; even after Action_Save returns, the writeback can
         // take a few seconds. Allow up to 60 s with a 250 ms poll cadence — a shorter budget can
         // be too tight given Collabora's autosave debouncing on CI.
@@ -414,6 +422,33 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
             await Task.Delay(250);
         }
 
+        if (!changed)
+        {
+            // The diagnostic postMessage trail disambiguates WHY the save was a no-op:
+            //   - Action_Save_Resp with success: false → host-side save handler failed (lock conflict, IO error).
+            //   - No Action_Save_Resp at all           → Collabora ignored the save trigger entirely.
+            throw await FailWithDiagnosticsAsync(
+                $"Expected {SampleDocxName} to be re-written by Collabora's Action_Save within 60s.\n" +
+                $"  LastWrite before: {modifiedBefore:O}\n" +
+                $"  LastWrite after:  {File.GetLastWriteTimeUtc(docxPath):O}\n" +
+                $"  Size before: {sizeBefore}\n" +
+                $"  Size after:  {new FileInfo(docxPath).Length}");
+        }
+
+        // Step 6: the write happened — now prove it carries the EDIT, not just any PutFile.
+        // Action_Save runs with DontSaveIfUnmodified:false, so a save can also fire on an
+        // unmodified model; only the typed marker inside word/document.xml distinguishes
+        // "edit round-tripped" from a no-op save of unchanged content.
+        // OrdinalIgnoreCase: LibreOffice's sentence autocapitalization may upper-case the
+        // marker's first letter; the case doesn't matter, only that the text persisted.
+        var documentXml = ReadDocumentXml(docxPath);
+        if (!documentXml.Contains(EditMarker, StringComparison.OrdinalIgnoreCase))
+        {
+            throw await FailWithDiagnosticsAsync(
+                $"Collabora re-wrote {SampleDocxName}, but the typed marker \"{EditMarker}\" is not in " +
+                "word/document.xml — the saved bytes carry no trace of the edit.");
+        }
+
         static async Task TryDismissAsync(ILocator locator, int timeoutMs)
         {
             try
@@ -422,59 +457,56 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
             }
             catch (Exception ex) when (ex is PlaywrightException or TimeoutException)
             {
-                // Modal genuinely didn't appear (or its selector drifted across CODE versions).
-                // Caller treats this as a best-effort dismissal — proceed regardless.
+                // Element genuinely absent/hidden (or its selector drifted across CODE
+                // versions). Caller treats this as a best-effort click — proceed regardless.
+                // Playwright's timeout surfaces as System.TimeoutException (WrapApiCallAsync),
+                // NOT as a PlaywrightException, hence the two-type filter.
             }
         }
 
-        if (!changed)
+        async Task<string?> GetContainerClassAsync()
         {
-            // Pull the postMessage trail + the editor's read-only state to disambiguate WHY the
-            // save was a no-op. Three classes of failure mode readable off the captured events:
-            //   - Document_LoadedSuccessfully with permissions != edit  → CheckFileInfo wire content not granting UserCanWrite.
-            //   - Action_Save_Resp with success: false                  → host-side save handler failed (lock conflict, IO error).
-            //   - No Action_Save_Resp at all                            → Collabora ignored the save trigger (doc in view mode).
-            // Stringify on the JS side. `EvaluateAsync<object>` over an array returns a boxed
-            // JS array whose .ToString() is "System.Object[]" — useless. JSON.stringify with
-            // indentation gives a readable, copy-pasteable diagnostic.
-            var messages = await page.EvaluateAsync<string>(
-                "() => JSON.stringify(window.__collaboraMessages || [], null, 2)");
-            string? containerClass = null;
             try
             {
-                containerClass = await officeFrame.Locator("#document-container").GetAttributeAsync("class");
+                return await officeFrame.Locator("#document-container").GetAttributeAsync("class");
             }
-            catch { /* selector may have died if Collabora unmounted */ }
-
-            var collaboraLogs = await app.CaptureClientLogsAsync();
-            throw new Xunit.Sdk.XunitException(
-                $"Expected {SampleDocxName} to be re-written by Collabora's Action_Save within 60s.\n" +
-                $"  LastWrite before: {modifiedBefore:O}\n" +
-                $"  LastWrite after:  {File.GetLastWriteTimeUtc(docxPath):O}\n" +
-                $"  Size before: {sizeBefore}\n" +
-                $"  Size after:  {new FileInfo(docxPath).Length}\n" +
-                $"  #document-container class: {containerClass ?? "<unresolved>"}\n" +
-                $"  Captured Collabora postMessages (newest last):\n{messages}\n" +
-                $"\nCollabora container logs (last 400 lines):\n{collaboraLogs}");
+            catch (Exception ex) when (ex is PlaywrightException or TimeoutException)
+            {
+                // Selector may have died if Collabora unmounted mid-test.
+                return null;
+            }
         }
 
-        // Step 5: the write happened — now prove it carries the EDIT, not just any PutFile.
-        // Action_Save runs with DontSaveIfUnmodified:false, so a document stuck in view mode
-        // (the failure Step 2 deliberately swallows) still produces a rewritten file; only the
-        // typed marker inside word/document.xml distinguishes "edit round-tripped" from a
-        // no-op save of unchanged content.
-        // OrdinalIgnoreCase: LibreOffice's sentence autocapitalization may upper-case the
-        // marker's first letter; the case doesn't matter, only that the text persisted.
-        var documentXml = ReadDocumentXml(docxPath);
-        if (!documentXml.Contains(EditMarker, StringComparison.OrdinalIgnoreCase))
+        static bool HasReadOnlyClass(string? containerClass)
+            => containerClass is not null && containerClass.Split(' ').Contains("readonly");
+
+        async Task<bool> WaitForModelDirtyAsync(TimeSpan budget)
+        {
+            var deadline = DateTime.UtcNow + budget;
+            while (DateTime.UtcNow < deadline)
+            {
+                var modelDirty = await page.EvaluateAsync<bool>(
+                    "() => (window.__collaboraMessages || []).some(m => m.messageId === 'Doc_ModifiedStatus' && m.modified === true)");
+                if (modelDirty)
+                {
+                    return true;
+                }
+                await Task.Delay(250);
+            }
+            return false;
+        }
+
+        // Stringify on the JS side. `EvaluateAsync<object>` over an array returns a boxed
+        // JS array whose .ToString() is "System.Object[]" — useless. JSON.stringify with
+        // indentation gives a readable, copy-pasteable diagnostic.
+        async Task<Xunit.Sdk.XunitException> FailWithDiagnosticsAsync(string headline)
         {
             var messages = await page.EvaluateAsync<string>(
                 "() => JSON.stringify(window.__collaboraMessages || [], null, 2)");
             var collaboraLogs = await app.CaptureClientLogsAsync();
-            throw new Xunit.Sdk.XunitException(
-                $"Collabora re-wrote {SampleDocxName}, but the typed marker \"{EditMarker}\" is not in " +
-                $"word/document.xml — the save was a no-op of unmodified content (document likely stayed " +
-                $"in view mode, or the keystrokes never reached the model).\n" +
+            return new Xunit.Sdk.XunitException(
+                headline + "\n" +
+                $"  #document-container class: {await GetContainerClassAsync() ?? "<unresolved>"}\n" +
                 $"  Captured Collabora postMessages (newest last):\n{messages}\n" +
                 $"\nCollabora container logs (last 400 lines):\n{collaboraLogs}");
         }

--- a/test/WopiHost.E2ETests/Collabora/CollaboraEditDocxTests.cs
+++ b/test/WopiHost.E2ETests/Collabora/CollaboraEditDocxTests.cs
@@ -1,4 +1,5 @@
 using System.IO.Compression;
+using System.Xml.Linq;
 using Microsoft.Playwright;
 using WopiHost.E2ETests.Fixtures;
 
@@ -431,14 +432,17 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
         // Action_Save runs with DontSaveIfUnmodified:false, so a save can also fire on an
         // unmodified model; only the typed marker inside word/document.xml distinguishes
         // "edit round-tripped" from a no-op save of unchanged content.
-        // OrdinalIgnoreCase: LibreOffice's sentence autocapitalization may upper-case the
-        // marker's first letter; the case doesn't matter, only that the text persisted.
-        var documentXml = ReadDocumentXml(docxPath);
-        if (!documentXml.Contains(EditMarker, StringComparison.OrdinalIgnoreCase))
+        // The search runs over the document's extracted TEXT, not the raw XML: LibreOffice's
+        // autocorrect (sentence capitalization fires at each hyphen word-boundary) splits the
+        // typed marker across adjacent <w:t> runs, so a raw-XML substring search misses text
+        // interleaved with tags. OrdinalIgnoreCase absorbs the capitalization itself.
+        var documentText = ReadDocumentText(docxPath);
+        if (!documentText.Contains(EditMarker, StringComparison.OrdinalIgnoreCase))
         {
             throw await FailWithDiagnosticsAsync(
                 $"Collabora re-wrote {SampleDocxName}, but the typed marker \"{EditMarker}\" is not in " +
-                "word/document.xml — the saved bytes carry no trace of the edit.");
+                "word/document.xml's text — the saved bytes carry no trace of the edit.\n" +
+                $"  Extracted document text (first 500 chars): {documentText[..Math.Min(documentText.Length, 500)]}");
         }
 
         static async Task TryDismissAsync(ILocator locator, int timeoutMs)
@@ -525,13 +529,15 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
                 $"\nCollabora container logs (last 400 lines):\n{collaboraLogs}");
         }
 
-        static string ReadDocumentXml(string docxPath)
+        static string ReadDocumentText(string docxPath)
         {
             using var archive = ZipFile.OpenRead(docxPath);
             var entry = archive.GetEntry("word/document.xml")
                 ?? throw new Xunit.Sdk.XunitException($"{docxPath} has no word/document.xml — saved file is not a valid docx.");
-            using var reader = new StreamReader(entry.Open());
-            return reader.ReadToEnd();
+            using var stream = entry.Open();
+            // XElement.Value concatenates every text node in document order, so a marker split
+            // across runs by autocorrect edits reads back as one contiguous string.
+            return XElement.Load(stream).Value;
         }
     }
 }

--- a/test/WopiHost.E2ETests/Collabora/CollaboraEditDocxTests.cs
+++ b/test/WopiHost.E2ETests/Collabora/CollaboraEditDocxTests.cs
@@ -58,8 +58,11 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
     /// Text typed into the document by the save test and asserted back out of the saved file's
     /// <c>word/document.xml</c>. A timestamp/size probe alone can't prove the edit landed:
     /// a save of an unmodified document still rewrites the file.
+    /// Letters and digits only — Playwright-synthesized punctuation keys don't reach COOL's
+    /// textinput path (a hyphenated marker arrived as "wopihoste2emarker" on CODE 26.04: every
+    /// letter and digit came through the kit's textinput stream, no hyphen ever did).
     /// </summary>
-    private const string EditMarker = "wopihost-e2e-marker";
+    private const string EditMarker = "wopihoste2emarker";
 
     /// <summary>How long to wait for Collabora's iframe to render the document area. Generous
     /// because CODE's startup + WebSocket handshake commonly takes 8–15 s on a cold cache.</summary>
@@ -432,10 +435,10 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
         // Action_Save runs with DontSaveIfUnmodified:false, so a save can also fire on an
         // unmodified model; only the typed marker inside word/document.xml distinguishes
         // "edit round-tripped" from a no-op save of unchanged content.
-        // The search runs over the document's extracted TEXT, not the raw XML: LibreOffice's
-        // autocorrect (sentence capitalization fires at each hyphen word-boundary) splits the
-        // typed marker across adjacent <w:t> runs, so a raw-XML substring search misses text
-        // interleaved with tags. OrdinalIgnoreCase absorbs the capitalization itself.
+        // The search runs over the document's extracted TEXT, not the raw XML: LibreOffice may
+        // split typed text across adjacent <w:t> runs (autocorrect edits, formatting
+        // boundaries), and a raw-XML substring search cannot match text interleaved with tags.
+        // OrdinalIgnoreCase absorbs sentence autocapitalization of the first letter.
         var documentText = ReadDocumentText(docxPath);
         if (!documentText.Contains(EditMarker, StringComparison.OrdinalIgnoreCase))
         {

--- a/test/WopiHost.E2ETests/Collabora/CollaboraEditDocxTests.cs
+++ b/test/WopiHost.E2ETests/Collabora/CollaboraEditDocxTests.cs
@@ -305,28 +305,15 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
         // race the modal's arrival. Use Playwright's auto-wait by trying to click the OK button
         // with a short timeout; on miss (modal genuinely didn't show), swallow the timeout and
         // proceed. The button id is well-named and stable across CODE versions.
+        await DismissWelcomeOverlayAsync();
         await TryDismissAsync(officeFrame.Locator("#response-ok-button"), timeoutMs: 5_000);
 
         // Step 1a: dismiss Collabora's "welcome" iframe overlay (CODE 25.04+ shows it on first
-        // open). The wrapper is a <div class="iframe-welcome-wrap"> with an .iframe-welcome
-        // child whose pointer-events sit ON TOP of the notebookbar. Until it's dismissed, every
-        // click into the toolbar (including the view-mode dropdown below) gets swallowed with
-        // "subtree intercepts pointer events" — Playwright then times out at 5 s.
-        //
-        // The dialog's close affordance has varied across CODE versions: 25.04 ships an
-        // <button class="iframe-welcome-close">, older versions had a "Close" link. Each is
-        // tried in turn, falling back to pressing Escape on the iframe contentWindow (Collabora's
-        // dialog manager closes on Esc), and finally just removing the wrapper from the DOM
-        // (defensive against further selector drift).
-        await TryDismissAsync(officeFrame.Locator(".iframe-welcome-close"), timeoutMs: 3_000);
-        await TryDismissAsync(officeFrame.Locator(".iframe-welcome-wrap button:has-text('Close')"), timeoutMs: 1_500);
-        await page.EvaluateAsync(@"() => {
-            try {
-                var frame = document.querySelector('iframe[name=""office_frame""]');
-                var wrap = frame && frame.contentDocument && frame.contentDocument.querySelector('.iframe-welcome-wrap');
-                if (wrap) { wrap.remove(); }
-            } catch (_) { /* same-origin policy or no wrap — both fine, fall through */ }
-        }");
+        // open). The wrapper is a <div class="iframe-welcome-wrap"> whose pointer-events sit
+        // ON TOP of the whole editor: until it's gone, every click — including a Force click,
+        // which "succeeds" without reaching the editor — is swallowed, keystrokes never focus
+        // the document, and typing goes nowhere. It also appears asynchronously, so it is
+        // purged again before every later interaction rather than once here.
 
         // Step 2: get the document out of read-only mode — and prove it before typing.
         // Whether a UserCanWrite doc starts in Collabora's "Viewing" mode has shifted across
@@ -341,10 +328,12 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
         // commands to an allowlist that does not include .uno:EditDoc (Toolbar.js).
         // Failing fast with the live container class beats typing into a read-only canvas and
         // leaving the diagnosis to the downstream save oracle.
+        await DismissWelcomeOverlayAsync();
         var editDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
         var containerClass = await GetContainerClassAsync();
         while (HasReadOnlyClass(containerClass) && DateTime.UtcNow < editDeadline)
         {
+            await DismissWelcomeOverlayAsync();
             await TryDismissAsync(officeFrame.Locator("#mobile-edit-button"), timeoutMs: 1_500);
             await TryDismissAsync(officeFrame.Locator("#viewModeDropdownButton-button"), timeoutMs: 1_500);
             await TryDismissAsync(officeFrame.Locator("text=Editing").First, timeoutMs: 1_500);
@@ -363,9 +352,11 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
         // input focus to Collabora's hidden input; the marker doubles as the save oracle — it
         // must come back in the saved file's word/document.xml, proving the keystrokes
         // round-tripped keystroke → loolwsd → tile invalidate → write-on-save → PutFile.
-        // Force=true skips the visible/enabled/stable check so a late modal popping up
-        // mid-click doesn't make the click retry-loop and time out.
-        await officeFrame.Locator("#document-container").ClickAsync(new() { Force = true });
+        // The overlay purge immediately before the click matters: the welcome dialog arrives
+        // asynchronously, a Force click would "succeed" through it without focusing anything,
+        // and a normal click would retry-loop against it until timeout.
+        await DismissWelcomeOverlayAsync();
+        await officeFrame.Locator("#document-container").ClickAsync(new() { Timeout = 10_000 });
         await page.Keyboard.TypeAsync(EditMarker, new KeyboardTypeOptions { Delay = 30 });
 
         // The typing must observably reach the document model before a save is worth
@@ -377,6 +368,7 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
         // unchanged content.
         if (!await WaitForModelDirtyAsync(TimeSpan.FromSeconds(10)))
         {
+            await DismissWelcomeOverlayAsync();
             await officeFrame.Locator("#document-container").ClickAsync(new() { Timeout = 5_000 });
             await page.Keyboard.TypeAsync(EditMarker, new KeyboardTypeOptions { Delay = 30 });
             if (!await WaitForModelDirtyAsync(TimeSpan.FromSeconds(10)))
@@ -461,6 +453,28 @@ public sealed class CollaboraEditDocxTests(CollaboraAppFixture app, PlaywrightFi
                 // versions). Caller treats this as a best-effort click — proceed regardless.
                 // Playwright's timeout surfaces as System.TimeoutException (WrapApiCallAsync),
                 // NOT as a PlaywrightException, hence the two-type filter.
+            }
+        }
+
+        // The welcome dialog lives inside the office frame, which is CROSS-ORIGIN to the host
+        // page — a page-context frame.contentDocument walk can never reach it (it silently
+        // yields null), which is how the overlay survived the old removal attempt and swallowed
+        // every subsequent click and keystroke. Playwright's frame-piercing locator does cross
+        // the boundary; removing the wrapper outright is version-proof, since the close
+        // affordance inside it has drifted across CODE releases while the wrapper class has not.
+        async Task DismissWelcomeOverlayAsync()
+        {
+            try
+            {
+                var wrap = officeFrame.Locator(".iframe-welcome-wrap");
+                if (await wrap.CountAsync() > 0)
+                {
+                    await wrap.First.EvaluateAsync("el => el.remove()");
+                }
+            }
+            catch (Exception ex) when (ex is PlaywrightException or TimeoutException)
+            {
+                // No overlay, or it vanished mid-check — nothing to dismiss either way.
             }
         }
 


### PR DESCRIPTION
### Motivation

Follow-up to #678, fixing the E2E failure it exposed ([run 33391970837](https://github.com/petrsvihlik/WopiHost/actions/runs/33391970837)) plus the CI annotations from [run 33388442598](https://github.com/petrsvihlik/WopiHost/actions/runs/33388442598) — all in one PR.

**E2E (Collabora) `SaveAfterEdit_WritesNewBytesToDisk`** — the new marker oracle from #678 did its job on its first nightly-style run: the postMessage trail shows `Doc_ModifiedStatus Modified:false` only, zero `key` messages reached coolwsd, and `Action_Save` (`DontSaveIfUnmodified:false`) uploaded the *unchanged* document — i.e. the previous green runs were the silent false pass the oracle was built to catch. Root cause: the workflow pulls `collabora/code:latest`, which moved to **CODE 26.04**, and 26.04 no longer honours the notebookbar view-mode toggle the test clicked (that failure was deliberately swallowed), so the document stayed read-only and the typed keystrokes went nowhere.

The test now proves each precondition instead of assuming it (verified against the COOL source):

- **Edit mode is entered verifiably**: a retry loop drives the known affordances — `#mobile-edit-button`, the exact entry point COOL's `Permission.js` wires for documents that *start* read-only (id stable across CODE versions), plus the 25.04-era notebookbar dropdown — until `#document-container` drops its `readonly` class, failing fast with the live class + postMessage trail if it never does. postMessage can't substitute here: COOL's read-only mode filters `Send_UNO_Command` to an allowlist that excludes `.uno:EditDoc` (`Toolbar.js`).
- **The dirty-wait is a hard gate**: `Doc_ModifiedStatus Modified:true` must arrive (the capture already proves the channel by recording the initial `Modified:false`), with one re-click + re-type retry for a transient focus steal. A model that stays clean now fails with a precise message instead of degrading into a no-op save.
- All failure paths share one diagnostics helper (container class, postMessage trail, filtered container logs).

**CI warnings/errors** (screenshot + build annotations):

- **qlty coverage error** ("missing field `package`" → "Error executing coverage command"): the E2E project runs zero tests under the default `--filter-not-trait "Category=E2E"` but still writes an empty, package-less cobertura file that qlty's parser rejects outright. A *Prune empty coverage reports* step now drops zero-data reports before upload in `pull_request.yml`, `integrate.yml`, and `release.yml`.
- **Deprecated `codecov/test-results-action`** (also pinned to Node 20): replaced with the already-pinned `codecov-action` v7 in `report_type: test_results` mode; the CLI's own search patterns pick up the `*.junit.xml` files in the results directory (the action's `files:` input doesn't expand globs — same gotcha the coverage upload already documents).
- **ASPIRE010 ×2** (build + both E2E lanes): `Aspire.AppHost.Sdk` bumped 13.4.6 → 13.5.2, restoring the lockstep with the `Aspire.Hosting.*` 13.5.2 packages that the csproj's own comment requires (dependabot can't bump `Sdk` elements) — and the CLI-bundle opt-out is now explicit with a documented suppression: the AppHost is `dotnet run`-driven and uses no feature needing the bundled CLI, so the nudge was pure noise in every lane.
- Not fixable here: the qlty CLI's "`--validate` is deprecated" log notice comes from inside `qltysh/qlty-action` (its `main` still passes the flag) — upstream's to fix, no repo-side knob.

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
- [x] Adheres to [.NET Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/)

### How to test

- `dotnet build WOPI.slnx` — succeeds with **0 warnings** (was 1: ASPIRE010).
- `dotnet test --project test/WopiHost.E2ETests/WopiHost.E2ETests.csproj` — harness intact (zero tests under the default filter, exit tolerated).
- Prune script verified against a fabricated package-less cobertura (pruned) and a real one (kept).
- The decisive check is the **E2E (Collabora) workflow on this PR / next nightly** — it exercises the edit-mode loop against the real CODE 26.04 image; if the container-class assumption drifted too, the new fail-fast paths name it in the failure output instead of a silent no-op save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136hX6FpWJJEGhVJmQkSJu3

---
_Generated by [Claude Code](https://claude.ai/code/session_0136hX6FpWJJEGhVJmQkSJu3)_