### PR TITLE
chore: bump collabora/code to 26.04.3.2.1

### DIFF
--- a/infra/WopiHost.AppHost/Program.cs
+++ b/infra/WopiHost.AppHost/Program.cs
@@ -262,7 +262,7 @@ if (builder.Configuration.GetValue("AppHost:IncludeOidcSample", defaultValue: fa
 // while loolwsd is still binding.
 if (useCollabora)
 {
-    var collabora = builder.AddContainer("collabora", "collabora/code", "26.04.3.1.1")
+    var collabora = builder.AddContainer("collabora", "collabora/code", "26.04.3.2.1")
            // host.docker.internal needs an explicit --add-host=host.docker.internal:host-gateway on
            // Linux Docker Engine — Docker Desktop on Mac/Windows wires it implicitly, but the Linux
            // daemon doesn't. Without this, Collabora's WOPI callbacks from inside the container can't


### PR DESCRIPTION
## Summary
- Bumps the `collabora/code` image used by `WopiHost.AppHost` from `26.04.3.1.1` to `26.04.3.2.1` (latest stable as of 2026-08-31).
- Upstream release notes for this patch range were not reachable via the GitHub releases page (which currently only surfaces Helm chart releases for CollaboraOnline/online). This is a patch-level bump (`3.1` → `3.2`) with no breaking changes flagged.

## Test plan
- [ ] `dotnet build infra/WopiHost.AppHost`
- [ ] `dotnet run --project infra/WopiHost.AppHost` with `AppHost:UseCollabora=true`, open the frontend URL shown in the Aspire dashboard, verify a document loads in the iframe and edits round-trip.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BpGrRYvKCtimxgMJofFPm8)_