### PR TITLE
fix(deps): align Aspire.AppHost.Sdk with Aspire.Hosting.* and enforce the pairing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,12 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 20
+    # Aspire is Renovate-owned. The AppHost pins Aspire.AppHost.Sdk on an <Sdk> element,
+    # which this ecosystem never scans (it reads PackageReference/PackageVersion only), so
+    # a bump from here would move the packages and leave the Sdk behind — a mismatch the
+    # AppHost build now rejects. Renovate ships both halves in one grouped PR instead.
+    ignore:
+      - dependency-name: "Aspire.*"
     commit-message:
       prefix: "chore(deps)"
     # Bundle same-day minor/patch bumps into one PR. Major bumps are left

--- a/infra/WopiHost.AppHost/WopiHost.AppHost.csproj
+++ b/infra/WopiHost.AppHost/WopiHost.AppHost.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-<!-- Keep in lockstep with the Aspire.Hosting.* versions in Directory.Packages.props.
-     Dependabot's nuget ecosystem scans PackageReference/PackageVersion elements only,
-     so this Sdk element needs a manual bump alongside every Aspire.Hosting.* bump. -->
-<Sdk Name="Aspire.AppHost.Sdk" Version="13.5.2" />
+<!-- Must match the Aspire.Hosting.* versions in Directory.Packages.props. Dependabot's
+     nuget ecosystem scans PackageReference/PackageVersion elements only and never sees an
+     Sdk element, so a Renovate custom manager proposes this pin and the
+     VerifyAspireSdkMatchesPackages target below fails the build if the two ever disagree. -->
+<Sdk Name="Aspire.AppHost.Sdk" Version="13.5.3" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -23,6 +24,28 @@
     <PackageReference Include="Aspire.Hosting.Azure.Storage" />
     <PackageReference Include="Aspire.Hosting.Redis" />
   </ItemGroup>
+
+  <!-- The Sdk pin at the top of this file and Aspire.Hosting.AppHost are bumped by different
+       automation and land in different PRs, and Aspire tolerates a skew between them at
+       runtime — so drift produces no symptom until something subtler breaks. Dependabot PRs
+       are auto-merged, so a comment asking for a paired manual bump is documentation, not a
+       control. This is the control. XmlPeek reads the attribute back out of this file because
+       MSBuild exposes no property for an Sdk element's version. -->
+  <Target Name="VerifyAspireSdkMatchesPackages" BeforeTargets="Build">
+    <XmlPeek XmlInputPath="$(MSBuildProjectFullPath)" Query="/Project/Sdk[@Name='Aspire.AppHost.Sdk']/@Version">
+      <Output TaskParameter="Result" PropertyName="_AspireSdkPin" />
+    </XmlPeek>
+    <ItemGroup>
+      <_AspireHostingAppHost Include="@(PackageVersion)" Condition="'%(Identity)' == 'Aspire.Hosting.AppHost'" />
+    </ItemGroup>
+    <PropertyGroup>
+      <_AspireHostingPin>@(_AspireHostingAppHost->'%(Version)')</_AspireHostingPin>
+    </PropertyGroup>
+    <Error Condition="'$(_AspireSdkPin)' == '' OR '$(_AspireHostingPin)' == ''"
+           Text="Could not read both Aspire versions to compare them (Sdk element: '$(_AspireSdkPin)', Aspire.Hosting.AppHost: '$(_AspireHostingPin)'). One of them moved; update this check to match." />
+    <Error Condition="'$(_AspireSdkPin)' != '$(_AspireHostingPin)'"
+           Text="Aspire version drift: the Aspire.AppHost.Sdk pin in $(MSBuildProjectFile) is $(_AspireSdkPin) but Aspire.Hosting.AppHost in Directory.Packages.props is $(_AspireHostingPin). Bump the Sdk element to $(_AspireHostingPin)." />
+  </Target>
 
   <ItemGroup>
     <ProjectReference Include="..\..\sample\WopiHost\WopiHost.csproj" />

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "enabledManagers": ["custom.regex"],
+  "enabledManagers": ["custom.regex", "nuget"],
   "dependencyDashboard": false,
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Tracks container image tags passed as C# string literals to Aspire's builder.AddContainer(name, image, tag) calls in the AppHost. Dependabot's docker ecosystems only parse Dockerfile/docker-compose files and never see a reference embedded in source, so Renovate patches these literals in place. enabledManagers keeps Renovate scoped to this manager only — NuGet and GitHub Actions stay owned by Dependabot to avoid duplicate PRs for the same dependency.",
+      "description": "Tracks container image tags passed as C# string literals to Aspire's builder.AddContainer(name, image, tag) calls in the AppHost. Dependabot's docker ecosystems only parse Dockerfile/docker-compose files and never see a reference embedded in source, so Renovate patches these literals in place. enabledManagers keeps Renovate scoped to custom managers only — the NuGet and GitHub Actions ecosystems stay owned by Dependabot, so no dependency is proposed twice.",
       "managerFilePatterns": ["/^infra/WopiHost\\.AppHost/Program\\.cs$/"],
       "matchStrings": [
         "AddContainer\\(\"[^\"]+\", \"(?<depName>[^\"]+)\", \"(?<currentValue>[^\"]+)\"\\)"
@@ -30,15 +30,36 @@
         "\"(?<depName>[a-z0-9.-]+(?:/[a-z0-9._-]+)*):(?<currentValue>[0-9][A-Za-z0-9._-]*)\""
       ],
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Tracks the Aspire.AppHost.Sdk pin on the AppHost's <Sdk> element, which must match the Aspire.Hosting.* versions in Directory.Packages.props. Dependabot's nuget ecosystem scans PackageReference/PackageVersion elements only and never sees this element, so nothing proposed it at all; the aspire packageRule below groups it with those packages so the pair moves in one PR.",
+      "managerFilePatterns": ["/^infra/WopiHost\\.AppHost/WopiHost\\.AppHost\\.csproj$/"],
+      "matchStrings": [
+        "<Sdk Name=\"(?<depName>[^\"]+)\" Version=\"(?<currentValue>[^\"]+)\"\\s*/>"
+      ],
+      "datasourceTemplate": "nuget"
     }
   ],
   "packageRules": [
     {
-      "description": "Waits out the window in which a freshly published (possibly compromised) image tag is most likely to be yanked — the same rationale as the 7-day Dependabot cooldown in .github/dependabot.yml.",
-      "matchManagers": ["custom.regex"],
+      "description": "Waits out the window in which a freshly published (possibly compromised) version is most likely to be yanked — the same rationale as the 7-day Dependabot cooldown in .github/dependabot.yml.",
+      "matchManagers": ["custom.regex", "nuget"],
       "minimumReleaseAge": "7 days",
       "commitMessagePrefix": "chore(deps)",
       "labels": ["dependencies"]
+    },
+    {
+      "description": "The nuget manager is enabled only to reach the Aspire packages; everything else in Directory.Packages.props stays Dependabot-owned so no dependency is proposed twice.",
+      "matchManagers": ["nuget"],
+      "enabled": false
+    },
+    {
+      "description": "Aspire.Hosting.* and the Aspire.AppHost.Sdk pin must move together — the AppHost project fails its build when they disagree. Dependabot cannot see the Sdk element, so it ignores Aspire.* entirely (see .github/dependabot.yml) and Renovate ships both halves in one PR under a shared groupName. Splitting them across two bots would leave each bot's PR red until the other merged.",
+      "matchManagers": ["nuget", "custom.regex"],
+      "matchPackageNames": ["/^Aspire\\./"],
+      "enabled": true,
+      "groupName": "aspire"
     }
   ]
 }


### PR DESCRIPTION
### Motivation

Spotted while prepping the 9.3.0 release notes: `WopiHost.AppHost.csproj` pinned `Aspire.AppHost.Sdk` at **13.5.2** while `Directory.Packages.props` carried `Aspire.Hosting.*` at **13.5.3**.

**How it slipped.** The csproj's own comment already named the hazard — *"Dependabot's nuget ecosystem scans PackageReference/PackageVersion elements only, so this Sdk element needs a manual bump alongside every Aspire.Hosting.\* bump."* Three things then lined up:

1. Dependabot genuinely cannot see an `<Sdk>` element, so #687 moved the four packages and left the Sdk behind.
2. Dependabot PRs are **auto-merged** here, so no human ever read the comment asking for the paired bump. A comment is documentation, not a control, when the merge is automated.
3. Aspire tolerates the skew at runtime — the build succeeded, tests passed, CI was green. **There was no signal at all**, which is why it survived from 2026-09-02 to being noticed by eye.

### What this changes

**1 — Align on the newer.** `Aspire.AppHost.Sdk` → `13.5.3`, matching the packages. 13.5.3 is also the latest stable of both on NuGet, so this is the newest coherent pair.

**2 — Make the pairing enforceable.** A `VerifyAspireSdkMatchesPackages` target fails the AppHost build when the Sdk pin and `Aspire.Hosting.AppHost` disagree. `XmlPeek` reads the attribute back out of the project file because MSBuild exposes no property for an `<Sdk>` element's version. Had this existed, #687 would have gone red and auto-merge could not have landed it.

**3 — Give the pair one owner.** This is what makes (2) safe rather than harmful. Renovate now tracks the `<Sdk>` element via a custom manager *and* takes over the `Aspire.*` packages (its `nuget` manager is enabled but disabled for everything else, so nothing is proposed twice), grouped under `groupName: aspire` so both halves move in a single PR. `.github/dependabot.yml` ignores `Aspire.*` to match.

> Without step 3 the build check would **deadlock the bots**: Dependabot's package bump and Renovate's Sdk bump are separate PRs, so whichever moved first would be red against the check, and neither could merge until the other landed. One owner, one PR, no window in which the two disagree.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added — n/a; the build target *is* the check, verified below
- [x] Tests are passing
- [x] Docs have been updated (if applicable) — the csproj/renovate comments now describe the enforced behaviour rather than the manual convention
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
- [x] Adheres to [.NET Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/)

### How to test

**The guard fires in both directions** (run locally, not just reasoned about):

```
# Positive — aligned 13.5.3 == 13.5.3
$ dotnet build infra/WopiHost.AppHost/WopiHost.AppHost.csproj
Build succeeded.  0 Warning(s)  0 Error(s)

# Negative — reintroduce the exact drift this PR fixes (Sdk 13.5.2, packages 13.5.3)
$ dotnet build infra/WopiHost.AppHost/WopiHost.AppHost.csproj
WopiHost.AppHost.csproj(46,5): error : Aspire version drift: the Aspire.AppHost.Sdk pin in
WopiHost.AppHost.csproj is 13.5.2 but Aspire.Hosting.AppHost in Directory.Packages.props is
13.5.3. Bump the Sdk element to 13.5.3.
Build FAILED.   (exit 1)
```

**Full solution:** `dotnet build WOPI.slnx` → `Build succeeded. 0 Warning(s) 0 Error(s)`.

**Renovate config:** validated with the official validator as repository config in strict mode — `npx --package renovate renovate-config-validator --strict` → `INFO: Config validated successfully`.

**Renovate regexes:** the new `matchStrings` pattern was executed against the real file with node (Renovate's own regex engine), extracting `depName=Aspire.AppHost.Sdk` / `currentValue=13.5.3`; the anchored `managerFilePatterns` matches the real path and rejects a `WopiHost.AppHostX/` lookalike. All four managers' patterns compile.

The Renovate/Dependabot handover is the one part that can only be confirmed in production — worth a glance at the first `aspire` group PR to confirm it carries both the packages and the Sdk element.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136hX6FpWJJEGhVJmQkSJu3

---
_Generated by [Claude Code](https://claude.ai/code/session_0136hX6FpWJJEGhVJmQkSJu3)_