### PR TITLE
ci: harden the workflows — concurrency, timeouts, and the hardcoded values they drifted around

### DIFF
--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -137,7 +137,14 @@ Then read the run's job summary for the draft URL and report it.
 
 The workflow only ever creates drafts, and refuses to run if the version is below the computed
 floor or malformed, the notes are empty, the tag or a release for that version already exists, or
-it is dispatched from anything but master. Notes travel as a `workflow_dispatch` input, which
+it is dispatched from anything but master.
+
+**Regenerating a draft.** A draft is pinned to the commit it was created from, so once master
+moves past it — a merge that belongs in the release, or notes that have gone stale behind a
+dependency bump — publishing it would tag the older commit and ship without those changes.
+Re-dispatch with `replace=true` (`-f replace=true`) to discard the existing draft and cut a new
+one from the current HEAD. It refuses to touch a *published* release: that tag exists, its
+packages are on NuGet.org, and consumers may already have resolved them. Notes travel as a `workflow_dispatch` input, which
 caps the whole inputs payload at 65,535 characters — far above any release so far, and a breach
 fails the dispatch loudly rather than truncating.
 

--- a/.github/actions/install-playwright-browsers/action.yml
+++ b/.github/actions/install-playwright-browsers/action.yml
@@ -1,0 +1,25 @@
+name: Install Playwright browsers
+description: >
+  Installs Chromium and the OS packages it needs, for the suites that drive a real browser
+  (the sample-app smoke tests and the Collabora / ONLYOFFICE E2E lanes). PlaywrightFixture
+  falls back to downloading the browser mid-test when this is skipped, which works but puts an
+  unretried network fetch inside the test run — on the release lane that lands after the tag
+  and GitHub release already exist.
+runs:
+  using: composite
+  steps:
+    - name: Install Chromium via the generated playwright.ps1
+      shell: bash
+      # The helper is located rather than hardcoded: a literal path encodes the artifacts
+      # layout, the project name and the build configuration at once, so a lane building
+      # Release silently gets a wrong path. Installing a browser is a per-runner operation,
+      # so whichever project's copy is found will do.
+      run: |
+        set -euo pipefail
+        script="$(find artifacts/bin -name playwright.ps1 -print -quit)"
+        if [[ -z "$script" ]]; then
+          echo "::error::No playwright.ps1 found under artifacts/bin — the build output moved, or Playwright is no longer referenced. Has the build step run?"
+          exit 1
+        fi
+        # Idempotent: returns immediately when the browser is already cached in ~/.cache.
+        pwsh "$script" install --with-deps chromium

--- a/.github/actions/setup-dotnet-sdk/action.yml
+++ b/.github/actions/setup-dotnet-sdk/action.yml
@@ -1,0 +1,13 @@
+name: Set up the .NET SDK
+description: >
+  Installs the SDK version global.json pins. Exists so that pin and the setup-dotnet SHA live
+  in one place rather than twelve: a Dependabot bump of the action rewrote the same line in
+  nine workflows, and the SDK version itself was hardcoded twelve times before it moved to
+  global.json. Lanes needing an extra SDK (the net8-targeted WOPI validator, the .NET 11
+  preview) add their own setup-dotnet step alongside this one — setup-dotnet is additive.
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+      with:
+        global-json-file: global.json

--- a/.github/actions/test-and-report/action.yml
+++ b/.github/actions/test-and-report/action.yml
@@ -1,0 +1,97 @@
+name: Test and publish coverage
+description: >
+  Runs the test suite and publishes coverage (and optionally test results) to Qlty and Codecov.
+  The three workflows that do this ran three copies of the same chain, and fixing it in one and
+  not the others is a recurring bug in this repo's history — the release lane kept a stale
+  coverage glob, then missed the Codecov rename, then needed the same plugin fix again. One
+  implementation with the lane differences as inputs removes that failure mode.
+inputs:
+  results-directory:
+    description: Absolute path the test run writes its coverage and JUnit reports into.
+    required: true
+  codecov-token:
+    description: CODECOV_TOKEN. Uploads are skipped by Codecov itself if this is empty.
+    required: true
+  configuration:
+    description: Build configuration to test. Empty uses the SDK default (Debug).
+    required: false
+    default: ''
+  report-test-results:
+    description: >
+      Emit JUnit XML and upload it to Codecov Test Analytics. The release lane leaves this off:
+      the same commit's results were already reported by the CI lane.
+    required: false
+    default: 'true'
+  fail-on-upload-error:
+    description: >
+      Fail the job when the coverage upload fails. True on CI, where a silent failure leaves the
+      codecov/patch and codecov/project statuses pending forever and blocks the merge with no
+      visible error. False when publishing a release, where a Codecov outage must not block it.
+    required: false
+    default: 'true'
+runs:
+  using: composite
+  steps:
+    - name: Test
+      shell: bash
+      env:
+        RESULTS_DIRECTORY: ${{ inputs.results-directory }}
+        CONFIGURATION: ${{ inputs.configuration }}
+        REPORT_TEST_RESULTS: ${{ inputs.report-test-results }}
+      # --report-xunit-junit is xUnit's own MTP JUnit reporter. Every project writes into the
+      # same --results-directory, so the default timestamped filename
+      # (<user>_<host>_<timestamp>.junit.xml) is what keeps the projects from overwriting each
+      # other — do not pin a fixed filename here.
+      run: |
+        set -euo pipefail
+        args=(--no-build --results-directory "$RESULTS_DIRECTORY" --coverage --coverage-output-format cobertura)
+        if [[ -n "$CONFIGURATION" ]]; then
+          args+=(--configuration "$CONFIGURATION")
+        fi
+        if [[ "$REPORT_TEST_RESULTS" == "true" ]]; then
+          args+=(--report-xunit-junit)
+        fi
+        dotnet test "${args[@]}"
+
+    - name: Upload test results to Codecov
+      # Runs even when the Test step failed — reporting the failed tests is the whole point.
+      # codecov/test-results-action is deprecated in favour of codecov-action with
+      # report_type: test_results; in that mode the CLI's own search patterns pick up the
+      # *.junit.xml files in the directory (the `files:` input does not expand globs).
+      if: ${{ inputs.report-test-results == 'true' && !cancelled() }}
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+      with:
+        token: ${{ inputs.codecov-token }}
+        report_type: test_results
+        directory: ${{ inputs.results-directory }}
+
+    - name: Normalize coverage reports
+      uses: ./.github/actions/normalize-coverage-reports
+      with:
+        results-directory: ${{ inputs.results-directory }}
+
+    - name: Upload coverage to Qlty
+      uses: qltysh/qlty-action/coverage@08a0a862c159eae9b9003081da6663d96efef637 # v2
+      with:
+        oidc: true
+        # Microsoft.Testing.Extensions.CodeCoverage writes one cobertura report per test
+        # project under the run's --results-directory. Root the glob explicitly so
+        # qlty-action's @actions/glob layer has an anchored starting directory.
+        files: "test-results/**/*.cobertura.xml"
+        # Coverage reports reference source-generated files (LoggerMessage.g.cs,
+        # LibraryImports.g.cs, etc.) under artifacts/obj/, which don't exist at publish time.
+        # Without this flag Qlty counts them as 0% covered. See also .qlty/qlty.toml.
+        skip-missing-files: true
+
+    - name: Codecov
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+      with:
+        token: ${{ inputs.codecov-token }}
+        # The CLI searches by filename, so scope it to the run's reports rather than the tree.
+        directory: ${{ inputs.results-directory }}
+        root_dir: ${{ github.workspace }}
+        # This repo's reports come straight from MTP as cobertura, so none of the CLI's
+        # language plugins (gcov, xcode, pycoverage) can contribute anything — they only run
+        # to warn that their toolchains are absent. They ignore `directory:`, so turn them off.
+        plugins: noop
+        fail_ci_if_error: ${{ inputs.fail-on-upload-error }}

--- a/.github/workflows/bump-baseline.yml
+++ b/.github/workflows/bump-baseline.yml
@@ -29,6 +29,12 @@ permissions:
   contents: write
   pull-requests: write
 
+# One run at a time. Nothing is cancelled: every commit, release and scheduled run is
+# wanted on its own, so overlapping runs queue rather than supersede each other.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   bump:
     name: Bump baseline
@@ -36,6 +42,7 @@ jobs:
     # the operator opts in by triggering it.
     if: ${{ github.event_name == 'workflow_dispatch' || (!github.event.release.prerelease && !github.event.release.draft) }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/ci-failure-diagnosis.yml
+++ b/.github/workflows/ci-failure-diagnosis.yml
@@ -12,10 +12,17 @@ on:
     workflows: ["Build & Test", "E2E (Collabora)"]
     types: [completed]
 
+# One run at a time. Nothing is cancelled: every commit, release and scheduled run is
+# wanted on its own, so overlapping runs queue rather than supersede each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
 jobs:
   diagnose:
     if: github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       actions: read         # read the failed run's logs
@@ -28,6 +35,7 @@ jobs:
           fetch-depth: 1
 
       - name: Diagnose the failure
+        # Advisory: a diagnosis hiccup must never affect the run it reports on.
         continue-on-error: true
         uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,14 @@ on:
       - 'LICENSE'
       - '.claude/**'
 
+# Supersede an in-flight run for the same PR rather than letting both finish: the two
+# race to write the same sticky comments and check statuses, and the loser can be the
+# newer one. Runs on master, releases and schedules are never cancelled — each commit's
+# result is wanted on its own.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Internal PRs only. The Claude GitHub App's OIDC token exchange doesn't work with
@@ -17,6 +25,7 @@ jobs:
     # by commenting `@claude review this` (handled by claude.yml).
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,12 @@ on:
   pull_request_review:
     types: [submitted]
 
+# One run at a time. Nothing is cancelled: every commit, release and scheduled run is
+# wanted on its own, so overlapping runs queue rather than supersede each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   claude:
     if: |
@@ -18,6 +24,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/codebase-audit.yml
+++ b/.github/workflows/codebase-audit.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       issues: write       # open/update the findings issue

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,10 +25,19 @@ permissions:
   security-events: write
   actions: read
 
+# Supersede an in-flight run for the same PR rather than letting both finish: the two
+# race to write the same sticky comments and check statuses, and the loser can be the
+# newer one. Runs on master, releases and schedules are never cancelled — each commit's
+# result is wanted on its own.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+
 jobs:
   analyze:
     name: Analyze (csharp)
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup .NET 10.0
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Set Cobalt packages token
         run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> $GITHUB_ENV

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,10 +42,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Setup .NET 10.0
-        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        with:
-          global-json-file: global.json
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet-sdk
 
       - name: Set Cobalt packages token
         run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> $GITHUB_ENV

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -24,7 +24,10 @@ concurrency:
 
 jobs:
   auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    # The PR's author, not the triggering actor: on a `reopened` event github.actor is
+    # whoever reopened it, so a maintainer reopening a Dependabot PR would silently skip
+    # auto-merge.
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,10 +16,17 @@ permissions:
   contents: write
   pull-requests: write
 
+# One run at a time. Nothing is cancelled: every commit, release and scheduled run is
+# wanted on its own, so overlapping runs queue rather than supersede each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   auto-merge:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Enable auto-merge
         run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -11,12 +11,21 @@ on:
       - 'src/**/*.cs'
       - '**/README.md'
 
+# Supersede an in-flight run for the same PR rather than letting both finish: the two
+# race to write the same sticky comments and check statuses, and the loser can be the
+# newer one. Runs on master, releases and schedules are never cancelled — each commit's
+# result is wanted on its own.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   docs-drift:
     # Internal PRs only — the OIDC token exchange doesn't work in the secret-less fork context
     # (same constraint as claude-code-review.yml).
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: write
@@ -29,6 +38,7 @@ jobs:
           fetch-depth: 0   # need the merge-base to diff the PR
 
       - name: Check for documentation drift
+        # Advisory: a drift-check hiccup never fails the PR's checks.
         continue-on-error: true
         uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1
         with:

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -31,10 +31,17 @@ on:
 permissions:
   contents: write # gh release create
 
+# One run at a time. Nothing is cancelled: every commit, release and scheduled run is
+# wanted on its own, so overlapping runs queue rather than supersede each other.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   draft:
     name: Draft release
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup .NET 10.0
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Set Cobalt packages token
         run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> "$GITHUB_ENV"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -67,10 +67,8 @@ jobs:
             exit 1
           fi
 
-      - name: Setup .NET 10.0
-        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        with:
-          global-json-file: global.json
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet-sdk
 
       - name: Set Cobalt packages token
         run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> "$GITHUB_ENV"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -27,6 +27,11 @@ on:
         description: "Full release-notes markdown. Must start with '# <version>'."
         required: true
         type: string
+      replace:
+        description: "Discard an existing DRAFT for this version and recreate it. Never touches a published release."
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write # gh release create
@@ -193,6 +198,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_VERSION: ${{ inputs.version }}
           INPUT_NOTES: ${{ inputs.notes }}
+          INPUT_REPLACE: ${{ inputs.replace }}
           PREV: ${{ steps.floor.outputs.prev }}
           FLOOR_BUMP: ${{ steps.floor.outputs.bump }}
           MIN_VERSION: ${{ steps.floor.outputs.min-version }}
@@ -235,8 +241,21 @@ jobs:
             exit 1
           fi
           if gh release view "$VERSION" >/dev/null 2>&1; then
-            echo "::error::A release (or draft) for $VERSION already exists: delete it first, or pick another version."
-            exit 1
+            if [[ "$INPUT_REPLACE" != "true" ]]; then
+              echo "::error::A release (or draft) for $VERSION already exists. Re-dispatch with replace=true to recreate the draft, or pick another version."
+              exit 1
+            fi
+            # replace only ever discards a draft. A published release is history: its tag
+            # exists, its packages are on NuGet.org and consumers may already have resolved
+            # them, so re-cutting one under the same version is never the right move.
+            if [[ "$(gh release view "$VERSION" --json isDraft --jq '.isDraft')" != "true" ]]; then
+              echo "::error::$VERSION is already published — refusing to replace it. Cut a new version instead."
+              exit 1
+            fi
+            echo "::notice::Discarding the existing $VERSION draft and recreating it."
+            # Deliberately no --cleanup-tag: a draft has no tag, and a stray one would belong
+            # to a real release.
+            gh release delete "$VERSION" --yes
           fi
 
           # printf rather than echo: the notes are arbitrary markdown and must reach the

--- a/.github/workflows/e2e-collabora.yml
+++ b/.github/workflows/e2e-collabora.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup .NET 10.0
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Set Cobalt packages token
         run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> $GITHUB_ENV
@@ -52,10 +52,20 @@ jobs:
         run: dotnet build test/WopiHost.E2ETests/WopiHost.E2ETests.csproj --no-restore /p:ContinuousIntegrationBuild=true
 
       - name: Install Playwright browsers
-        # --with-deps installs the apt packages Chromium needs on a fresh ubuntu-latest. The
-        # build emits playwright.ps1 next to the test assembly under artifacts/bin/ (the repo
-        # uses UseArtifactsOutput); the path mirrors test/WopiHost.SmokeTests's CI step.
-        run: pwsh artifacts/bin/WopiHost.E2ETests/debug/playwright.ps1 install --with-deps chromium
+        # Locate the generated helper instead of hardcoding a path: the literal encoded the
+        # artifacts layout, the project name and the *Debug* configuration at once, so a lane
+        # building Release would silently get a wrong path. --with-deps installs the apt packages
+        # Chromium needs on a fresh runner. Installing a browser is per-runner, so whichever
+        # project's copy of the script is found will do. Idempotent — caches in ~/.cache.
+        shell: bash
+        run: |
+          set -euo pipefail
+          script="$(find artifacts/bin -name playwright.ps1 -print -quit)"
+          if [[ -z "$script" ]]; then
+            echo "::error::No playwright.ps1 found under artifacts/bin — the build output moved, or Playwright is no longer referenced."
+            exit 1
+          fi
+          pwsh "$script" install --with-deps chromium
 
       - name: Pre-pull Collabora image
         # Pre-pulling outside the test makes the test's WaitForResourceHealthyAsync timeout

--- a/.github/workflows/e2e-collabora.yml
+++ b/.github/workflows/e2e-collabora.yml
@@ -37,10 +37,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Setup .NET 10.0
-        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        with:
-          global-json-file: global.json
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet-sdk
 
       - name: Set Cobalt packages token
         run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> $GITHUB_ENV

--- a/.github/workflows/e2e-collabora.yml
+++ b/.github/workflows/e2e-collabora.yml
@@ -23,6 +23,12 @@ on:
 permissions:
   contents: read
 
+# One run at a time. Nothing is cancelled: every commit, release and scheduled run is
+# wanted on its own, so overlapping runs queue rather than supersede each other.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   e2e:
     name: Collabora end-to-end

--- a/.github/workflows/e2e-collabora.yml
+++ b/.github/workflows/e2e-collabora.yml
@@ -52,20 +52,7 @@ jobs:
         run: dotnet build test/WopiHost.E2ETests/WopiHost.E2ETests.csproj --no-restore /p:ContinuousIntegrationBuild=true
 
       - name: Install Playwright browsers
-        # Locate the generated helper instead of hardcoding a path: the literal encoded the
-        # artifacts layout, the project name and the *Debug* configuration at once, so a lane
-        # building Release would silently get a wrong path. --with-deps installs the apt packages
-        # Chromium needs on a fresh runner. Installing a browser is per-runner, so whichever
-        # project's copy of the script is found will do. Idempotent — caches in ~/.cache.
-        shell: bash
-        run: |
-          set -euo pipefail
-          script="$(find artifacts/bin -name playwright.ps1 -print -quit)"
-          if [[ -z "$script" ]]; then
-            echo "::error::No playwright.ps1 found under artifacts/bin — the build output moved, or Playwright is no longer referenced."
-            exit 1
-          fi
-          pwsh "$script" install --with-deps chromium
+        uses: ./.github/actions/install-playwright-browsers
 
       - name: Pre-pull Collabora image
         # Pre-pulling outside the test makes the test's WaitForResourceHealthyAsync timeout

--- a/.github/workflows/e2e-onlyoffice.yml
+++ b/.github/workflows/e2e-onlyoffice.yml
@@ -53,20 +53,7 @@ jobs:
         run: dotnet build test/WopiHost.E2ETests/WopiHost.E2ETests.csproj --no-restore /p:ContinuousIntegrationBuild=true
 
       - name: Install Playwright browsers
-        # Locate the generated helper instead of hardcoding a path: the literal encoded the
-        # artifacts layout, the project name and the *Debug* configuration at once, so a lane
-        # building Release would silently get a wrong path. --with-deps installs the apt packages
-        # Chromium needs on a fresh runner. Installing a browser is per-runner, so whichever
-        # project's copy of the script is found will do. Idempotent — caches in ~/.cache.
-        shell: bash
-        run: |
-          set -euo pipefail
-          script="$(find artifacts/bin -name playwright.ps1 -print -quit)"
-          if [[ -z "$script" ]]; then
-            echo "::error::No playwright.ps1 found under artifacts/bin — the build output moved, or Playwright is no longer referenced."
-            exit 1
-          fi
-          pwsh "$script" install --with-deps chromium
+        uses: ./.github/actions/install-playwright-browsers
 
       - name: Pre-pull ONLYOFFICE image
         # Pre-pulling outside the test makes the fixture's healthcheck timeout bound the runtime cost

--- a/.github/workflows/e2e-onlyoffice.yml
+++ b/.github/workflows/e2e-onlyoffice.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup .NET 10.0
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Set Cobalt packages token
         run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> $GITHUB_ENV
@@ -53,10 +53,20 @@ jobs:
         run: dotnet build test/WopiHost.E2ETests/WopiHost.E2ETests.csproj --no-restore /p:ContinuousIntegrationBuild=true
 
       - name: Install Playwright browsers
-        # --with-deps installs the apt packages Chromium needs on a fresh ubuntu-latest. The build
-        # emits playwright.ps1 next to the test assembly under artifacts/bin/ (the repo uses
-        # UseArtifactsOutput); the path mirrors the Collabora e2e step.
-        run: pwsh artifacts/bin/WopiHost.E2ETests/debug/playwright.ps1 install --with-deps chromium
+        # Locate the generated helper instead of hardcoding a path: the literal encoded the
+        # artifacts layout, the project name and the *Debug* configuration at once, so a lane
+        # building Release would silently get a wrong path. --with-deps installs the apt packages
+        # Chromium needs on a fresh runner. Installing a browser is per-runner, so whichever
+        # project's copy of the script is found will do. Idempotent — caches in ~/.cache.
+        shell: bash
+        run: |
+          set -euo pipefail
+          script="$(find artifacts/bin -name playwright.ps1 -print -quit)"
+          if [[ -z "$script" ]]; then
+            echo "::error::No playwright.ps1 found under artifacts/bin — the build output moved, or Playwright is no longer referenced."
+            exit 1
+          fi
+          pwsh "$script" install --with-deps chromium
 
       - name: Pre-pull ONLYOFFICE image
         # Pre-pulling outside the test makes the fixture's healthcheck timeout bound the runtime cost

--- a/.github/workflows/e2e-onlyoffice.yml
+++ b/.github/workflows/e2e-onlyoffice.yml
@@ -38,10 +38,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Setup .NET 10.0
-        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        with:
-          global-json-file: global.json
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet-sdk
 
       - name: Set Cobalt packages token
         run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> $GITHUB_ENV

--- a/.github/workflows/e2e-onlyoffice.yml
+++ b/.github/workflows/e2e-onlyoffice.yml
@@ -24,6 +24,12 @@ on:
 permissions:
   contents: read
 
+# One run at a time. Nothing is cancelled: every commit, release and scheduled run is
+# wanted on its own, so overlapping runs queue rather than supersede each other.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   e2e:
     name: ONLYOFFICE end-to-end

--- a/.github/workflows/infersharp.yml
+++ b/.github/workflows/infersharp.yml
@@ -22,16 +22,26 @@ permissions:
   contents: read
   security-events: write
 
+# Supersede an in-flight run for the same PR rather than letting both finish: the two
+# race to write the same sticky comments and check statuses, and the loser can be the
+# newer one. Runs on master, releases and schedules are never cancelled — each commit's
+# result is wanted on its own.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+
 jobs:
   approve:
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Approve
         run: echo For security reasons, all pull requests need to be approved first before running any automated CI.
 
   analyze:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs: [approve]
     if: |
       always() &&

--- a/.github/workflows/infersharp.yml
+++ b/.github/workflows/infersharp.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup .NET 10.0
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Set Cobalt packages token
         run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> $GITHUB_ENV

--- a/.github/workflows/infersharp.yml
+++ b/.github/workflows/infersharp.yml
@@ -54,10 +54,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 2
 
-      - name: Setup .NET 10.0
-        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        with:
-          global-json-file: global.json
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet-sdk
 
       - name: Set Cobalt packages token
         run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> $GITHUB_ENV

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Setup .NET 10.0
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
-        dotnet-version: '10.0.x'
+        global-json-file: global.json
     - name: Set Cobalt packages token
       run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> $GITHUB_ENV
     - name: Restore dependencies
@@ -40,7 +40,20 @@ jobs:
     - name: Build
       run: dotnet build --no-restore /p:ContinuousIntegrationBuild=true
     - name: Install Playwright browsers (for sample-app smoke tests)
-      run: pwsh artifacts/bin/WopiHost.SmokeTests/debug/playwright.ps1 install --with-deps chromium
+      # Locate the generated helper instead of hardcoding a path: the literal encoded the
+      # artifacts layout, the project name and the *Debug* configuration at once, so a lane
+      # building Release would silently get a wrong path. --with-deps installs the apt packages
+      # Chromium needs on a fresh runner. Installing a browser is per-runner, so whichever
+      # project's copy of the script is found will do. Idempotent — caches in ~/.cache.
+      shell: bash
+      run: |
+        set -euo pipefail
+        script="$(find artifacts/bin -name playwright.ps1 -print -quit)"
+        if [[ -z "$script" ]]; then
+          echo "::error::No playwright.ps1 found under artifacts/bin — the build output moved, or Playwright is no longer referenced."
+          exit 1
+        fi
+        pwsh "$script" install --with-deps chromium
     - name: Pre-pull Testcontainers images
       uses: ./.github/actions/prepull-testcontainers-images
     - name: Test
@@ -117,7 +130,7 @@ jobs:
     - name: Setup .NET 10.0
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
-        dotnet-version: '10.0.x'
+        global-json-file: global.json
     - name: Set Cobalt packages token
       # Not needed by this test project (package-source mapping keeps the private feed
       # scoped to Microsoft.CobaltCore), but set it so any incidental restore stays quiet.

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -40,20 +40,7 @@ jobs:
     - name: Build
       run: dotnet build --no-restore /p:ContinuousIntegrationBuild=true
     - name: Install Playwright browsers (for sample-app smoke tests)
-      # Locate the generated helper instead of hardcoding a path: the literal encoded the
-      # artifacts layout, the project name and the *Debug* configuration at once, so a lane
-      # building Release would silently get a wrong path. --with-deps installs the apt packages
-      # Chromium needs on a fresh runner. Installing a browser is per-runner, so whichever
-      # project's copy of the script is found will do. Idempotent — caches in ~/.cache.
-      shell: bash
-      run: |
-        set -euo pipefail
-        script="$(find artifacts/bin -name playwright.ps1 -print -quit)"
-        if [[ -z "$script" ]]; then
-          echo "::error::No playwright.ps1 found under artifacts/bin — the build output moved, or Playwright is no longer referenced."
-          exit 1
-        fi
-        pwsh "$script" install --with-deps chromium
+      uses: ./.github/actions/install-playwright-browsers
     - name: Pre-pull Testcontainers images
       uses: ./.github/actions/prepull-testcontainers-images
     - name: Test

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -41,55 +41,11 @@ jobs:
       uses: ./.github/actions/install-playwright-browsers
     - name: Pre-pull Testcontainers images
       uses: ./.github/actions/prepull-testcontainers-images
-    - name: Test
-      # Emit JUnit XML alongside cobertura coverage so Codecov Test Analytics can ingest
-      # run times / failures. --report-xunit-junit is xUnit's own MTP JUnit reporter. Every
-      # project writes into the same --results-directory, so the default timestamped filename
-      # (<user>_<host>_<timestamp>.junit.xml) is what keeps the projects from overwriting
-      # each other — do not pin a fixed filename here.
-      run: dotnet test --no-build --results-directory ${{ github.workspace }}/test-results --coverage --coverage-output-format cobertura --report-xunit-junit
-    - name: Upload test results to Codecov
-      # Runs even when the Test step failed — reporting the failed tests is the whole point.
-      # codecov/test-results-action is deprecated in favor of codecov-action with
-      # report_type: test_results; in that mode the CLI's own search patterns pick up the
-      # *.junit.xml files in the directory (the `files:` input does not expand globs).
-      if: ${{ !cancelled() }}
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        report_type: test_results
-        directory: ${{ github.workspace }}/test-results
-    - name: Normalize coverage reports
-      uses: ./.github/actions/normalize-coverage-reports
+    - name: Test and publish coverage
+      uses: ./.github/actions/test-and-report
       with:
         results-directory: ${{ github.workspace }}/test-results
-    - name: Upload coverage to Qlty
-      uses: qltysh/qlty-action/coverage@08a0a862c159eae9b9003081da6663d96efef637 # v2
-      with:
-        oidc: true
-        # Microsoft.Testing.Extensions.CodeCoverage writes one cobertura report per test
-        # project under the run's --results-directory. Root the glob explicitly so
-        # qlty-action's @actions/glob layer has an anchored starting directory.
-        files: "test-results/**/*.cobertura.xml"
-        # Coverage reports reference source-generated files (LoggerMessage.g.cs,
-        # LibraryImports.g.cs, etc.) under artifacts/obj/, which don't exist at
-        # publish time. Without this flag Qlty counts them as 0% covered. See also
-        # .qlty/qlty.toml.
-        skip-missing-files: true
-    - name: Codecov
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        # See pull_request.yml for the search-scoping rationale.
-        directory: ${{ github.workspace }}/test-results
-        root_dir: ${{ github.workspace }}
-        # This repo's reports come straight from MTP as cobertura, so none of the CLI's
-        # language plugins (gcov, xcode, pycoverage) can contribute anything — they only run
-        # to warn that their toolchains are absent. They ignore `directory:`, so turn them off.
-        plugins: noop
-        # A silent upload failure leaves the codecov/patch and codecov/project statuses
-        # pending forever on PRs, blocking the merge with no visible error.
-        fail_ci_if_error: true
+        codecov-token: ${{ secrets.CODECOV_TOKEN }}
     - name: FOSSA scan + policy gate
       uses: fossa-contrib/fossa-action@d28f0c947e7406706981a62a91ecc009bcc39fd7 # v4
       with:

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -14,10 +14,18 @@ permissions:
   contents: read
   id-token: write # Required for OIDC
 
+# One run at a time. Nothing is cancelled: every commit, release and scheduled run is
+# wanted on its own, so overlapping runs queue rather than supersede each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
+
+    timeout-minutes: 45
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -97,6 +105,7 @@ jobs:
     # dependency-free FileSystemProvider tests on the other OSes/architectures.
     name: FS owner lookup (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -29,10 +29,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-    - name: Setup .NET 10.0
-      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-      with:
-        global-json-file: global.json
+    - name: Setup .NET
+      uses: ./.github/actions/setup-dotnet-sdk
     - name: Set Cobalt packages token
       run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> $GITHUB_ENV
     - name: Restore dependencies
@@ -114,10 +112,8 @@ jobs:
         os: [windows-latest, macos-latest]
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-    - name: Setup .NET 10.0
-      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-      with:
-        global-json-file: global.json
+    - name: Setup .NET
+      uses: ./.github/actions/setup-dotnet-sdk
     - name: Set Cobalt packages token
       # Not needed by this test project (package-source mapping keeps the private feed
       # scoped to Microsoft.CobaltCore), but set it so any incidental restore stays quiet.

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -8,11 +8,18 @@ on:
   issues:
     types: [opened]
 
+# One run at a time. Nothing is cancelled: every commit, release and scheduled run is
+# wanted on its own, so overlapping runs queue rather than supersede each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
 jobs:
   triage:
     # Humans only — don't triage bot-filed issues.
     if: github.event.issue.user.type != 'Bot'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,9 +8,18 @@ permissions:
   contents: read
   pull-requests: write
 
+# Supersede an in-flight run for the same PR rather than letting both finish: the two
+# race to write the same sticky comments and check statuses, and the loser can be the
+# newer one. Runs on master, releases and schedules are never cancelled — each commit's
+# result is wanted on its own.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   label:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
         with:

--- a/.github/workflows/net11-preview.yml
+++ b/.github/workflows/net11-preview.yml
@@ -22,6 +22,12 @@ on:
 permissions:
   contents: read
 
+# One run at a time. Nothing is cancelled: every commit, release and scheduled run is
+# wanted on its own, so overlapping runs queue rather than supersede each other.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   preview-runtime:
     name: net10.0 binaries on the .NET 11 runtime

--- a/.github/workflows/net11-preview.yml
+++ b/.github/workflows/net11-preview.yml
@@ -61,20 +61,7 @@ jobs:
           dotnet build --no-restore /p:ContinuousIntegrationBuild=true
 
       - name: Install Playwright browsers (for sample-app smoke tests)
-        # Locate the generated helper instead of hardcoding a path: the literal encoded the
-        # artifacts layout, the project name and the *Debug* configuration at once, so a lane
-        # building Release would silently get a wrong path. --with-deps installs the apt packages
-        # Chromium needs on a fresh runner. Installing a browser is per-runner, so whichever
-        # project's copy of the script is found will do. Idempotent — caches in ~/.cache.
-        shell: bash
-        run: |
-          set -euo pipefail
-          script="$(find artifacts/bin -name playwright.ps1 -print -quit)"
-          if [[ -z "$script" ]]; then
-            echo "::error::No playwright.ps1 found under artifacts/bin — the build output moved, or Playwright is no longer referenced."
-            exit 1
-          fi
-          pwsh "$script" install --with-deps chromium
+        uses: ./.github/actions/install-playwright-browsers
 
       # Roll-forward policies below LatestMajor only engage when the requested runtime is ABSENT,
       # and .NET 10 is installed on this runner — so DOTNET_ROLL_FORWARD=Major would quietly keep

--- a/.github/workflows/net11-preview.yml
+++ b/.github/workflows/net11-preview.yml
@@ -61,7 +61,20 @@ jobs:
           dotnet build --no-restore /p:ContinuousIntegrationBuild=true
 
       - name: Install Playwright browsers (for sample-app smoke tests)
-        run: pwsh artifacts/bin/WopiHost.SmokeTests/debug/playwright.ps1 install --with-deps chromium
+        # Locate the generated helper instead of hardcoding a path: the literal encoded the
+        # artifacts layout, the project name and the *Debug* configuration at once, so a lane
+        # building Release would silently get a wrong path. --with-deps installs the apt packages
+        # Chromium needs on a fresh runner. Installing a browser is per-runner, so whichever
+        # project's copy of the script is found will do. Idempotent — caches in ~/.cache.
+        shell: bash
+        run: |
+          set -euo pipefail
+          script="$(find artifacts/bin -name playwright.ps1 -print -quit)"
+          if [[ -z "$script" ]]; then
+            echo "::error::No playwright.ps1 found under artifacts/bin — the build output moved, or Playwright is no longer referenced."
+            exit 1
+          fi
+          pwsh "$script" install --with-deps chromium
 
       # Roll-forward policies below LatestMajor only engage when the requested runtime is ABSENT,
       # and .NET 10 is installed on this runner — so DOTNET_ROLL_FORWARD=Major would quietly keep

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -55,20 +55,7 @@ jobs:
     - name: Build
       run: dotnet build --no-restore /p:ContinuousIntegrationBuild=true
     - name: Install Playwright browsers (for sample-app smoke tests)
-      # Locate the generated helper instead of hardcoding a path: the literal encoded the
-      # artifacts layout, the project name and the *Debug* configuration at once, so a lane
-      # building Release would silently get a wrong path. --with-deps installs the apt packages
-      # Chromium needs on a fresh runner. Installing a browser is per-runner, so whichever
-      # project's copy of the script is found will do. Idempotent — caches in ~/.cache.
-      shell: bash
-      run: |
-        set -euo pipefail
-        script="$(find artifacts/bin -name playwright.ps1 -print -quit)"
-        if [[ -z "$script" ]]; then
-          echo "::error::No playwright.ps1 found under artifacts/bin — the build output moved, or Playwright is no longer referenced."
-          exit 1
-        fi
-        pwsh "$script" install --with-deps chromium
+      uses: ./.github/actions/install-playwright-browsers
     - name: Pre-pull Testcontainers images
       uses: ./.github/actions/prepull-testcontainers-images
     - name: Test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -44,10 +44,8 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 2
-    - name: Setup .NET 10.0
-      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-      with:
-        global-json-file: global.json
+    - name: Setup .NET
+      uses: ./.github/actions/setup-dotnet-sdk
     - name: Set Cobalt packages token
       run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> $GITHUB_ENV
     - name: Restore dependencies
@@ -132,10 +130,8 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 1
-    - name: Setup .NET 10.0
-      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-      with:
-        global-json-file: global.json
+    - name: Setup .NET
+      uses: ./.github/actions/setup-dotnet-sdk
     - name: Set Cobalt packages token
       # Not needed by this test project (package-source mapping keeps the private feed
       # scoped to Microsoft.CobaltCore), but set it so any incidental restore stays quiet.
@@ -157,10 +153,8 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 1
-    - name: Setup .NET 10.0
-      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-      with:
-        global-json-file: global.json
+    - name: Setup .NET
+      uses: ./.github/actions/setup-dotnet-sdk
     - name: Set Cobalt packages token
       run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> $GITHUB_ENV
     - name: Pack PR nupkgs

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,9 +15,18 @@ permissions:
   id-token: write # Required for OIDC
   pull-requests: write # Required for the api-compat sticky comment
 
+# Supersede an in-flight run for the same PR rather than letting both finish: the two
+# race to write the same sticky comments and check statuses, and the loser can be the
+# newer one. Runs on master, releases and schedules are never cancelled — each commit's
+# result is wanted on its own.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   approve:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
     - name: Approve
@@ -25,6 +34,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     needs: [approve]
     environment:
@@ -109,6 +119,7 @@ jobs:
     # dependency-free FileSystemProvider tests on the other OSes/architectures.
     name: FS owner lookup (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     needs: [approve]
     strategy:
       fail-fast: false
@@ -139,6 +150,7 @@ jobs:
   api-compat:
     name: API Compatibility
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [approve]
     environment:
       name: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'Integrate Pull Request' || '' }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Setup .NET 10.0
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
-        dotnet-version: '10.0.x'
+        global-json-file: global.json
     - name: Set Cobalt packages token
       run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> $GITHUB_ENV
     - name: Restore dependencies
@@ -55,9 +55,20 @@ jobs:
     - name: Build
       run: dotnet build --no-restore /p:ContinuousIntegrationBuild=true
     - name: Install Playwright browsers (for sample-app smoke tests)
-      # The build emits playwright.ps1 next to the SmokeTests assembly; run it with --with-deps
-      # so Linux runners get the apt packages Chromium needs. Idempotent — caches in ~/.cache.
-      run: pwsh artifacts/bin/WopiHost.SmokeTests/debug/playwright.ps1 install --with-deps chromium
+      # Locate the generated helper instead of hardcoding a path: the literal encoded the
+      # artifacts layout, the project name and the *Debug* configuration at once, so a lane
+      # building Release would silently get a wrong path. --with-deps installs the apt packages
+      # Chromium needs on a fresh runner. Installing a browser is per-runner, so whichever
+      # project's copy of the script is found will do. Idempotent — caches in ~/.cache.
+      shell: bash
+      run: |
+        set -euo pipefail
+        script="$(find artifacts/bin -name playwright.ps1 -print -quit)"
+        if [[ -z "$script" ]]; then
+          echo "::error::No playwright.ps1 found under artifacts/bin — the build output moved, or Playwright is no longer referenced."
+          exit 1
+        fi
+        pwsh "$script" install --with-deps chromium
     - name: Pre-pull Testcontainers images
       uses: ./.github/actions/prepull-testcontainers-images
     - name: Test
@@ -137,7 +148,7 @@ jobs:
     - name: Setup .NET 10.0
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
-        dotnet-version: '10.0.x'
+        global-json-file: global.json
     - name: Set Cobalt packages token
       # Not needed by this test project (package-source mapping keeps the private feed
       # scoped to Microsoft.CobaltCore), but set it so any incidental restore stays quiet.
@@ -162,7 +173,7 @@ jobs:
     - name: Setup .NET 10.0
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
-        dotnet-version: '10.0.x'
+        global-json-file: global.json
     - name: Set Cobalt packages token
       run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> $GITHUB_ENV
     - name: Pack PR nupkgs
@@ -227,7 +238,7 @@ jobs:
 
           # Resolve latest stable on NuGet.org (filter out prereleases by '-').
           versions_json="$(curl -fsSL "https://api.nuget.org/v3-flatcontainer/${pkg_lower}/index.json" || echo '{"versions":[]}')"
-          baseline_version="$(echo "$versions_json" | grep -oE '"[0-9][^"]+"' | tr -d '"' | grep -v -- '-' | tail -n 1 || true)"
+          baseline_version="$(echo "$versions_json" | grep -oE '"[0-9][^"]+"' | tr -d '"' | grep -v -- '-' | sort -V | tail -n 1 || true)"
 
           if [[ -z "$baseline_version" ]]; then
             echo "### :grey_question: ${pkg}" >> "$REPORT_FILE"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -56,52 +56,11 @@ jobs:
       uses: ./.github/actions/install-playwright-browsers
     - name: Pre-pull Testcontainers images
       uses: ./.github/actions/prepull-testcontainers-images
-    - name: Test
-      # Emit JUnit XML alongside cobertura coverage so Codecov Test Analytics can ingest run
-      # times / failures. --report-xunit-junit is xUnit's own MTP JUnit reporter. Every project
-      # writes into the same --results-directory, so the default timestamped filename
-      # (<user>_<host>_<timestamp>.junit.xml) is what keeps 13 projects from overwriting each
-      # other — do not pin a fixed filename here.
-      run: dotnet test --no-build --results-directory ${{ github.workspace }}/test-results --coverage --coverage-output-format cobertura --report-xunit-junit
-    - name: Upload test results to Codecov
-      # Runs even when the Test step failed — reporting the failed tests is the whole point.
-      # codecov/test-results-action is deprecated in favor of codecov-action with
-      # report_type: test_results; in that mode the CLI's own search patterns pick up the
-      # *.junit.xml files in the directory (the `files:` input does not expand globs).
-      if: ${{ !cancelled() }}
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        report_type: test_results
-        directory: ${{ github.workspace }}/test-results
-    - name: Normalize coverage reports
-      uses: ./.github/actions/normalize-coverage-reports
+    - name: Test and publish coverage
+      uses: ./.github/actions/test-and-report
       with:
         results-directory: ${{ github.workspace }}/test-results
-    - name: Upload coverage to Qlty
-      uses: qltysh/qlty-action/coverage@08a0a862c159eae9b9003081da6663d96efef637 # v2
-      with:
-        oidc: true
-        files: "test-results/**/*.cobertura.xml"
-        # See integrate.yml for the rationale.
-        skip-missing-files: true
-    - name: Codecov
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        # Scope the CLI's search to the reports this run produced: left unscoped it walks the
-        # whole workspace and could pick up an unrelated report. root_dir keeps the uploaded
-        # paths anchored at the repo root regardless of the narrower search.
-        directory: ${{ github.workspace }}/test-results
-        root_dir: ${{ github.workspace }}
-        # This repo's reports come straight from MTP as cobertura, so none of the CLI's
-        # language plugins (gcov, xcode, pycoverage) can contribute anything — they only run
-        # to warn that their toolchains are absent. They ignore `directory:`, so turn them off.
-        plugins: noop
-        # A silent upload failure leaves the required codecov/patch and codecov/project
-        # statuses pending forever, blocking the merge with no visible error.
-        fail_ci_if_error: true
-
+        codecov-token: ${{ secrets.CODECOV_TOKEN }}
     - name: FOSSA scan + policy gate
       uses: fossa-contrib/fossa-action@d28f0c947e7406706981a62a91ecc009bcc39fd7 # v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,34 +40,16 @@ jobs:
       uses: ./.github/actions/install-playwright-browsers
     - name: Pre-pull Testcontainers images
       uses: ./.github/actions/prepull-testcontainers-images
-    - name: Test
-      run: dotnet test --no-build --configuration Release --results-directory ${{ github.workspace }}/test-results --coverage --coverage-output-format cobertura
-    - name: Normalize coverage reports
-      uses: ./.github/actions/normalize-coverage-reports
+    - name: Test and publish coverage
+      uses: ./.github/actions/test-and-report
       with:
         results-directory: ${{ github.workspace }}/test-results
-    - name: Upload coverage to Qlty
-      uses: qltysh/qlty-action/coverage@08a0a862c159eae9b9003081da6663d96efef637 # v2
-      with:
-        oidc: true
-        # Microsoft.Testing.Extensions.CodeCoverage writes one cobertura report per project;
-        # see integrate.yml for the glob rationale.
-        files: "test-results/**/*.cobertura.xml"
-        # See integrate.yml for the rationale.
-        skip-missing-files: true
-    - name: Codecov
-      # Unlike the CI workflows, deliberately no fail_ci_if_error: a Codecov outage
-      # must not block publishing the release.
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        # See pull_request.yml for the search-scoping rationale.
-        directory: ${{ github.workspace }}/test-results
-        root_dir: ${{ github.workspace }}
-        # This repo's reports come straight from MTP as cobertura, so none of the CLI's
-        # language plugins (gcov, xcode, pycoverage) can contribute anything — they only run
-        # to warn that their toolchains are absent. They ignore `directory:`, so turn them off.
-        plugins: noop
+        codecov-token: ${{ secrets.CODECOV_TOKEN }}
+        configuration: Release
+        # The CI lane already reported this commit's test results.
+        report-test-results: 'false'
+        # A Codecov outage must not block publishing a release.
+        fail-on-upload-error: 'false'
     - name: Pack
       # Output is centralized via UseArtifactsOutput (see Directory.Build.props);
       # nupkg/snupkg files land in artifacts/package/release/.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup .NET 10.0
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
-        dotnet-version: '10.0.x'
+        global-json-file: global.json
     - name: Extract version from tag
       id: get_version
       run: |
@@ -38,6 +38,20 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore --configuration Release /p:ContinuousIntegrationBuild=true /p:Version="${{ steps.get_version.outputs.version-without-v }}"
+    - name: Install Playwright browsers (for sample-app smoke tests)
+      # The smoke tests carry no Category=E2E trait, so the default filter runs them here too.
+      # Without this step PlaywrightFixture falls back to downloading Chromium mid-test, with no
+      # retry — and this workflow runs on `release: published`, so a transient failure lands after
+      # the tag and release already exist. Installing upfront keeps that off the release path.
+      shell: bash
+      run: |
+        set -euo pipefail
+        script="$(find artifacts/bin -name playwright.ps1 -print -quit)"
+        if [[ -z "$script" ]]; then
+          echo "::error::No playwright.ps1 found under artifacts/bin — the build output moved, or Playwright is no longer referenced."
+          exit 1
+        fi
+        pwsh "$script" install --with-deps chromium
     - name: Pre-pull Testcontainers images
       uses: ./.github/actions/prepull-testcontainers-images
     - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,18 @@ permissions:
   contents: write
   id-token: write # Required for OIDC
 
+# One run at a time. Nothing is cancelled: every commit, release and scheduled run is
+# wanted on its own, so overlapping runs queue rather than supersede each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
+
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,19 +39,7 @@ jobs:
     - name: Build
       run: dotnet build --no-restore --configuration Release /p:ContinuousIntegrationBuild=true /p:Version="${{ steps.get_version.outputs.version-without-v }}"
     - name: Install Playwright browsers (for sample-app smoke tests)
-      # The smoke tests carry no Category=E2E trait, so the default filter runs them here too.
-      # Without this step PlaywrightFixture falls back to downloading Chromium mid-test, with no
-      # retry — and this workflow runs on `release: published`, so a transient failure lands after
-      # the tag and release already exist. Installing upfront keeps that off the release path.
-      shell: bash
-      run: |
-        set -euo pipefail
-        script="$(find artifacts/bin -name playwright.ps1 -print -quit)"
-        if [[ -z "$script" ]]; then
-          echo "::error::No playwright.ps1 found under artifacts/bin — the build output moved, or Playwright is no longer referenced."
-          exit 1
-        fi
-        pwsh "$script" install --with-deps chromium
+      uses: ./.github/actions/install-playwright-browsers
     - name: Pre-pull Testcontainers images
       uses: ./.github/actions/prepull-testcontainers-images
     - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-    - name: Setup .NET 10.0
-      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-      with:
-        global-json-file: global.json
+    - name: Setup .NET
+      uses: ./.github/actions/setup-dotnet-sdk
     - name: Extract version from tag
       id: get_version
       run: |

--- a/.github/workflows/semgrep-guardrails.yml
+++ b/.github/workflows/semgrep-guardrails.yml
@@ -28,9 +28,18 @@ on:
 permissions:
   contents: read
 
+# Supersede an in-flight run for the same PR rather than letting both finish: the two
+# race to write the same sticky comments and check statuses, and the loser can be the
+# newer one. Runs on master, releases and schedules are never cancelled — each commit's
+# result is wanted on its own.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+
 jobs:
   guardrails:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 

--- a/.github/workflows/semgrep-guardrails.yml
+++ b/.github/workflows/semgrep-guardrails.yml
@@ -44,8 +44,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Semgrep
-        # Pinned like every other CI dependency. Dependabot doesn't manage pipx
-        # run-lines, so bump the version manually now and then.
+        # Pinned like every other CI dependency. Dependabot has no ecosystem that reads a
+        # version out of a shell command, so a Renovate custom manager tracks this line.
         run: pipx install semgrep==1.168.0
 
       - name: Run guardrail rules

--- a/.github/workflows/wopi-validator.yml
+++ b/.github/workflows/wopi-validator.yml
@@ -65,10 +65,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet-sdk
+      - name: Set up the .NET 8 SDK (for the net8-targeted WOPI validator)
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          global-json-file: global.json
-          # The upstream Microsoft.Office.WopiValidator package targets net8.0.
           dotnet-version: 8.0.x
 
       - name: Set Cobalt packages token

--- a/.github/workflows/wopi-validator.yml
+++ b/.github/workflows/wopi-validator.yml
@@ -34,16 +34,26 @@ env:
   HOST_URL: http://localhost:5000
   WOPI_FILE_ID: WOPITEST
 
+# Supersede an in-flight run for the same PR rather than letting both finish: the two
+# race to write the same sticky comments and check statuses, and the loser can be the
+# newer one. Runs on master, releases and schedules are never cancelled — each commit's
+# result is wanted on its own.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+
 jobs:
   approve:
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Approve
       run: echo "For security reasons, all pull requests need to be approved first before running any automated CI."
 
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [approve]
     if: always() && (needs.approve.result == 'success' || needs.approve.result == 'skipped')
     environment:

--- a/.github/workflows/wopi-validator.yml
+++ b/.github/workflows/wopi-validator.yml
@@ -67,9 +67,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: |
-            8.0.x
-            10.0.x
+          global-json-file: global.json
+          # The upstream Microsoft.Office.WopiValidator package targets net8.0.
+          dotnet-version: 8.0.x
 
       - name: Set Cobalt packages token
         run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> $GITHUB_ENV

--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,14 @@
         "<Sdk Name=\"(?<depName>[^\"]+)\" Version=\"(?<currentValue>[^\"]+)\"\\s*/>"
       ],
       "datasourceTemplate": "nuget"
+    },
+    {
+      "customType": "regex",
+      "description": "Tracks the Semgrep version pinned on the pipx run-line in semgrep-guardrails.yml. Dependabot has no ecosystem that reads a version embedded in a workflow's shell command, so nothing proposed it and the pin was documented as a manual bump.",
+      "managerFilePatterns": ["/^\\.github/workflows/semgrep-guardrails\\.yml$/"],
+      "matchStrings": ["pipx install semgrep==(?<currentValue>[0-9][0-9A-Za-z.-]*)"],
+      "depNameTemplate": "semgrep",
+      "datasourceTemplate": "pypi"
     }
   ],
   "packageRules": [

--- a/test/WopiHost.SmokeTests/Fixtures/PlaywrightFixture.cs
+++ b/test/WopiHost.SmokeTests/Fixtures/PlaywrightFixture.cs
@@ -27,7 +27,7 @@ public sealed class PlaywrightFixture : IAsyncLifetime
         {
             throw new InvalidOperationException(
                 $"Playwright browser install failed with exit code {exitCode}. " +
-                "Run 'pwsh test/WopiHost.SmokeTests/bin/Debug/net10.0/playwright.ps1 install chromium' manually.");
+                "Run 'pwsh artifacts/bin/WopiHost.SmokeTests/debug/playwright.ps1 install chromium' manually.");
         }
 
         Playwright = await Microsoft.Playwright.Playwright.CreateAsync();


### PR DESCRIPTION
### Motivation

Fixes the findings from the workflow fragility scan (21 workflows, 2 composite actions, 2,476 lines). Every item below was verified in the files rather than inferred.

### H1 — Every workflow now has a concurrency group

Two of twenty-one declared one, and `pull_request.yml` and `wopi-validator.yml` — **the two that write sticky PR comments** — were not among them. Pushing twice in quick succession left both runs to completion; when the older finished last it overwrote the newer result, so the API-compat and validator comments could describe a commit that was no longer the head.

Cancellation is scoped, not uniform:

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
```

Superseded PR runs are cancelled; master, release and scheduled runs never are, because each commit's result is wanted on its own. Workflows that can never cancel carry their own wording rather than a comment about superseding PRs that cannot apply to them.

### H2 — Every job now has a timeout

Seventeen workflows had none, so a hung job ran to GitHub's **six-hour** default. The four that did set one were the heavy lanes someone had already anticipated hanging. Ceilings here are 2–3× observed runtimes, high enough to catch only a genuine hang.

### M1 — The SDK version came out of thirteen places

`dotnet-version: '10.0.x'` was written out **13 times across 9 workflows** while `global.json` already pinned it. A framework bump meant thirteen edits, and a missed one would have built on a different SDK silently. They now use `global-json-file: global.json`.

Two deliberate exceptions: `net11-preview` keeps its literals (exercising other SDKs is that lane's purpose), and `wopi-validator` keeps `8.0.x` for the net8-targeted upstream validator.

### M2 — release.yml was missing the Playwright install

The smoke tests carry **no** `Category=E2E` trait, so the default filter runs them in `release.yml` too. Without an upfront install, `PlaywrightFixture` falls back to downloading Chromium mid-test **with no retry** — and that workflow runs on `release: published`, so a transient failure lands *after* the tag and release already exist.

This is the third time `release.yml` has been found missing something its siblings had (#647, #660).

### M3 — One of four version derivations didn't sort

`pull_request.yml` took `tail -n 1` of NuGet's version list without `sort -V`, alone among four such derivations. I checked empirically — NuGet returns them ordered, so it was correct — but nothing guaranteed that, and the inconsistency invites the wrong conclusion about which form is right.

### M4 — The Playwright path encoded three things at once

`artifacts/bin/WopiHost.SmokeTests/debug/playwright.ps1` couples CI to the artifacts layout, the project name **and** the Debug configuration, so any lane building Release silently gets a wrong path. The step now locates the script and fails loudly if it moved. Installing a browser is per-runner, so five hardcoded paths collapse to one snippet.

### M5 — A stale path in a user-facing error

`PlaywrightFixture` told you to run `test/WopiHost.SmokeTests/bin/Debug/net10.0/playwright.ps1`. That directory does not exist — `UseArtifactsOutput` centralises to `artifacts/`. Verified both ways; corrected.

### L2, L3, L4

- **L2** — the Semgrep pin on the `pipx` run-line is now tracked by a Renovate custom manager instead of the manual bump its own comment described.
- **L3** — auto-merge gates on the PR's **author** rather than `github.actor`: on a `reopened` event the actor is whoever reopened it, so a maintainer reopening a Dependabot PR silently skipped auto-merge. (Failed closed, so cosmetic.)
- **L4** — no behavioural change. All six `continue-on-error` uses are correct; `wopi-validator`'s is *required*, since the validator CLI treats skipped tests as failures and the real gate is the known-failure name comparison in the next step. Two that lacked the rationale their siblings carry now have it.

### L1 — deliberately not done, and I'd like your call

The remaining duplication is the `Setup .NET` + `Set Cobalt packages token` pair across ~10 workflows. I did **not** collapse it into a composite action:

- A composite can't read `secrets` itself, so the caller still writes `cobalt-token: ${{ secrets.COBALT_PACKAGES_TOKEN }}` — it saves about two lines per workflow, not six.
- The real win would be consolidating the `actions/setup-dotnet` SHA from 10 copies to 1.
- Against that: it re-touches nine workflows including three `pull_request_target` ones that **cannot be exercised until merge**, and a mechanical sweep in this very PR already introduced an indentation bug I caught only because I re-parsed the YAML.

Given M1 already removed the substantive duplication (the SDK version), I judged the composite a mild win at real risk. Happy to do it as a follow-up if you'd rather have it.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added — n/a for workflow config; validated with the real linters below
- [x] Tests are passing
- [x] Docs have been updated (if applicable) — comments corrected wherever this change made them untrue
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
- [x] Adheres to [.NET Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/)

### How to test

```
$ actionlint -shellcheck shellcheck .github/workflows/*.yml
exit=0        # excluding pre-existing info/style findings in release.yml
$ dotnet build WOPI.slnx
Build succeeded.  0 Warning(s)  0 Error(s)
$ npx --package renovate renovate-config-validator --strict
INFO: Config validated successfully
```

The Renovate regex was executed against the real file with **node** (Renovate's own engine), extracting `currentValue=1.168.0`, with the anchored file pattern matching the real path and rejecting a lookalike.

The Playwright step rewrite was checked for step loss — `- name:` counts are identical before and after in all five workflows (8/8, 8/8, 15/15, 16/16, 22/22). Mid-way through, my first attempt inserted the block at the wrong indentation and broke `integrate.yml` and `pull_request.yml`; re-parsing every workflow as YAML caught it, and the rewrite was redone per-file.

⚠️ `pull_request.yml`, `infersharp.yml`, `wopi-validator.yml` and `labeler.yml` are `pull_request_target`, so **their changes here first execute post-merge** — GitHub loads those definitions from the base ref. The concurrency and timeout additions on this PR's own checks come from master's copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136hX6FpWJJEGhVJmQkSJu3

---
_Generated by [Claude Code](https://claude.ai/code/session_0136hX6FpWJJEGhVJmQkSJu3)_