### PR TITLE
ci: skip the Claude review workflows on bot-authored pull requests

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,10 +20,20 @@ concurrency:
 
 jobs:
   claude-review:
-    # Internal PRs only. The Claude GitHub App's OIDC token exchange doesn't work with
-    # the secret-less fork-PR context, so fork PRs are skipped here — review one manually
-    # by commenting `@claude review this` (handled by claude.yml).
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Internal, human-authored PRs only.
+    #
+    # Fork PRs: the Claude GitHub App's OIDC token exchange doesn't work in the secret-less
+    # fork-PR context — review one manually by commenting `@claude review this` (claude.yml).
+    #
+    # Bot PRs: the action refuses a non-human initiator unless the bot is listed in
+    # allowed_bots, and it reads the initiator from the event payload, so a re-run replays
+    # the same refusal — the failure is not transient. continue-on-error keeps the check
+    # green, which is why this surfaced only as annotations on every baseline-bump and
+    # Dependabot PR. Those PRs are a version-string change and an auto-merge; skipping the
+    # job outright beats paying for a review nobody reads.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -21,9 +21,12 @@ concurrency:
 
 jobs:
   docs-drift:
-    # Internal PRs only — the OIDC token exchange doesn't work in the secret-less fork context
-    # (same constraint as claude-code-review.yml).
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Internal, human-authored PRs only — the OIDC token exchange doesn't work in the
+    # secret-less fork context, and the action refuses a bot initiator outright (same two
+    # constraints as claude-code-review.yml, which documents them).
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:


### PR DESCRIPTION
### Motivation

Surfaced on #694 (the 9.3.0 baseline bump). `claude-code-action` refuses a non-human initiator:

```
Action failed with error: Workflow initiated by non-human actor: github-actions (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
Process completed with exit code 1.
```

Two things made this easy to miss:

- **Re-running can't clear it.** The action reads the initiator from the *event payload*, and `pull_request.user` is `github-actions[bot]` because `bump-baseline.yml` opens the PR with `peter-evans/create-pull-request` under `secrets.GITHUB_TOKEN`. Every re-run replays the same payload, so the refusal is deterministic, not transient.
- **`continue-on-error: true` masks it.** The step's `outcome` is `failure` but its `conclusion` is `success`, so the job is green and only two red annotations remain on the run page. That's why it has gone unnoticed on every baseline-bump PR since 9.0.0 — #646 (9.2.0), #589 (9.1.0) and #532 (9.0.0) all carry it.

`continue-on-error` stays as-is: a reviewer hiccup genuinely shouldn't fail a PR's checks. The fix is to not start the job.

### Why gate rather than allow

`allowed_bots: '*'` would make Claude review these PRs instead. Both categories are the wrong target: a baseline bump is a single version-string change, and Dependabot PRs are configured to auto-merge — so a review on either is spend on something nobody reads.

The gate keys off the PR author in the payload:

```yaml
if: >-
  github.event.pull_request.head.repo.full_name == github.repository
  && github.event.pull_request.user.type != 'Bot'
```

Same read-the-author-from-the-payload pattern that #693 gave the Dependabot auto-merge gate when it moved off `github.actor`. `user.type` is `"Bot"` for both `github-actions[bot]` and `dependabot[bot]`, and `"User"` for a person, so it covers current and future bots without an allow-list to maintain.

`docs-drift.yml` carries the same action behind the same condition and would fail identically on a bot PR touching `src/**/*.cs` or a README, so it takes the gate too — fixing the class rather than the one instance that happened to surface.

`claude.yml` is deliberately left alone: it fires only on an explicit `@claude` mention, which is a person asking for something.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added — n/a for workflow conditions; verified against real event payloads below
- [x] Tests are passing
- [ ] Docs have been updated (if applicable) — n/a, the rationale lives in the workflow comments
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
- [x] Adheres to [.NET Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/)

### How to test

**The expression was checked against real payloads from this repo**, not assumed:

| PR | Author | `user.type` | Gate |
|---|---|---|---|
| #694 (baseline bump) | `github-actions[bot]` | `Bot` | skipped ✅ |
| #691 (Dependabot) | `dependabot[bot]` | `Bot` | skipped ✅ |
| #692 (human) | `petrsvihlik` | `User` | still runs ✅ |

The folded scalar resolves to a single-line expression — confirmed by parsing the YAML rather than reading it:

```
claude-code-review.yml
  if -> "github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.type != 'Bot'"
  steps: 2
docs-drift.yml
  if -> "github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.type != 'Bot'"
  steps: 2
```

Step counts are unchanged in both. `actionlint 1.7.7` → exit 0 on the two changed files and on all 21 workflows.

The real confirmation is the next bot-authored PR: `claude-review` and `docs-drift` should report **skipped** rather than green-with-annotations.

### Out of scope, found while investigating

`pull_request.yml` (**Build**, **API Compatibility**, **WOPI validator**) has never run on a baseline-bump PR. The split is exactly by trigger type — every `pull_request` workflow fires, every `pull_request_target` one does not — which is GitHub's GITHUB_TOKEN recursion guard, since `peter-evans/create-pull-request` authenticates with `secrets.GITHUB_TOKEN`:

| Fired on #694 | Did not fire |
|---|---|
| `codeql`, `claude-code-review`, `semgrep-guardrails` (`pull_request`) | `pull_request.yml`, `wopi-validator`, `labeler`, `infersharp`, `dependabot-auto-merge` (`pull_request_target`) |

Confirmed systematic: #646 has the identical six checks. Left out of this PR because the remedy — giving `create-pull-request` a PAT or GitHub App token — introduces a new secret and is a maintainer decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136hX6FpWJJEGhVJmQkSJu3

---
_Generated by [Claude Code](https://claude.ai/code/session_0136hX6FpWJJEGhVJmQkSJu3)_