### PR TITLE
ci: open the baseline-bump PR under an identity that triggers the full check set

### DIFF
--- a/.github/workflows/bump-baseline.yml
+++ b/.github/workflows/bump-baseline.yml
@@ -150,6 +150,41 @@ jobs:
             git rm --quiet "${files[@]}"
           fi
 
+      # GITHUB_TOKEN must not author this PR. GitHub raises no pull_request_target for events
+      # it triggers, so Build, API Compatibility and the WOPI validator never ran on a baseline
+      # bump: 9.0.0 through 9.3.0 all merged carrying only the pull_request-triggered checks.
+      # dependabot-rebase-queue.yml documents the same rule for pushes.
+      #
+      # An app installation token is preferred — it belongs to the repository rather than to a
+      # person and has no expiry to renew. Provisioning is two settings: the app's numeric id in
+      # the BASELINE_AUTOMATION_APP_ID repository *variable* (an app id is not a secret) and its
+      # PEM in the BASELINE_AUTOMATION_APP_PRIVATE_KEY secret. The app needs contents: write and
+      # pull requests: write on this repository.
+      - name: Mint a GitHub App token
+        id: app-token
+        if: ${{ vars.BASELINE_AUTOMATION_APP_ID != '' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.BASELINE_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.BASELINE_AUTOMATION_APP_PRIVATE_KEY }}
+
+      # Names the identity in the log so a silently degraded run is visible. Only the presence
+      # of each credential crosses into the script, never its value.
+      - name: Report which identity opens the PR
+        env:
+          APP_TOKEN_PRESENT: ${{ steps.app-token.outputs.token != '' }}
+          PAT_PRESENT: ${{ secrets.DEPENDABOT_AUTOMATION_PAT != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$APP_TOKEN_PRESENT" == "true" ]]; then
+            echo "Opening the PR as the GitHub App installation."
+          elif [[ "$PAT_PRESENT" == "true" ]]; then
+            echo "Opening the PR with DEPENDABOT_AUTOMATION_PAT."
+          else
+            echo "::warning::Neither a GitHub App token nor DEPENDABOT_AUTOMATION_PAT is available, so the PR is opened with GITHUB_TOKEN. GitHub suppresses pull_request_target for GITHUB_TOKEN-authored PRs, so Build, API Compatibility and the WOPI validator will not run on it — review the bump manually before merging."
+          fi
+
       - name: Open PR with the bump
         # peter-evans/create-pull-request is intentionally idempotent: if Directory.Build.props
         # has no diff (because CURRENT was already at NEW, or because the backward-bump guard
@@ -158,7 +193,10 @@ jobs:
         # spawning duplicates.
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Falls through the same way dependabot-auto-merge.yml and dependabot-rebase-queue.yml
+          # do. A skipped app-token step leaves its output empty, so the chain degrades without
+          # a condition of its own.
+          token: ${{ steps.app-token.outputs.token || secrets.DEPENDABOT_AUTOMATION_PAT || secrets.GITHUB_TOKEN }}
           branch: chore/bump-package-validation-baseline-${{ steps.target.outputs.version }}
           base: master
           commit-message: "chore: bump PackageValidationBaselineVersion to ${{ steps.target.outputs.version }}"


### PR DESCRIPTION
### Motivation

Follow-up to #695, which fixed the *annotations* on baseline-bump PRs. This fixes the more serious half found in the same investigation: those PRs never ran **Build**, **API Compatibility** or the **WOPI validator**.

GitHub raises no `pull_request_target` for events triggered by `GITHUB_TOKEN`, and `bump-baseline.yml` opened its PR with `secrets.GITHUB_TOKEN`. The split on #694 is exactly by trigger type:

| Fired | Did not fire |
|---|---|
| `codeql`, `claude-code-review`, `semgrep-guardrails` — `pull_request` | `pull_request.yml`, `wopi-validator`, `labeler`, `infersharp`, `dependabot-auto-merge` — `pull_request_target` |

`docs-drift` is `pull_request` and also didn't run, but its `paths:` filter is `src/**/*.cs` + `**/README.md`, so it correctly skipped — not a counterexample.

Systematic, not a one-off: #646 (9.2.0), #589 (9.1.0) and #532 (9.0.0) carry the identical six checks. **Every baseline bump from 9.0.0 to 9.3.0 merged without a build.**

The repo already knew this rule — `dependabot-rebase-queue.yml:12` documents it for pushes ("pushes made with GITHUB_TOKEN don't trigger other workflows") and already carries a fine-grained PAT to work around it. The lesson just never reached this workflow.

### The token chain

```yaml
token: ${{ steps.app-token.outputs.token || secrets.DEPENDABOT_AUTOMATION_PAT || secrets.GITHUB_TOKEN }}
```

Same shape `dependabot-auto-merge.yml` and `dependabot-rebase-queue.yml` already use, extended with an app-installation rung. Preferred because an app token belongs to the repository rather than to a person and has no expiry to renew.

Only the app-token step is gated (on the app-id variable); a skipped step's output is the empty string, so the chain degrades on its own without a second condition. Neither credential is required — with neither, the PR still opens and a warning names the checks it won't get. Only the *presence* of each credential crosses into the reporting script, never its value.

### ⚠️ Provisioning needed before the app rung activates

This ships inert. To turn it on, an app you own must be created and installed — the **Claude GitHub App already installed on this repo cannot be used**, because `create-github-app-token` needs the app's own private key and that one belongs to Anthropic.

| Setting | Kind | Value |
|---|---|---|
| `BASELINE_AUTOMATION_APP_ID` | repository **variable** | the app's numeric id (an app id is not a secret) |
| `BASELINE_AUTOMATION_APP_PRIVATE_KEY` | repository **secret** | the app's PEM |

App permissions: `contents: write`, `pull requests: write`.

Until then the middle rung does the work: `DEPENDABOT_AUTOMATION_PAT` already exists with exactly those two scopes and belongs to a user with push access, so **merging this alone already fixes the next bump** — the app rung is the durability upgrade.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added — n/a for workflow wiring; verification below
- [x] Tests are passing
- [ ] Docs have been updated (if applicable) — n/a, rationale lives in the workflow comments
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
- [x] Adheres to [.NET Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/)

### How to test

`actionlint 1.7.7 -shellcheck shellcheck` → exit 0 on this file and on all 21 workflows. YAML parses to 7 steps in the intended order:

```
actions/checkout@3d3c42e5…
Determine target version
Update Directory.Build.props
Retire suppressions absorbed into the new baseline
Mint a GitHub App token          ← new
Report which identity opens the PR ← new
Open PR with the bump
```

`actions/create-github-app-token` is pinned to `bcd2ba49218906704ab6c1aa796996da409d3eb1`, which is `v3.2.0` and the current target of the floating `v3` tag — resolved from the upstream refs, not copied from documentation.

The real confirmation is the next release: the bump PR should be authored by a non-`github-actions[bot]` identity and carry **Build**, **API Compatibility** and **WOPI Validator** alongside the checks it already got.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136hX6FpWJJEGhVJmQkSJu3

---
_Generated by [Claude Code](https://claude.ai/code/session_0136hX6FpWJJEGhVJmQkSJu3)_