### PR TITLE
ci: stop publishing release-lane coverage so release commits keep a comparable baseline

### DIFF
--- a/.github/actions/test-and-report/action.yml
+++ b/.github/actions/test-and-report/action.yml
@@ -24,9 +24,21 @@ inputs:
     default: 'true'
   fail-on-upload-error:
     description: >
-      Fail the job when the coverage upload fails. True on CI, where a silent failure leaves the
+      Fail the job when the coverage upload fails. On by default: a silent failure leaves the
       codecov/patch and codecov/project statuses pending forever and blocks the merge with no
-      visible error. False when publishing a release, where a Codecov outage must not block it.
+      visible error.
+    required: false
+    default: 'true'
+  publish-coverage:
+    description: >
+      Upload the coverage reports to Qlty and Codecov. The release lane leaves this off: it
+      builds Release while the CI lane builds Debug, and Codecov merges every upload for a
+      commit. Release codegen emits sequence points the Debug build does not (the switch
+      expression in WopiAuthorizationHandler is five such lines, one branch), so a second upload
+      raises that commit's coverable-line total. Every later PR whose merge-base is the release
+      commit then measures against an inflated denominator and reports a coverage drop it did
+      not cause. The CI lane already measured this exact commit, so the release upload adds no
+      information.
     required: false
     default: 'true'
 runs:
@@ -66,24 +78,28 @@ runs:
         directory: ${{ inputs.results-directory }}
 
     - name: Normalize coverage reports
+      if: ${{ inputs.publish-coverage == 'true' }}
       uses: ./.github/actions/normalize-coverage-reports
       with:
         results-directory: ${{ inputs.results-directory }}
 
     - name: Upload coverage to Qlty
+      if: ${{ inputs.publish-coverage == 'true' }}
       uses: qltysh/qlty-action/coverage@08a0a862c159eae9b9003081da6663d96efef637 # v2
       with:
         oidc: true
         # Microsoft.Testing.Extensions.CodeCoverage writes one cobertura report per test
         # project under the run's --results-directory. Root the glob explicitly so
-        # qlty-action's @actions/glob layer has an anchored starting directory.
-        files: "test-results/**/*.cobertura.xml"
+        # qlty-action's @actions/glob layer has an anchored starting directory — derived from
+        # the input rather than repeated as a literal, so the two cannot disagree.
+        files: ${{ inputs.results-directory }}/**/*.cobertura.xml
         # Coverage reports reference source-generated files (LoggerMessage.g.cs,
         # LibraryImports.g.cs, etc.) under artifacts/obj/, which don't exist at publish time.
         # Without this flag Qlty counts them as 0% covered. See also .qlty/qlty.toml.
         skip-missing-files: true
 
     - name: Codecov
+      if: ${{ inputs.publish-coverage == 'true' }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
       with:
         token: ${{ inputs.codecov-token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,11 @@ jobs:
         configuration: Release
         # The CI lane already reported this commit's test results.
         report-test-results: 'false'
-        # A Codecov outage must not block publishing a release.
-        fail-on-upload-error: 'false'
+        # ...and already measured this commit's coverage, in Debug. Uploading a second report
+        # built in Release makes Codecov merge two configurations into one commit's totals,
+        # inflating its coverable-line count and charging the difference to the next PR based
+        # on it. Tests still run here as a release gate; only the upload is dropped.
+        publish-coverage: 'false'
     - name: Pack
       # Output is centralized via UseArtifactsOutput (see Directory.Build.props);
       # nupkg/snupkg files land in artifacts/package/release/.


### PR DESCRIPTION
### Motivation

#695's Codecov comment reported **−0.30%** on a diff containing no C# at all — two YAML `if:` lines. Qlty said −0.5%. Chasing it found a deterministic cause, not the flakiness it looked like.

Codecov merges **every** upload for a commit. A release commit gets two:

| Lane | Configuration | Runs on |
|---|---|---|
| `integrate.yml` | Debug | every push to master |
| `release.yml` | **Release** | the same commit, on `release: published` |

The two configurations don't agree on what is *coverable*. Release codegen emits a sequence point per arm of the switch expression in `WopiAuthorizationHandler.cs` that Debug folds into fewer — five lines and one branch, after `codecov.yml`'s `sample/infra/test` ignore leaves only `src/`.

So the release commit's denominator sits five above every other commit's, and the next PR based on it is charged the difference:

| Commit | Lines | Branches |
|---|---:|---:|
| `1326f8b` master | 4533 | 622 |
| `0d4f9a2` master — **tagged `9.3.0`** | **4538** | **623** |
| `b6e857d` (#693 head) | 4533 | 622 |
| `fa8e43f` (#695 head) | 4533 | 622 |

Only the tagged commit differs, and only by the amount the second upload adds.

### Measured, not inferred

Ran locally against `origin/master`, comparing the union of coverable `(file, line)` pairs across every cobertura report, generated files excluded (they live under `artifacts/obj/<proj>/debug|release/`, so their paths differ by configuration and `codecov.yml` ignores them anyway):

```
Debug run 1 : 5893 coverable lines, 156 files
Debug run 2 : 5893 coverable lines, 156 files     ← identical, so the tool is deterministic
Release     : 4677 coverable lines, 156 files
Debug ∪ Release : 5898                            ← +5, exactly the observed gap

lines only in Release:
  src/WopiHost.Core/Security/Authorization/WopiAuthorizationHandler.cs  106 107 110 112 115
```

Those five are the `return required switch { … };` expression. Two identical Debug runs agreeing byte-for-byte is what rules out nondeterminism — the denominator only moves when configurations are mixed.

### The change

`release.yml` still runs the full suite as a release gate; it just stops uploading. Its coverage was never information — the CI lane had already measured that exact commit, which is the argument the adjacent `report-test-results: 'false'` already makes.

`fail-on-upload-error: 'false'` is dropped from that call site: with no upload it has nothing to act on, and its description no longer named a lane that uses it.

Also derives the Qlty glob from `results-directory` rather than repeating `test-results/**/*.cobertura.xml` as a literal. The two agreed only by coincidence; a caller passing a different directory would have uploaded nothing to Qlty while Codecov kept working — silent, and this pipeline has failed that way four times already.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added — n/a for workflow wiring; measurements above
- [x] Tests are passing
- [ ] Docs have been updated (if applicable) — n/a, rationale lives in the input's description
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
- [x] Adheres to [.NET Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/)

### How to test

`actionlint 1.7.7 -shellcheck shellcheck` → exit 0 across all 21 workflows. Parsed structure:

```
Test                             if=-                                    ← release gate preserved
Upload test results to Codecov   if=report-test-results == 'true' && !cancelled()
Normalize coverage reports       if=publish-coverage == 'true'
Upload coverage to Qlty          if=publish-coverage == 'true'
Codecov                          if=publish-coverage == 'true'

integrate.yml     publish-coverage=(unset → default true)
pull_request.yml  publish-coverage=(unset → default true)
release.yml       publish-coverage=false
```

Two things to confirm after merge:

1. **The Qlty glob still resolves.** It is now absolute (`<workspace>/test-results/**/*.cobertura.xml`) where it was workspace-relative. `@actions/glob` supports absolute patterns, but this repo has a history of silent coverage-upload breakage, so the first master run's Qlty step is worth a look.
2. **The next release** should leave its commit's totals at the CI lane's numbers, and the baseline-bump PR that follows should no longer open with a phantom coverage drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136hX6FpWJJEGhVJmQkSJu3

---
_Generated by [Claude Code](https://claude.ai/code/session_0136hX6FpWJJEGhVJmQkSJu3)_