### PR TITLE
ci: verify the baseline bump before proposing it, and keep the coverage reports

### DIFF
--- a/.github/actions/test-and-report/action.yml
+++ b/.github/actions/test-and-report/action.yml
@@ -83,6 +83,22 @@ runs:
       with:
         results-directory: ${{ inputs.results-directory }}
 
+    # Kept so a coverage anomaly can be diagnosed from the run that produced it. Codecov and
+    # Qlty report totals, not the reports behind them, so working out why a number moved has
+    # meant reproducing the run locally — which is what tracing the release-lane Debug/Release
+    # merge took. Two runs' artifacts can be diffed directly instead.
+    #
+    # Uploaded after normalization so the archive holds exactly the set the uploaders consumed,
+    # and on failure too, since a run whose tests failed is the one worth inspecting.
+    - name: Archive coverage reports
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: coverage-reports-${{ github.job }}
+        path: ${{ inputs.results-directory }}/*.cobertura.xml
+        if-no-files-found: warn
+        retention-days: 30
+
     - name: Upload coverage to Qlty
       if: ${{ inputs.publish-coverage == 'true' }}
       uses: qltysh/qlty-action/coverage@08a0a862c159eae9b9003081da6663d96efef637 # v2

--- a/.github/workflows/bump-baseline.yml
+++ b/.github/workflows/bump-baseline.yml
@@ -91,6 +91,29 @@ jobs:
           fi
           echo "version=$TARGET" >> "$GITHUB_OUTPUT"
 
+      # release.yml and this workflow both fire on `release: published`, so the target version
+      # is typically not on NuGet.org yet when this starts — 9.3.0 took roughly eight minutes
+      # from the release to being served. Everything below needs the package to exist: the
+      # verification restores it as a validation baseline, and the PR's own checks restore it
+      # too, which is what left #694's CodeQL run red until it was re-run by hand.
+      - name: Wait for the baseline package on NuGet.org
+        env:
+          TARGET: ${{ steps.target.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          deadline=$((SECONDS + 900))
+          until curl -fsSL "https://api.nuget.org/v3-flatcontainer/wopihost.core/index.json" \
+              | grep -q "\"$TARGET\""; do
+            if (( SECONDS >= deadline )); then
+              echo "::error::WopiHost.Core $TARGET is still not on NuGet.org after 15 minutes. Either the release did not publish or indexing is delayed; re-run this workflow once the package is listed."
+              exit 1
+            fi
+            echo "WopiHost.Core $TARGET not indexed yet — waiting."
+            sleep 30
+          done
+          echo "WopiHost.Core $TARGET is available."
+
       - name: Update Directory.Build.props
         id: update
         shell: bash
@@ -149,6 +172,28 @@ jobs:
             printf 'Retiring: %s\n' "${files[@]}"
             git rm --quiet "${files[@]}"
           fi
+
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet-sdk
+
+      - name: Set Cobalt packages token
+        run: echo "COBALT_PACKAGES_TOKEN=${{ secrets.COBALT_PACKAGES_TOKEN }}" >> $GITHUB_ENV
+
+      # Proves the bump before proposing it, rather than relying on the PR's checks. Packing is
+      # the operation PackageValidationBaselineVersion actually governs: the SDK downloads the
+      # baseline nupkg for every packable project and compares the current surface against it,
+      # so a baseline that does not resolve, or a real break the retired suppressions were
+      # hiding, fails here instead of landing in a PR someone has to diagnose.
+      #
+      # Validation is left ON, unlike the PR-time pack, which is the whole point. The version is
+      # the same throwaway that job uses; it only has to sit above the baseline so the compared
+      # package is not also the older one.
+      - name: Verify the bump packs against the new baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          dotnet restore
+          dotnet pack --configuration Release --no-restore -p:Version=99.99.99
 
       # GITHUB_TOKEN must not author this PR. GitHub raises no pull_request_target for events
       # it triggers, so Build, API Compatibility and the WOPI validator never ran on a baseline

--- a/.github/workflows/bump-baseline.yml
+++ b/.github/workflows/bump-baseline.yml
@@ -227,7 +227,7 @@ jobs:
           elif [[ "$PAT_PRESENT" == "true" ]]; then
             echo "Opening the PR with DEPENDABOT_AUTOMATION_PAT."
           else
-            echo "::warning::Neither a GitHub App token nor DEPENDABOT_AUTOMATION_PAT is available, so the PR is opened with GITHUB_TOKEN. GitHub suppresses pull_request_target for GITHUB_TOKEN-authored PRs, so Build, API Compatibility and the WOPI validator will not run on it — review the bump manually before merging."
+            echo "Opening the PR with GITHUB_TOKEN — see the identity check at the end of this run."
           fi
 
       - name: Open PR with the bump
@@ -258,3 +258,21 @@ jobs:
             chore
             automated
           delete-branch: true
+
+      # Deliberately after the PR is opened, not before. The bump's contents were verified
+      # above, so a missing credential is no reason to withhold the change — but the PR quietly
+      # losing Build, API Compatibility and the WOPI validator is what went unnoticed across
+      # four releases, and it went unnoticed because the run stayed green. Failing here keeps
+      # the PR and makes the lapse impossible to miss.
+      - name: Fail when the PR was opened without a checked identity
+        env:
+          APP_TOKEN_PRESENT: ${{ steps.app-token.outputs.token != '' }}
+          PAT_PRESENT: ${{ secrets.DEPENDABOT_AUTOMATION_PAT != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$APP_TOKEN_PRESENT" == "true" || "$PAT_PRESENT" == "true" ]]; then
+            exit 0
+          fi
+          echo "::error::The bump PR was opened with GITHUB_TOKEN, so GitHub raises no pull_request_target for it and Build, API Compatibility and the WOPI validator will not run on it. This workflow verified the bump itself, so the PR is still sound to review and merge — but restore BASELINE_AUTOMATION_APP_ID plus BASELINE_AUTOMATION_APP_PRIVATE_KEY, or DEPENDABOT_AUTOMATION_PAT, before the next release."
+          exit 1


### PR DESCRIPTION
### Motivation

Three related hardenings, all falling out of the 9.3.0 release. Closes #698, which proposed provisioning a GitHub App to get the bump PR its checks — that treats *who opens the PR* rather than what the checks were protecting against.

### 1. Verify the bump instead of relying on the PR's checks

The bump PR's own checks were the only thing standing behind the change, and they are exactly the checks it does not reliably get. Packing is what `PackageValidationBaselineVersion` actually governs, so the workflow now does it:

```yaml
- name: Verify the bump packs against the new baseline
  run: |
    dotnet restore
    dotnet pack --configuration Release --no-restore -p:Version=99.99.99
```

Validation is deliberately left **on**, unlike the PR-time pack which disables it. The SDK downloads the baseline nupkg for every packable project and compares the current surface against it, so a baseline that does not resolve — or a real break the just-retired `CompatibilitySuppressions.xml` files were masking — fails in the workflow that made the change.

**The wait is the other half.** A naive version would fail on essentially every release, because this workflow and `release.yml` both fire on `release: published`:

| | 9.3.0 |
|---|---|
| release published, both workflows fire | 21:38:56 |
| bump PR opened | 21:39:08 — **12 seconds in** |
| `release.yml` finished pushing to NuGet | 21:41:54 |
| NuGet actually served 9.3.0 | ~21:47 |

Restoring that baseline eight minutes before it exists cannot work — which is also why #694's CodeQL run went red on `dotnet restore` and had to be re-run by hand. The workflow now polls for the package and refuses to proceed without it: a bump to a baseline that does not exist is not worth proposing.

### 2. Fail the run when the PR loses its checks

The credential check was a `::warning::` on an otherwise green run — the shape of signal that let the missing checks go unnoticed across four releases.

It now fails, but **after** the PR is opened rather than before. The contents are verified by (1), so a lapsed credential is no reason to withhold a sound bump; keeping the PR and reddening the run gets the signal without the collateral damage.

### 3. Archive the cobertura reports

Codecov and Qlty report totals, not the reports behind them. Establishing why the 9.3.0 coverage number moved meant reproducing the run locally — a build plus three test runs — to find that release commits carried a second, Release-configuration upload (#699). The reports are already sitting in the results directory; keeping them turns the next such question into a diff of two runs' artifacts.

Uploaded after normalization so the archive holds exactly the set the uploaders consumed, and on failure too, since a run whose tests failed is the one worth inspecting.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added — n/a for workflow steps; both directions exercised below
- [x] Tests are passing
- [ ] Docs have been updated (if applicable) — n/a, rationale lives in the step comments
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
- [x] Adheres to [.NET Design Guidelines](https://learn.microsoft.com/dotnet/standard/design-guidelines/)

### How to test

**The verification passes on the current tree** — ran exactly what the step runs, against master's baseline of `9.3.0`:

```
dotnet pack --configuration Release --no-restore -p:Version=99.99.99   → exit 0, 9 packages
```

**Validation genuinely ran.** A green pack proves nothing if it was silently off:

```
EnablePackageValidation         : true
PackageValidationBaselineVersion: 9.3.0
~/.nuget/packages/wopihost.core/             → 9.2.0, 9.3.0   ← baseline really downloaded
~/.nuget/packages/wopihost.redislockprovider/→ 9.2.0, 9.3.0
```

**And it has teeth** — turning `WopiRedisLockProviderOptions` internal and packing:

```
error CP0001: Type 'WopiHost.RedisLockProvider.WopiRedisLockProviderOptions'
  exists on [Baseline] …/wopihost.redislockprovider/9.3.0/… but not on …
error : API breaking changes found.
```

That is the break #692 used to demonstrate the gap, now caught before a PR exists rather than after a release.

**The poll predicate**, against live NuGet: `9.3.0` → found, exits immediately; `99.98.97` → not found, waits and errors at the 15-minute deadline.

**The identity gate**, all four combinations:

```
app=true  pat=true  -> passes      app=false pat=true  -> passes
app=true  pat=false -> passes      app=false pat=false -> FAILS the run
```

`actionlint 1.7.7 -shellcheck shellcheck` → exit 0 across all 21 workflows. Resulting step order:

```
1. checkout                       7. Set Cobalt packages token
2. Determine target version       8. Verify the bump packs against the new baseline
3. Wait for the baseline package  9. Mint a GitHub App token
4. Update Directory.Build.props  10. Report which identity opens the PR
5. Retire suppressions           11. Open PR with the bump
6. Setup .NET                    12. Fail when opened without a checked identity
```

⚠️ `bump-baseline.yml` only runs on `release: published` or `workflow_dispatch`, so **this PR's own CI does not exercise (1) or (2)** — a green run here proves only that nothing else broke. First real proof is the next release, or a manual dispatch (safe: with the baseline already current, `create-pull-request` sees no diff and opens nothing). Change (3) *is* exercised here — the `build` job should publish a `coverage-reports-build` artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136hX6FpWJJEGhVJmQkSJu3